### PR TITLE
zsh compatibility fixes

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -16,7 +16,7 @@ if [ ! `which curl` ]; then
         curl() {
             ARGS="$* "
             ARGS=${ARGS/-s /-q }
-            ARGS=${ARGS/-\# /}
+            ARGS=${ARGS/--progress-bar /}
             ARGS=${ARGS/-C - /-c }
             ARGS=${ARGS/-o /-O }
 


### PR DESCRIPTION
- version detection now works with zsh
- curl routine now compatible with zsh
- changed curl to use --progress-bar instead of unsafe shorthand (-#)

closes #34
closes #39
