### PR TITLE
Fix wrong full version matching

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -38,7 +38,7 @@ nvm_version()
         return
     fi
     # If it looks like an explicit version, don't do anything funny
-    if [[ "$PATTERN" == v*.*.* ]]; then
+    if [[ "$PATTERN" == v?*.?*.?* ]]; then
         VERSION="$PATTERN"
     fi
     # The default version is the current one


### PR DESCRIPTION
This commit fixes the matching of a full (explicit) version. 

Running `nvm version v..` outputs "v..", as \* matches any character. 
Running `nvm version v0.5.` outputs "v0.5.", for the same reason

With the patch the commands correctly return N/A.
