### PR TITLE
Fix issue in copy-packages

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -473,7 +473,7 @@ nvm()
         VERSION=`nvm_version $2`
         ROOT=`nvm use $VERSION && npm -g root`
         INSTALLS=`nvm use $VERSION > /dev/null && npm -g -p ll | grep "$ROOT\/[^/]\+$" | cut -d '/' -f 8 | cut -d ":" -f 2 | grep -v npm | tr "\n" " "`
-        eval "npm install -g $INSTALLS"
+        eval npm install -g $INSTALLS
     ;;
     "clear-cache" )
         rm -f $NVM_DIR/v* 2>/dev/null


### PR DESCRIPTION
$INSTALLS passed as string argument to npm install =>`npm install -g "bower@0.9.2 grunt-cli"` would only install the first package `bower@0.9.2`.

Modified that to be `eval "npm install -g $INSTALLS"`.
