### PR TITLE
Use .nvmrc if present

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -352,7 +352,7 @@ nvm()
       fi
     ;;
     "use" )
-      if [ $# -ne 2 ]; then
+      if [ $# -eq 0 ]; then
         nvm help
         return
       fi


### PR DESCRIPTION
When you execute "nvm use" in a directory without specify a node version, if present a file .nvmrc that contain a node version, that version is used.

Example:
gpad@gpad-travel:~/workspace$ mkdir nvm_example
gpad@gpad-travel:~/workspace$ cd nvm_example/
gpad@gpad-travel:~/workspace/nvm_example$ echo "0.8.16" > .nvmrc
gpad@gpad-travel:~/workspace/nvm_example$ nvm use 0.6.3
Now using node v0.6.3
gpad@gpad-travel:~/workspace/nvm_example$ node -v
v0.6.3
gpad@gpad-travel:~/workspace/nvm_example$ nvm use
Found .nvmrc files with version <0.8.16>
Now using node v0.8.16
gpad@gpad-travel:~/workspace/nvm_example$ node -v
v0.8.16
