### PR TITLE
fix the test of 'nvm deactivate'

### DIFF
--- a/test/fast/Running "nvm deactivate" should unset the nvm environment variables.
+++ b/test/fast/Running "nvm deactivate" should unset the nvm environment variables.
@@ -6,6 +6,6 @@ mkdir ../../v0.8.6
 
 nvm &&
 nvm use 0.8.6 &&
-(echo $PATH | grep nvm)
+(echo $PATH | grep nvm) &&
 nvm deactivate &&
 ! (echo $PATH | grep nvm)


### PR DESCRIPTION
It seems that the last condition of the test of `nvm deactivate` is wrong and the test itself has never passed. 

The problem is that the test supposes that after `nvm deactivate`, `nvm` itself fails. But the behaviour of `nvm deactivate` is only to remove paths for nvm-nodes and not to remove `nvm` itself. So the last condition should be `!(echo $PATH | grep nvm)`.

This PR fixes it.
