### PR TITLE
Add check for unsetopt issue #128

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -12,7 +12,9 @@ fi
 
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
-unsetopt nomatch 2>/dev/null
+if [[ `which unsetopt` ]]; then
+    unsetopt nomatch 2>/dev/null
+fi
 
 # Expand a version using the version cache
 nvm_version()


### PR DESCRIPTION
unsetopt doesn't exist on OSX by default which causes `. nvm.sh` to
fail at that line.

https://github.com/creationix/nvm/issues/128
