### PR TITLE
Avoid carrying over test status when no node version is installed

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -283,4 +283,4 @@ nvm()
   esac
 }
 
-nvm ls default >/dev/null 2>&1 && nvm use default >/dev/null
+nvm ls default &>/dev/null && nvm use default >/dev/null || true


### PR DESCRIPTION
When sourcing nvm.sh, if there are no version of node installed the command
`nvm ls default` silentry fails, however it's return status code (`$?`) is
still set to non-zero, which means an error.

This patch simply avoids this issue by making sure the status code after
sourcing is ok so that people that put the returned status codes in their
command line prompt don't get an error every time `nvm.sh` is sourced.
