### PR TITLE
Zsh compatibility

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -36,8 +36,10 @@ nvm_version()
     # The default version is the current one
     if [ ! "$PATTERN" ]; then
         PATTERN='current'
+    else
+        PATTERN=`nvm_format_version $PATTERN`
     fi
-
+    
     VERSION=`nvm_ls $PATTERN | tail -n1`
     echo "$VERSION"
 
@@ -60,6 +62,11 @@ nvm_remote_version()
 nvm_normalize_version()
 {
   echo "$1" | sed -e 's/^v//' | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }';
+}
+
+nvm_format_version()
+{
+  echo "$1" | sed -e 's/^\([0-9]\)/v\1/g'
 }
   
 nvm_binary_available()
@@ -87,7 +94,7 @@ nvm_ls()
         return
     fi
     # If it looks like an explicit version, don't do anything funny
-    if [[ "$PATTERN" == v?*.?*.?* ]]; then
+    if echo "$PATTERN" | grep 'v.*\..*\..*' ; then
         VERSIONS="$PATTERN"
     else
         VERSIONS=`(cd $NVM_DIR; \ls -d v${PATTERN}* 2>/dev/null) | sort -t. -k 1.2,1n -k 2,2n -k 3,3n`
@@ -104,9 +111,7 @@ nvm_ls_remote()
 {
     PATTERN=$1
     if [ "$PATTERN" ]; then
-        if echo "${PATTERN}" | grep -v '^v' ; then
-            PATTERN=v$PATTERN
-        fi
+        PATTERN=`nvm_format_version "$PATTERN"`
     else
         PATTERN=".*"
     fi
@@ -254,11 +259,12 @@ nvm()
     ;;
     "uninstall" )
       [ $# -ne 2 ] && nvm help && return
-      if [[ $2 == `nvm_version` ]]; then
-        echo "nvm: Cannot uninstall currently-active node version, $2."
+      PATTERN=`nvm_format_version $2`
+      if [[ $PATTERN == `nvm_version` ]]; then
+        echo "nvm: Cannot uninstall currently-active node version, $PATTERN."
         return
       fi
-      VERSION=`nvm_version $2`
+      VERSION=`nvm_version $PATTERN`
       if [ ! -d $NVM_DIR/$VERSION ]; then
         echo "$VERSION version is not installed yet... installing"
         nvm install $VERSION


### PR DESCRIPTION
Fixed compatibility with zsh
Added method to normalize versions so they are comparable and method to 'format' a version number (prepend `v` if not starting with number).
