### PR TITLE
Fix nvm_ls_remote() using decorated-grep

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -83,8 +83,8 @@ nvm_ls_remote()
         PATTERN=".*"
     fi
     VERSIONS=`curl -s http://nodejs.org/dist/ \
-                  | egrep -o 'v[0-9]+\.[0-9]+\.[0-9]+' \
-                  | grep -w "${PATTERN}" \
+                  | command egrep -o 'v[0-9]+\.[0-9]+\.[0-9]+' \
+                  | command grep -w "${PATTERN}" \
                   | sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n`
     if [ ! "$VERSIONS" ]; then
         echo "N/A"


### PR DESCRIPTION
" export GREP_OPTIONS='-n' " in bashrc disrupts nvm_ls_remote().
so I have added "command" before "grep" to execute raw-grep

```
$ nvm ls-remote
200:v0.1.96  52:v0.6.3  104:v0.8.14  67:v0.7.1      211:v0.2.2
1:v0.5.1     62:v0.6.8  205:v0.1.99  77:v0.7.3      111:v0.
5:v0.5.2     32:v0.6.13 ..................................
```
