### PR TITLE
Fix parse error in Zsh 4.3.17

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -12,7 +12,7 @@ fi
 
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
-if [[ `which unsetopt` ]]; then
+if [ ! -z "$(which unsetopt)" ]; then
     unsetopt nomatch 2>/dev/null
 fi
 


### PR DESCRIPTION
Apparently the globbing fix for Zsh breaks in some versions of Zsh. (Kinda funny, huh?)
