### PR TITLE
better guides for missing profile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,11 +6,10 @@ if [ -d "$NVM_DIR" ]; then
   echo "=> NVM is already installed in $NVM_DIR, trying to update"
   echo -ne "\r=> "
   cd $NVM_DIR && git pull
-  exit
+else
+  # Cloning to $NVM_DIR
+  git clone https://github.com/creationix/nvm.git $NVM_DIR  
 fi
-
-# Cloning to $NVM_DIR
-git clone https://github.com/creationix/nvm.git $NVM_DIR
 
 echo
 
@@ -29,15 +28,21 @@ SOURCE_STR="[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads NVM"
 
 if [ -z "$PROFILE" ] || [ ! -f "$PROFILE" ] ; then
   if [ -z $PROFILE ]; then
-	echo "=> Profile not found"
+	echo "=> Profile not found. Tried $HOME/.bash_profile and $HOME/.profile"
   else
 	echo "=> Profile $PROFILE not found"
   fi
+  echo "=> Run this script again after running the following:"
+  echo
+  echo "\ttouch $HOME/.profile"
+  echo
+  echo "-- OR --"
+  echo
   echo "=> Append the following line to the correct file yourself"
   echo
   echo "\t$SOURCE_STR"
   echo
-  echo "=> Close and reopen your terminal to start using NVM"
+  echo "=> Close and reopen your terminal afterwards to start using NVM"
   exit
 fi
 


### PR DESCRIPTION
New OSX systems do not have a .profile file. The guides for handling such situations should now be more helpful.

In addition the script has been modified so that it can be used for the profile script injections by running it again also after the first run.
