### PR TITLE
NVM downloading x86 binaries instead of source for ARM Linux box

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -19,7 +19,7 @@ fi
 # Try to figure out the os and arch for binary fetching
 uname="$(uname -a)"
 os=
-arch=x86
+arch="$(uname -m)"
 case "$uname" in
   Linux\ *) os=linux ;;
   Darwin\ *) os=darwin ;;


### PR DESCRIPTION
I couldn't install 0.8 or 0.9 on my Raspberry Pi via NVM and figured out that it wasn't building from source because NVM thought I was on an x86 box. This should fix it.
