### PR TITLE
Docs: The README should state that a cURL installation is necessary.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 ## Installation
 
-First you'll need to make sure your system has a c++ compiler.  For OSX, XCode will work, for Ubuntu, the build-essential and libssl-dev packages work.
+First you'll need to make sure your system has cURL and a c++ compiler.  For OSX, XCode will work, for Ubuntu, the build-essential and libssl-dev packages work.
 
 ### Install script
 


### PR DESCRIPTION
Just a tiny doc improvement: With the current README, it seems as if cURL is optional ("either install through cURL or Wget..."), where in fact it is not. 

Workshop participants failed to notice this dependency and spend some time looking for the error. With a small hint that cURL is necessary, they might not have had this issue.
