### PR TITLE
Fixed directory in readme to use ".nvm" everywhere

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,11 +8,11 @@ To install create a folder somewhere in your filesystem with the "`nvm.sh`" file
 
 Or if you have `git` installed, then just clone it:
 
-    git clone git://github.com/creationix/nvm.git ~/nvm
+    git clone git://github.com/creationix/nvm.git ~/.nvm
 
 To activate nvm, you need to source it from your bash shell
 
-    . ~/nvm/nvm.sh
+    . ~/.nvm/nvm.sh
 
 I always add this line to my ~/.bashrc or ~/.profile file to have it automatically sources upon login.   
 Often I also put in a line to use a specific version of node.


### PR DESCRIPTION
You say you use .nvm and then commands use "nvm" which is confusing for first time user. 
