### PR TITLE
Remove `-e` option in `install.sh` script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ if [ -z "$PROFILE" ] || [ ! -f "$PROFILE" ] ; then
   fi
   echo "=> Append the following line to the correct file yourself"
   echo
-  echo -e "\t$SOURCE_STR"
+  echo "\t$SOURCE_STR"
   echo
   echo "=> Close and reopen your terminal to start using NVM"
   exit
@@ -43,7 +43,7 @@ fi
 
 if ! grep -qc 'nvm.sh' $PROFILE; then
   echo "=> Appending source string to $PROFILE"
-  echo -e "\n" >> "$PROFILE"
+  echo "\n" >> "$PROFILE"
   echo $SOURCE_STR >> "$PROFILE"
 else
   echo "=> Source string already in $PROFILE"


### PR DESCRIPTION
My `.bash_profile` file was as follows when installed `nvm` via `curl`.

```
-e

[[ -s /Users/okuryu/.nvm/nvm.sh ]] && . /Users/okuryu/.nvm/nvm.sh # This loads NVM
```

I guess that shell actually doesn't support -e option. So seems to unneeded these options at install.sh.
