### PR TITLE
Options for nodejs.org mirrors and source for NVM

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ if [ -d "$NVM_TARGET" ]; then
 fi
 
 # Allow for alternate NVM sources so we can use a local copy or a fork
-if [ ! -d "$NVM_GIT_SOURCE" ]; then
+if [ -z "$NVM_GIT_SOURCE" ]; then
    export NVM_GIT_SOURCE="git://github.com/creationix/nvm.git"
 fi
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -10,7 +10,8 @@ if [ ! -d "$NVM_DIR" ]; then
     export NVM_DIR=$(cd $(dirname ${BASH_SOURCE[0]:-$0}) && pwd)
 fi
 
-if [ ! -d "$NODEJS_MIRROR" ]; then
+# Check to see if a MIRROR was defined
+if [ -z "$NODEJS_MIRROR" ]; then
    export NODEJS_MIRROR="http://nodejs.org/"
 fi
 


### PR DESCRIPTION
Two environment variables are checked for, namely `$NODEJS_MIRROR` and `$NVM_GIT_SOURCE`.

This allows people to use a mirror (or even local copy) of the nodejs.org/dist repository and even elect to use their own fork of nvm (it made testing the mirror setting easier).
