### PR TITLE
add support for Raspberry Pi binaries

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -114,6 +114,9 @@ nvm_ls_remote() {
 nvm_checksum() {
     if [ "$1" = "$2" ]; then
         return
+    elif [ -z $2 ]; then
+        echo 'Checksums empty' #missing in raspberry pi binary
+        return
     else
         echo 'Checksums do not match.'
         return 1
@@ -153,6 +156,7 @@ nvm() {
   case "$uname" in
     *x86_64*) arch=x64 ;;
     *i*86*) arch=x86 ;;
+    *armv6l*) arch=arm-pi ;;
   esac
 
   # initialize local variables


### PR DESCRIPTION
Nodejs.org named the Raspberry Pi binaries as
http://nodejs.org/dist/v0.10.5/node-v0.10.5-linux-arm-pi.tar.gz

And the checksum is missing in v0.9
http://nodejs.org/dist/v0.9.9/SHASUMS.txt

This change addresses both
