### PR TITLE
fixed 'bash command not found sha1sum' in Mac OS

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -185,7 +185,7 @@ nvm()
         echo 'NVM Needs curl to proceed.' >&2;
       fi
 
-      if [ ! `which shasum > /dev/null 2>&1` ]; then
+      if [ -z "`which shasum`" ]; then
         shasum='sha1sum'
       fi
 


### PR DESCRIPTION
line 188, `which shasum > /dev/null 2>&1` will be replaced by:

```
'/usr/bin/shasum > /dev/null 2>&1'
```

but, `/usr/bin/shasum` needs filename argument which is ommited and the
test results always 'false'.
