### PR TITLE
Fixed bash error caused by lack of double quotes

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -389,7 +389,7 @@ nvm() {
       if [ -z $VERSION ]; then
         VERSION=`nvm_version $2`
       fi
-      if [ ! -d $NVM_DIR/$VERSION ]; then
+      if [ ! -d "$NVM_DIR/$VERSION" ]; then
         echo "$VERSION version is not installed yet"
         return 1
       fi


### PR DESCRIPTION
Without quotes, this line caused a bash error/warning to be printed every time nvm.sh was sourced by bash:

-bash: [: too many arguments
