### PR TITLE
Basic install file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+NVM_TARGET="$HOME/.nvm"
+
+if [ -d "$NVM_TARGET" ]; then
+  echo "=> NVM is already installed in $NVM_TARGET, trying to update"
+  echo -ne "\r=> "
+  cd $NVM_TARGET && git pull
+  exit
+fi
+
+# Cloning to $NVM_TARGET
+git clone git://github.com/creationix/nvm.git $NVM_TARGET
+
+echo 
+
+# Detect profile file, .bash_profile has precedence over .profile
+if [ ! -z "$1" ]; then
+  PROFILE="$1"
+else
+  if [ -f "$HOME/.bash_profile" ]; then
+	PROFILE="$HOME/.bash_profile"
+  elif [ -f "$HOME/.profile" ]; then
+	PROFILE="$HOME/.profile"
+  fi
+fi
+
+SOURCE_STR='[[ -s "$HOME/.nvm/nvm.sh" ]] && . "$HOME/.nvm/nvm.sh"  # This loads NVM'
+
+if [ -z "$PROFILE" ] || [ ! -f "$PROFILE" ] ; then
+  if [ -z $PROFILE ]; then 
+	echo "=> Profile not found"
+  else
+	echo "=> Profile $PROFILE not found"
+  fi
+  echo "=> Append the following line to the correct file yourself"
+  echo
+  echo -e "\t$SOURCE_STR"
+  echo  
+  echo "=> Close and reopen your terminal to start using NVM"
+  exit
+fi
+
+if ! grep -qc 'nvm.sh' $PROFILE; then
+  echo "=> Appending source string to $PROFILE"
+  echo $SOURCE_STR >> "$PROFILE"
+else
+  echo "=> Source string already in $PROFILE"
+fi
+
+echo "=> Close and reopen your terminal to start using NVM"


### PR DESCRIPTION
A basic installer for NVM, can be run (when merged) like:

```
curl -L https://raw.github.com/creationix/nvm/master/install.sh | bash
```

It tries to determine which `.profile` file to use, but its also possible to specify one as first argument.

The script basically does a clone to `~/.nvm` and adds the source line to the user profile. If NVM is already installed it tries to update it (`git pull`)
