### PR TITLE
Invoke basename with -a, so that it accepts multiple arguments

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -79,7 +79,7 @@ nvm_ls()
     if [[ "$PATTERN" == v?*.?*.?* ]]; then
         VERSIONS="$PATTERN"
     else
-        VERSIONS=`nvm_set_nullglob; basename $NVM_DIR/v${PATTERN}* 2>/dev/null | sort -t. -k 1.2,1n -k 2,2n -k 3,3n`
+        VERSIONS=`nvm_set_nullglob; basename -a $NVM_DIR/v${PATTERN}* 2>/dev/null | sort -t. -k 1.2,1n -k 2,2n -k 3,3n`
     fi
     if [ ! "$VERSIONS" ]; then
         echo "N/A"


### PR DESCRIPTION
`nvm ls` doesn't work on my system, because it passes multiple arguments to `basename`. This commit fixes it.

Before:

```
$ nvm ls
       N/A
current:    v0.10.5
default -> 0.10 (-> v0.10.5)
```

After:

```
$ nvm ls
   v0.6.21     v0.8.23     v0.10.5
current:    v0.10.5
default -> 0.10 (-> v0.10.5)
```

I'm using Ubuntu 13.04 with basename (GNU coreutils) 8.20 and GNU bash 4.2.45(1)-release. The `-a` option added in this commit works on Mac OS X version 10.8.3 as well, so it should be good.
