### PR TITLE
Don't allow installing already installed version.

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -108,6 +108,9 @@ nvm()
       fi
       [ "$NOCURL" ] && curl && return
       VERSION=`nvm_version $2`
+
+      [ -d "$NVM_DIR/$VERSION" ] && echo "$VERSION is already installed." && return
+
       tarball=''
       if [ "`curl -Is "http://nodejs.org/dist/$VERSION/node-$VERSION.tar.gz" | grep '200 OK'`" != '' ]; then
         tarball="http://nodejs.org/dist/$VERSION/node-$VERSION.tar.gz"


### PR DESCRIPTION
Trying to install already installed version causes misleading message
from curl and nvm:

```
$ nvm install v0.4.11
curl: (33) HTTP server doesn't seem to support byte ranges. Cannot
resume.
nvm: install v0.4.11 failed!
```

Of course, resuming interrupted installs is still possible (script
checks for existance of `$VERSION` in `$NVM_DIR`, not `$NVM_DIR/src`).
