### PR TITLE
Add uninstall and unalias commands

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -142,12 +142,11 @@ nvm()
 
       # Delete all files related to target version.
       (cd "$NVM_DIR" && \
-      mkdir -p "$NVM_DIR/src" && \
-      rm -rf "node-$VERSION" 2>/dev/null && \
-      mkdir -p "$NVM_DIR/src" && \
-      cd "$NVM_DIR/src" && \
-      rm -f "node-$VERSION.tar.gz" 2>/dev/null && \
-      rm -rf "$NVM_DIR/$VERSION" 2>/dev/null)
+          rm -rf "node-$VERSION" 2>/dev/null && \
+          mkdir -p "$NVM_DIR/src" && \
+          cd "$NVM_DIR/src" && \
+          rm -f "node-$VERSION.tar.gz" 2>/dev/null && \
+          rm -rf "$NVM_DIR/$VERSION" 2>/dev/null)
       echo "Uninstalled node $VERSION"
 
       # Rm any aliases that point to uninstalled version.


### PR DESCRIPTION
As per issues [22](https://github.com/creationix/nvm/issues/22) and [25](https://github.com/creationix/nvm/issues/25). Uninstall has been updated since my post in issue 22 to make use of `nvm unalias` to remove orphaned aliases to uninstalled versions.
