### PR TITLE
Fix version sorting to handle v0.6.10 and eventually v1.0.0

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -38,7 +38,7 @@ nvm_version()
         return
     fi
     if [ ! "$VERSION" ]; then
-        VERSION=`(cd $NVM_DIR; \ls -d v${PATTERN}* 2>/dev/null) | sort -t. -k 2,1n -k 2,2n -k 3,3n | tail -n1`
+        VERSION=`(cd $NVM_DIR; \ls -d v${PATTERN}* 2>/dev/null) | sort -t. -k 1,1 -k 2,2n -k 3,3n | tail -n1`
     fi
     if [ ! "$VERSION" ]; then
         echo "N/A"


### PR DESCRIPTION
As of the recent v0.6.10 release of node, it has become apparent that nvm_version is not correctly handling the version sorting.

There are really two bug fixes here, both to the way nvm uses the 'sort' command.

First, the argument "2,1n" is illegal, and was being ignored, because position 2 is after 1, and it causes sort to incorrectly interpret the later keys like "2,2n" and "3,3n" as well.  That's why v0.6.10 is exercising the problem.

However, even if we changed it to "1,1n", it still wouldn't quite work for "v1.0.0".

That's because "-t." tells sort to break up v0.6.10 into "v0" "6", "10", and unfortunately "v0" is not numeric at all, so it would not correctly sort "v0" before "v1".

So, by removing the "n" from the first specifier, it just sorts the first part using ASCII, which will work up until node hits "v10.0.0".  I can live with that.  :)

FWIW, I think skipping over the "v" may have been why the "2,1n" slipped in there in the first place, but it clearly didn't work.
