### PR TITLE
`nvm version` and `nvm ls` not correctly reporting current version.

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -38,7 +38,8 @@ nvm_ls()
     PATTERN=$1
     VERSIONS=''
     if [ "$PATTERN" = 'current' ]; then
-        VERSION=`node -v 2>/dev/null`
+        echo `node -v 2>/dev/null`
+        return
     fi
 
     if [ -f "$NVM_DIR/alias/$PATTERN" ]; then


### PR DESCRIPTION
On a fresh install from HEAD after `nvm use heroku` and `nvm ls` I got the following on both zsh 4.3.11 and bash 3.2.48:

```
v0.4.7  v0.6.11
current:    nvm_ls:16: no matches found: vcurrent*
N/A
default -> stable (-> v0.6.11)
heroku -> v0.4.7
stable -> v0.6.11
```

Basically, current version is not being correctly reported. After taking a look at the source it seems the $VERSION var is unused and `node -v` should've been printed, thus this pull request.
