### PR TITLE
Overwritting GREP_OPTIONS on local script

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -100,6 +100,7 @@ nvm_ls() {
 nvm_ls_remote() {
   local PATTERN=$1
   local VERSIONS
+  local GREP_OPTIONS=''
   if [ "$PATTERN" ]; then
     if echo "${PATTERN}" | \grep -v '^v' ; then
       PATTERN=v$PATTERN
@@ -170,6 +171,7 @@ nvm() {
   local uname="$(uname -a)"
   local os=
   local arch="$(uname -m)"
+  local GREP_OPTIONS=''
   case "$uname" in
     Linux\ *) os=linux ;;
     Darwin\ *) os=darwin ;;


### PR DESCRIPTION
I found an issue (possibly related to #285 and #262) that `nvm.sh` uses `grep` but doesn't ignore the user's `GREP_OPTIONS` (http://www.gnu.org/savannah-checkouts/gnu/grep/manual/grep.html#Environment-Variables) environment variable, which may change the output expected by `nvm.sh`.

I have overwrite it inside nvm.sh.

[ ]'s
