### PR TITLE
Changed git download protocol from git:// to https:// to work around firewalls.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ if [ -d "$NVM_TARGET" ]; then
 fi
 
 # Cloning to $NVM_TARGET
-git clone git://github.com/creationix/nvm.git $NVM_TARGET
+git clone https://github.com/creationix/nvm.git $NVM_TARGET
 
 echo
 


### PR DESCRIPTION
I was trying to write an automated script for using nvm in the development toolchain at work. However, the `install.sh` script would fail to complete with a timeout error. I discovered that the script used `git clone git://github.com/creationix/nvm.git $NVM_TARGET` to download the repo. I changed the protocol from `git://` to `https://` and everything works as I expected. I don't believe there is a downside to this change.

Thank you for the great project, and thank you for considering my pull request.

Chip Warden
