### PR TITLE
Gitless in Seattle 

### DIFF
--- a/install-gitless.sh
+++ b/install-gitless.sh
@@ -32,7 +32,7 @@ else
   fi
 fi
 
-SOURCE_STR="[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_TARGET/nvm.sh"  # This loads NVM"
+SOURCE_STR="[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads NVM"
 
 if [ -z "$PROFILE" ] || [ ! -f "$PROFILE" ] ; then
   if [ -z $PROFILE ]; then


### PR DESCRIPTION
Few changes to @ronkorving 's contribution:
1. We do now blow up the directory hosting the installed node versions and global modules
2. We update only nvm.sh, which is faster to download and does not require tar.
3. Just like my prior pull request, we base ourselves on NVM_DIR instead of NVM_TARGET, which means we will detect (and update) the correct installation (instead of potentially double-installing)
