### PR TITLE
Drop invalid -a flag for basename.

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -79,7 +79,7 @@ nvm_ls()
     if [[ "$PATTERN" == v?*.?*.?* ]]; then
         VERSIONS="$PATTERN"
     else
-        VERSIONS=`nvm_set_nullglob; basename -a $NVM_DIR/v${PATTERN}* 2>/dev/null | sort -t. -k 1.2,1n -k 2,2n -k 3,3n`
+        VERSIONS=`nvm_set_nullglob; basename $NVM_DIR/v${PATTERN}* 2>/dev/null | sort -t. -k 1.2,1n -k 2,2n -k 3,3n`
     fi
     if [ ! "$VERSIONS" ]; then
         echo "N/A"


### PR DESCRIPTION
basename doesn't accept options in bash. This causes the VERSIONS variable get the 'N/A' value for $ nvm ls command.

From basename man page:
NAME
       basename - strip directory and suffix from filenames

SYNOPSIS
       basename NAME [SUFFIX]
       basename OPTION

DESCRIPTION
       Print NAME with any leading directory components removed.  If specified, also remove a trailing SUFFIX.

```
   --help display this help and exit

   --version
          output version information and exit
```

coreutils version used in Linux Mint 14 Nadia.

GNU coreutils 8.12.197-032bb                                               September 2011                                                               BASENAME(1)

No idea if this flag exists on FreeBSD or other unixes (if they use gnu coreutils shouldn't be any problem)
