### PR TITLE
Add nvmsudo Command

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -406,4 +406,10 @@ nvm()
   esac
 }
 
+nvmsudo(){
+    PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
+    PATH=$NVM_BIN:$PATH
+    sudo NVM_PATH=$NVM_PATH NVM_BIN=$NVM_BIN NVM_DIR=$NVM_DIR PATH=$PATH -- $@
+}
+
 nvm ls default &>/dev/null && nvm use default >/dev/null || true


### PR DESCRIPTION
I would like to execute sudo commands with the current nvm context. This is kind of a ripoff of rvmsudo.

Right now it creates a fresh PATH variable including the NVM_BIN director, and passes in all the NVM_ variables. Call it a rough cut; I am very open to suggestions.
