### PR TITLE
Set the NODE_PATH variable when activating node

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -197,6 +197,7 @@ nvm()
       export MANPATH
       export NVM_PATH="$NVM_DIR/$VERSION/lib/node"
       export NVM_BIN="$NVM_DIR/$VERSION/bin"
+      export NODE_PATH="$NODE_PATH:$NVM_DIR/$VERSION/lib/node_modules"
       echo "Now using node $VERSION"
     ;;
     "run" )


### PR DESCRIPTION
When installing packages with npm using the global switch `-g` the package ends
up in the proper directory (i.e. .nvm/$VERSION/lib/node_modules), however node
is unable to require it since it somehow isn't searching on it's prefix.

This patch fixes this behavior by manually adding the `node_modules` dir to the
`NODE_PATH` variable.
