### PR TITLE
Recommend installing nvm in ~/.nvm

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,11 +23,11 @@ For manual install create a folder somewhere in your filesystem with the `nvm.sh
 
 Or if you have `git` installed, then just clone it:
 
-    git clone git://github.com/creationix/nvm.git ~/nvm
+    git clone git://github.com/creationix/nvm.git ~/.nvm
 
 To activate nvm, you need to source it from your bash shell
 
-    . ~/nvm/nvm.sh
+    source ~/.nvm/nvm.sh
 
 I always add this line to my `~/.bashrc` or `~/.profile` file to have it automatically sourced upon login.   
 Often I also put in a line to use a specific version of node.


### PR DESCRIPTION
The README oddly recommends to install nvm inside of `~/nvm` which goes against conventions. It makes more sense to install tools like nvm in hidden home directories.

Oddly enough the existing README also claims that the shell script installation method puts nvm inside of `~/.nvm`. In the case, why do the manual installation instructions differ?

It's also best to use the `source` command explicitly instead of its `.` alias so that more people (even if they don't know bash scripting well) understand what the command does.
