### PR TITLE
Avoid error from aliased `which` during install

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -201,7 +201,7 @@ nvm() {
       local shasum='shasum'
       local nobinary
 
-      if [ ! `which curl` ]; then
+      if [ ! `\which curl` ]; then
         echo 'NVM Needs curl to proceed.' >&2;
       fi
 


### PR DESCRIPTION
The same fix as #207, just for fools like me who have `which` aliased to `type` in OS X. Without this escape, a very cryptic error message is emitted (though the install ultimately succeeds, as long as one actually has `curl` installed).
