### PR TITLE
Fix for `nvm_ls current` always returning "N/A"

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -38,7 +38,8 @@ nvm_ls()
     PATTERN=$1
     VERSIONS=''
     if [ "$PATTERN" = 'current' ]; then
-        VERSION=`node -v 2>/dev/null`
+        echo `node -v 2>/dev/null`
+        return
     fi
 
     if [ -f "$NVM_DIR/alias/$PATTERN" ]; then


### PR DESCRIPTION
since the `VERSION` var wasn't used anywhere (it's called `VERSIONS`) and it's easier to just echo...
