### PR TITLE
Fixed curl silently ignoring 302 redirections

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -258,7 +258,7 @@ nvm() {
             local tmptarball="$tmpdir/node-${t}.tar.gz"
             if (
               mkdir -p "$tmpdir" && \
-              curl -C - --progress-bar $url -o "$tmptarball" && \
+              curl -L -C - --progress-bar $url -o "$tmptarball" && \
               nvm_checksum `${shasum} "$tmptarball" | awk '{print $1}'` $sum && \
               tar -xzf "$tmptarball" -C "$tmpdir" --strip-components 1 && \
               mv "$tmpdir" "$NVM_DIR/$VERSION" && \
@@ -294,7 +294,7 @@ nvm() {
       if (
         [ ! -z $tarball ] && \
         mkdir -p "$tmpdir" && \
-        curl --progress-bar $tarball -o "$tmptarball" && \
+        curl -L --progress-bar $tarball -o "$tmptarball" && \
         if [ "$sum" = "" ]; then : ; else nvm_checksum `${shasum} "$tmptarball" | awk '{print $1}'` $sum; fi && \
         tar -xzf "$tmptarball" -C "$tmpdir" && \
         cd "$tmpdir/node-$VERSION" && \


### PR DESCRIPTION
Under certain network environments, due to poor implementation of file
download caches (immoral Chinese ISP), the direct download of Node.js
packages (http://nodejs.org/dist/node-$VERSION.tar.gz) will be
redirected to alternative urls using 302 redirections, which are not
handled by `curl --process-bar` by default. Instead, curl will "fail"
silently without creating any output file or error exitcode.
(Tested under Ubuntu 12.04 Desktop)

Fixed by adding "-L" switches to the curl commands responsible for
downloading the binary and source node.js packages.
