### PR TITLE
NVM "need curl to proceed"

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -69,11 +69,6 @@ print_versions()
 
 nvm()
 {
-  if [ ! `which curl` ]; then
-    echo 'NVM Needs curl to proceed.' >&2;
-    return
-  fi
-
   if [ $# -lt 1 ]; then
     nvm help
     return
@@ -105,11 +100,14 @@ nvm()
       echo
     ;;
     "install" )
+      if [ ! `which curl` ]; then
+        echo 'NVM Needs curl to proceed.' >&2;
+      fi
+      
       if [ $# -ne 2 ]; then
         nvm help
         return
       fi
-      [ "$NOCURL" ] && curl && return
       VERSION=`nvm_version $2`
 
       [ -d "$NVM_DIR/$VERSION" ] && echo "$VERSION is already installed." && return


### PR DESCRIPTION
I've used nvm easily with most of my existing systems, but a newly installed mint system did not have curl installed by default.

nvm did not function, and provided the error "need curl to proceed", I installed curl, and nvm refused to function - even curl provided the same error, which was rather odd.  Eventually i realized that nvm creates a curl function in the "global" shell environment, and when sourced from .bashrc it overwrites the existing (if it exists) curl function, preventing a subsequently installed curl from functioning until the bash shell is restarted

This behaviour could be very confusing to those not familiar with bash / sourcing behavior.  (like myself :P)

and since curl is only required for those downloading tarballs, I moved it into the install branch of the nvm function.

If this is not an adequate solution, then let me know and we can brainstorm on it a bit.
