### PR TITLE
Create a symlink to alias target's node binary.

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -197,6 +197,7 @@ nvm()
       fi
       if [ ! "$3" ]; then
           rm -f $NVM_DIR/alias/$2
+          rm -rf $NVM_DIR/alias/$2_bin
           echo "$2 -> *poof*"
           return
       fi
@@ -210,6 +211,9 @@ nvm()
           echo "$2 -> $3 (-> $VERSION)"
           echo "! WARNING: Moving target. Aliases to implicit versions may change without warning."
       else
+        rm -rf $NVM_DIR/alias/$2_bin 2>/dev/null
+        mkdir -p $NVM_DIR/alias/$2_bin
+        ln -s $NVM_DIR/$3/bin/node $NVM_DIR/alias/$2_bin/node
         echo "$2 -> $3"
       fi
     ;;


### PR DESCRIPTION
When an alias is created, a directory named <alias>_bin is also created
in the alias directory, and a symlink pointing to the target's node
binary is created within that directory. This allows you to, for
example, make that alias's node the default node binary for all users,
by placing a symlink to the alias's symlink in, say, /usr/bin.

This is most handy for ensuring that node scripts which must be run as
root, such as init scripts that change their uids, will have access to a
node binary.
