### PR TITLE
Add support for Raspberry PI

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -116,8 +116,8 @@ nvm_checksum()
 {
     if [ "$1" = "$2" ]; then
         return
-    elif [[ "$VERSION" =~ ^v0\.10\.[0-5]$ && "$arch" == 'arm-pi' && "$binavail" == 1 ]]; then
-      echo 'Checksums matching failed but this failure will be ignored because no shasum is available for node v0.10.[0-5] for arm-pi'
+    elif [[ "$arch" == 'arm-pi' && "$binavail" == 1 ]]; then
+      echo 'Checksums matching failed but this failure will be ignored because no shasum is available for node for arm-pi'
       return
     else
         echo 'Checksums do not match.'


### PR DESCRIPTION
Hi @creationix,

It should have been an one line change but the shasums for the arm-pi binaries are not available in SHASUMS.txt so I added a few lines to ignore the checksum matching failure. I posted an issue on [joyent/node#5460](https://github.com/joyent/node/issues/5460) so for the next release the shasum should be available.

Cheers

ref #227
