### PR TITLE
fix MANPATH generation on FreeBSD

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -407,6 +407,10 @@ nvm() {
       else
         PATH="$NVM_DIR/$VERSION/bin:$PATH"
       fi
+      if [ -z "$MANPATH" ]; then
+        MANPATH=$(manpath)
+      fi
+      MANPATH=${MANPATH#*$NVM_DIR/*/man:}
       if [[ $MANPATH == *$NVM_DIR/*/share/man* ]]; then
         MANPATH=${MANPATH%$NVM_DIR/*/share/man*}$NVM_DIR/$VERSION/share/man${MANPATH#*$NVM_DIR/*/share/man}
       else


### PR DESCRIPTION
FOREWORD: I have tested this on FreeBSD and GNU+Linux (Ubuntu
13.04).  I have not been able to test on Mac OS X, so hopefully a
maintainer can...

On FreeBSD, if MANPATH is set it is used verbatim; configuration
files are completely ignored.  Therefore, setting MANPATH to (only)
the nvm man dir makes system man pages unreachable.

To get around this, before doing anything else to MANPATH, if it is
empty set it to the output of manpath(1).

One further complication: FreeBSD automatically adds a path to the
man pages path for each path in PATH that ends in "/bin", which
causes "~/.nvm/$VERSION/man" to be added.  This interferes with the
subsequent substitution so strip this from MANPATH before the
substitution.
