### PR TITLE
~/.nvm/bin/node symbolic link

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -388,6 +388,7 @@ nvm()
       export MANPATH
       export NVM_PATH="$NVM_DIR/$VERSION/lib/node"
       export NVM_BIN="$NVM_DIR/$VERSION/bin"
+      ln -sf ${NVM_DIR}/${VERSION}/bin/node ${NVM_DIR}/bin
       echo "Now using node $VERSION"
     ;;
     "run" )


### PR DESCRIPTION
Added symbolic link in ~/.nvm/bin to active node version.

WebStorm, IMO, is the best nodejs IDE and debugging/running code from the IDE requires users to configure the path to their node installation.  Adding a symbolic link to ~/.nvm/bin allows users to link WebStorm once even if nodejs versions are changed using nvm use.
