### PR TITLE
alias node for sudoers in documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,3 +44,7 @@ To set a default Node version to be used in any new shell, use the alias 'defaul
 If you try to install a node version and the installation fails, be sure to delete the node downloads from src (~/.nvm/src/) or you might get an error when trying to reinstall them again or you might get an error like the following:
     
     curl: (33) HTTP server doesn't seem to support byte ranges. Cannot resume.
+
+Where's my 'sudo node'? Checkout this link:
+    
+    https://github.com/creationix/nvm/issues/43


### PR DESCRIPTION
Added the link to the issue for 'sudo node', that should help.
