### PR TITLE
Add mirror option for node binaries

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,6 +66,11 @@ To set a default Node version to be used in any new shell, use the alias 'defaul
 
     nvm alias default 0.10
 
+To use a mirror of the node binaries, set `$NODEJS_MIRROR`:
+
+    export NODEJS_MIRROR=http://nodejs.org/dist
+    nvm install 0.10
+
 ## License
 
 nvm is released under the MIT license.

--- a/nvm.sh
+++ b/nvm.sh
@@ -26,7 +26,7 @@ fi
 
 # Setup mirror location if not already set
 if [ -z "$NODEJS_MIRROR" ]; then
-    export NODEJS_MIRROR="http://nodejs.org"
+    export NODEJS_MIRROR="http://nodejs.org/dist"
 fi
 
 nvm_set_nullglob() {
@@ -110,7 +110,7 @@ nvm_ls_remote() {
     else
         PATTERN=".*"
     fi
-    VERSIONS=`curl -s $NODEJS_MIRROR/dist/ \
+    VERSIONS=`curl -s $NODEJS_MIRROR/ \
                   | \egrep -o 'v[0-9]+\.[0-9]+\.[0-9]+' \
                   | \grep -w "${PATTERN}" \
                   | sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n`
@@ -267,8 +267,8 @@ nvm() {
           esac
           if [ $binavail -eq 1 ]; then
             t="$VERSION-$os-$arch"
-            url="$NODEJS_MIRROR/dist/$VERSION/node-${t}.tar.gz"
-            sum=`curl -s $NODEJS_MIRROR/dist/$VERSION/SHASUMS.txt | \grep node-${t}.tar.gz | awk '{print $1}'`
+            url="$NODEJS_MIRROR/$VERSION/node-${t}.tar.gz"
+            sum=`curl -s $NODEJS_MIRROR/$VERSION/SHASUMS.txt | \grep node-${t}.tar.gz | awk '{print $1}'`
             local tmpdir="$NVM_DIR/bin/node-${t}"
             local tmptarball="$tmpdir/node-${t}.tar.gz"
             if (
@@ -300,11 +300,11 @@ nvm() {
       fi
       local tmpdir="$NVM_DIR/src"
       local tmptarball="$tmpdir/node-$VERSION.tar.gz"
-      if [ "`curl -Is "$NODEJS_MIRROR/dist/$VERSION/node-$VERSION.tar.gz" | \grep '200 OK'`" != '' ]; then
-        tarball="$NODEJS_MIRROR/dist/$VERSION/node-$VERSION.tar.gz"
-        sum=`curl -s $NODEJS_MIRROR/dist/$VERSION/SHASUMS.txt | \grep node-$VERSION.tar.gz | awk '{print $1}'`
-      elif [ "`curl -Is "$NODEJS_MIRROR/dist/node-$VERSION.tar.gz" | \grep '200 OK'`" != '' ]; then
-        tarball="$NODEJS_MIRROR/dist/node-$VERSION.tar.gz"
+      if [ "`curl -Is "$NODEJS_MIRROR/$VERSION/node-$VERSION.tar.gz" | \grep '200 OK'`" != '' ]; then
+        tarball="$NODEJS_MIRROR/$VERSION/node-$VERSION.tar.gz"
+        sum=`curl -s $NODEJS_MIRROR/$VERSION/SHASUMS.txt | \grep node-$VERSION.tar.gz | awk '{print $1}'`
+      elif [ "`curl -Is "$NODEJS_MIRROR/node-$VERSION.tar.gz" | \grep '200 OK'`" != '' ]; then
+        tarball="$NODEJS_MIRROR/node-$VERSION.tar.gz"
       fi
       if (
         [ ! -z $tarball ] && \


### PR DESCRIPTION
This sets the url for nodejs.org as a variable. This allows for mirroring, but also keeps the code away from being completely hardcoded.
