### PR TITLE
fix for npm install failure (corrects: Issue #91)

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -156,10 +156,10 @@ nvm()
             if [[ "`expr match $VERSION '\(^v0\.2\.[0-2]$\)'`" != '' ]]; then
               echo "npm requires node v0.2.3 or higher"
             else
-              curl http://npmjs.org/install.sh | clean=yes npm_install=0.2.19 sh
+              curl https://npmjs.org/install.sh | clean=yes npm_install=0.2.19 sh
             fi
           else
-            curl http://npmjs.org/install.sh | clean=yes sh
+            curl https://npmjs.org/install.sh | clean=yes sh
           fi
         fi
       else


### PR DESCRIPTION
Updated the section of nvm.sh that installs npm for older versions of node. E.g.: nvm install v.0.4.10 fails with the error: "sh: Syntax error: newline unexpected" - this is because the curl command is encountering an HTML result (due to a 301 page moved) and trying to execute it as a shell script. The new url for the install script is via https instead of http. This patch changes the urls for both 2.x npm installs and others to use https.
