### PR TITLE
Force use of unaliased version of ls from shell

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -52,17 +52,17 @@ nvm_version()
         PATTERN='*.*.'
     fi
     if [ "$PATTERN" = 'all' ]; then
-        (cd $NVM_DIR; ls -dG v* 2>/dev/null || echo "N/A")
+        (cd $NVM_DIR; \ls -dG v* 2>/dev/null || echo "N/A")
         return
     fi
     if [ ! "$VERSION" ]; then
-        VERSION=`(cd $NVM_DIR; ls -d v${PATTERN}* 2>/dev/null) | sort -t. -k 2,1n -k 2,2n -k 3,3n | tail -n1`
+        VERSION=`(cd $NVM_DIR; \ls -d v${PATTERN}* 2>/dev/null) | sort -t. -k 2,1n -k 2,2n -k 3,3n | tail -n1`
     fi
     if [ ! "$VERSION" ]; then
         echo "N/A"
         return 13
     elif [ -e "$NVM_DIR/$VERSION" ]; then
-        (cd $NVM_DIR; ls -dG "$VERSION")
+        (cd $NVM_DIR; \ls -dG "$VERSION")
     else
         echo "$VERSION"
     fi
@@ -181,7 +181,7 @@ nvm()
     "alias" )
       mkdir -p $NVM_DIR/alias
       if [ $# -le 2 ]; then
-        (cd $NVM_DIR/alias && for ALIAS in `ls $2* 2>/dev/null`; do
+        (cd $NVM_DIR/alias && for ALIAS in `\ls $2* 2>/dev/null`; do
             DEST=`cat $ALIAS`
             VERSION=`nvm_version $DEST`
             if [ "$DEST" = "$VERSION" ]; then


### PR DESCRIPTION
In my .profile, I often setup an alias for ls to use:
alias ls='ls -F'

This gives me nicer readability from this common command in my shell.

nvm.sh, however, is using ls without a backslash, which causes it to use the aliased version, rather than the default system version of ls.  It causes the automatic version selection logic to think there are slashes in the name.

I just added backslashes to all uses of ls in nvm.sh, which is a common practice to force the unaliased version of a command in shell scripts.  If no alias exists, it has no effect, so it's a harmless addition.

Hope you agree this is the intended use of ls, and a useful addition to keep nvm.sh less brittle to the environment.
