### PR TITLE
Properly remove the tar file.

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -262,7 +262,7 @@ nvm() {
               curl -L -C - --progress-bar $url -o "$tmptarball" && \
               nvm_checksum `${shasum} "$tmptarball" | awk '{print $1}'` $sum && \
               tar -xzf "$tmptarball" -C "$tmpdir" --strip-components 1 && \
-              rm "$tmptarball" && \
+              rm -f "$tmptarball" && \
               mv "$tmpdir" "$NVM_DIR/$VERSION"
               )
             then


### PR DESCRIPTION
The tar file isn't being removed properly because the folder was being moved before the removal command. The `-f` was masking the error.
