### PR TITLE
Symlink contents of current node version bin to ~/.nvm/bin

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -388,7 +388,7 @@ nvm()
       export MANPATH
       export NVM_PATH="$NVM_DIR/$VERSION/lib/node"
       export NVM_BIN="$NVM_DIR/$VERSION/bin"
-      ln -sf ${NVM_DIR}/${VERSION}/bin/node ${NVM_DIR}/bin
+      ln -sf ${NVM_DIR}/${VERSION}/bin/* ${NVM_DIR}/bin
       echo "Now using node $VERSION"
     ;;
     "run" )


### PR DESCRIPTION
There needs to be a static path to all node binaries.
