### PR TITLE
Fixes issue 232 and "nvm ls" returning "N/A" when it shouldn't

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -79,9 +79,7 @@ nvm_ls()
     if [[ "$PATTERN" == v?*.?*.?* ]]; then
         VERSIONS="$PATTERN"
     else
-        VERSIONS=`find $NVM_DIR -type d -name "v$PATTERN*" -print \
-                    | tr '\n' '\0' \
-                    | xargs -0 -n 1 basename 2>/dev/null \
+        VERSIONS=`find "$NVM_DIR/" -maxdepth 1 -type d -name "v$PATTERN*" -exec basename '{}' ';' \
                     | sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n`
     fi
     if [ ! "$VERSIONS" ]; then


### PR DESCRIPTION
Fixes issue 232 that occurs in at least bash v4.2.25 where "nvm ls" returns "N/A" no matter how many versions of node have been installed.  The fix uses a combination of the find, tr and basename commands instead of basename only.  Tested in bash v3.2.48 and v4.2.25 and zsh v4.3.11.
