### PR TITLE
install.sh: use a more generic SOURCE_STR

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ else
   fi
 fi
 
-SOURCE_STR="[[ -s "$NVM_DIR/nvm.sh" ]] && . "$NVM_DIR/nvm.sh"  # This loads NVM"
+SOURCE_STR="[ -s \$HOME/.nvm/nvm.sh ] && . \$HOME/.nvm/nvm.sh  # This loads NVM"
 
 if [ -z "$PROFILE" ] || [ ! -f "$PROFILE" ] ; then
   if [ -z $PROFILE ]; then


### PR DESCRIPTION
SOURCE_STR currently includes the value of $HOME (at install time).
Change SOURCE_STR to include a literal "$HOME" (to be expanded at
profile runtime) so that sourcing nvm will work if the user changes
their username, shares their profile, et cetera.

Also use the more portable single-square-bracket test.
