### PR TITLE
readme: use https clone url

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ For manual install create a folder somewhere in your filesystem with the `nvm.sh
 
 Or if you have `git` installed, then just clone it:
 
-    git clone git://github.com/creationix/nvm.git ~/.nvm
+    git clone https://github.com/creationix/nvm.git ~/.nvm
 
 To activate nvm, you need to source it from your bash shell
 


### PR DESCRIPTION
The git:// transport is vulnerable to man-in-the-middle and DNS
spoofing attacks and its use over untrusted networks should be
discouraged.

Change to the https:// clone url in the install instructions.
