### PR TITLE
Fixes ls-remote with no parameters in linux

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -78,6 +78,8 @@ nvm_ls_remote()
         if [ "${PATTERN:0:1}" != "v" ]; then
             PATTERN=v$PATTERN
         fi
+    else
+        PATTERN=".*"
     fi
     VERSIONS=`curl -s http://nodejs.org/dist/ \
             | egrep -o 'v[0-9]+\.[0-9]+\.[0-9]+' \


### PR DESCRIPTION
It turns out that ls-remote wasn't working with the linux version of grep (worked on OSX). This patch fixes that by explicitly setting a pattern if one isn't specified.
