### PR TITLE
Check for versions like vX.Y

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -61,6 +61,9 @@ nvm_ls()
     if [[ "$PATTERN" == v?*.?*.?* ]]; then
         VERSIONS="$PATTERN"
     else
+        if [[ "$PATTERN" == v* ]]; then
+            PATTERN=${PATTERN/v//}
+        fi
         VERSIONS=`(cd $NVM_DIR; \ls -d v${PATTERN}* 2>/dev/null) | sort -t. -k 1.2,1n -k 2,2n -k 3,3n`
     fi
     if [ ! "$VERSIONS" ]; then


### PR DESCRIPTION
Users might ask for a v0.x version (`nvm use v0.9` for example). So we check for v\* versions that have no patch number.
We do that because v?_.?_.?\* does not match 'vX.Y'.
