### PR TITLE
Using source instead of dot.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ Or if you have `git` installed, then just clone it:
 
 To activate nvm, you need to source it from your bash shell
 
-    . ~/.nvm/nvm.sh
+    source ~/.nvm/nvm.sh
 
 I always add this line to my `~/.bashrc` or `~/.profile` file to have it automatically sourced upon login.   
 Often I also put in a line to use a specific version of node.


### PR DESCRIPTION
Per the suggestion in #211, using `source` instead of a dot in the readme. Closes #211.
