### PR TITLE
trivial: remove references to stable and latest

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -206,9 +206,7 @@ nvm()
         return
       fi
       nvm_version all
-      for P in {stable,latest,current}; do
-          echo -ne "$P: \t"; nvm_version $P
-      done
+      echo -ne "current: \t"; nvm_version current
       nvm alias
     ;;
     "alias" )


### PR DESCRIPTION
also, my fingers always want to 'nvm list'.  Hope you'll accept the synonym.

Love that you got rid of sync!!  Seems like nvm_version() is barely used now and could be simplified...?  I'd look into it if you're interested.
