### PR TITLE
Don't pollute the START variable

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -36,21 +36,25 @@ nvm()
         nvm help
         return;
       fi
-      START=`pwd`
-      mkdir -p "$NVM_DIR/src" && \
-      cd "$NVM_DIR/src" && \
-      wget "http://nodejs.org/dist/node-$2.tar.gz" -N && \
-      tar -xzf "node-$2.tar.gz" && \
-      cd "node-$2" && \
-      ./configure --prefix="$NVM_DIR/$2" && \
-      make && \
-      make install && \
-      nvm use $2
-      if ! which npm ; then
-        echo "Installing npm..."
-        curl http://npmjs.org/install.sh | sh
+      if (
+        mkdir -p "$NVM_DIR/src" &&
+        cd "$NVM_DIR/src" && \
+        wget "http://nodejs.org/dist/node-$2.tar.gz" -N && \
+        tar -xzf "node-$2.tar.gz" && \
+        cd "node-$2" && \
+        ./configure --prefix="$NVM_DIR/$2" && \
+        make && \
+        make install
+        )
+      then
+        nvm use $2
+        if ! which npm ; then
+          echo "Installing npm..."
+          curl http://npmjs.org/install.sh | sh
+        fi
+      else
+        echo "nvm: install $2 failed!"
       fi
-      cd $START
     ;;
     "deactivate" )
       if [[ $PATH == *$NVM_DIR/*/bin* ]]; then


### PR DESCRIPTION
It's bad to leak the START variable into the user's environment so do the install steps in a subshell.
Also, don't try to install npm if the node install fails.

This change is mostly indentation, here's the git diff -b:

```
@@ -36,21 +36,25 @@ nvm()
         nvm help
         return;
       fi
-      START=`pwd`
-      mkdir -p "$NVM_DIR/src" && \
+      if (
+        mkdir -p "$NVM_DIR/src" &&
       cd "$NVM_DIR/src" && \
       wget "http://nodejs.org/dist/node-$2.tar.gz" -N && \
       tar -xzf "node-$2.tar.gz" && \
       cd "node-$2" && \
       ./configure --prefix="$NVM_DIR/$2" && \
       make && \
-      make install && \
+        make install
+        )
+      then
       nvm use $2
       if ! which npm ; then

         echo "Installing npm..."
         curl http://npmjs.org/install.sh | sh
       fi
-      cd $START
+      else
+        echo "nvm: install $2 failed!"
+      fi
     ;;
     "deactivate" )
       if [[ $PATH == *$NVM_DIR/*/bin* ]]; then
```
