### PR TITLE
Error for zsh user with 'setopt nomatch'

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -34,11 +34,11 @@ nvm_version()
         VERSION=`node -v 2>/dev/null`
     fi
     if [ "$PATTERN" = 'all' ]; then
-        (cd $NVM_DIR; \ls -dG v* 2>/dev/null || echo "N/A")
+        (cd $NVM_DIR; (\ls -dG v*) 2>/dev/null || echo "N/A")
         return
     fi
     if [ ! "$VERSION" ]; then
-        VERSION=`(cd $NVM_DIR; \ls -d v${PATTERN}* 2>/dev/null) | sort -t. -k 2,1n -k 2,2n -k 3,3n | tail -n1`
+        VERSION=`(cd $NVM_DIR; (\ls -d v${PATTERN}*) 2>/dev/null) | sort -t. -k 2,1n -k 2,2n -k 3,3n | tail -n1`
     fi
     if [ ! "$VERSION" ]; then
         echo "N/A"
@@ -225,7 +225,7 @@ nvm()
     "alias" )
       mkdir -p $NVM_DIR/alias
       if [ $# -le 2 ]; then
-        (cd $NVM_DIR/alias && for ALIAS in `\ls $2* 2>/dev/null`; do
+          (cd $NVM_DIR/alias && for ALIAS in `(\ls $2*) 2>/dev/null`; do
             DEST=`cat $ALIAS`
             VERSION=`nvm_version $DEST`
             if [ "$DEST" = "$VERSION" ]; then


### PR DESCRIPTION
For zsh user with setopt nomatch(nomatch is standard setting)

"no matches found: *"  error when function 'nvm_version' and 'nvm alias'  run
if Not yet been 'nvm inastall' or 'nvm alias'

Tested on CentOS release 5.4 (Final) In bash & zsh, tested 'nvm ls' and 'nvm install' and 'nvm alias'.
