### PR TITLE
Fix `nvm ls` with multiple installed versions

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -79,7 +79,7 @@ nvm_ls()
     if [[ "$PATTERN" == v?*.?*.?* ]]; then
         VERSIONS="$PATTERN"
     else
-        VERSIONS=`nvm_set_nullglob; basename $NVM_DIR/v${PATTERN}* 2>/dev/null | sort -t. -k 1.2,1n -k 2,2n -k 3,3n`
+        VERSIONS=`\ls -d $NVM_DIR/v${PATTERN}* 2>/dev/null | xargs -n 1 basename | sort -t. -k 1.2,1n -k 2,2n -k 3,3n`
     fi
     if [ ! "$VERSIONS" ]; then
         echo "N/A"


### PR DESCRIPTION
The `-a` flag for basename, dropped in commit 335456d, was needed
to instruct it to not ignore the arguments after the first one.

Go back to using `\ls` as done before commit 42915fc, but using basename
and xargs to avoid changing the current directory.

With this the 'Running "nvm ls" should display all installed versions.'
test passes again.
