### PR TITLE
Fixes Issue 199

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -79,4 +79,11 @@ __nvm ()
   return 0
 }
 
+# complete is a bash builtin, but recent versions of ZSH come with a function 
+# called bashcompinit that will create a complete in ZSH. If the user is in 
+# ZSH, load and run bashcompinit before calling the complete function.
+if [[ -n ${ZSH_VERSION-} ]]; then
+	autoload -U +X bashcompinit && bashcompinit
+fi
+
 complete -o default -o nospace -F __nvm nvm


### PR DESCRIPTION
Fixes issue 199 where the bash completion was not working in ZSH
because the builtin bash command `complete` was not found. The fix
executes the `bashcompinit` command which creates the `complete`
function for the Z shell.
