### PR TITLE
nvm symlink for IDE/development purposes

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -127,7 +127,10 @@ nvm_checksum() {
 nvm_update_symlink() {
     # execute only when a symlink is defined
     if [ -f $NVM_DIR/symlink ]; then
-        ln -s $(echo $NVM_DIR/v`cat $NVM_DIR/alias/default`) $(echo `cat $NVM_DIR/symlink`)
+        if [ -d `cat $NVM_DIR/symlink` ]; then
+            rm `cat $NVM_DIR/symlink`
+        fi
+        ln -sf $(echo $NVM_DIR/`cat $NVM_DIR/alias/default`) $(echo `cat $NVM_DIR/symlink`)
     fi
 }
 


### PR DESCRIPTION
added a symlink to a provided custom path for IDE/development references with the latest Node.JS version.
`nvm symlink ~/nvm` can be used as the default Node.JS version for projects.

I also added it to `nvm (un)alias` to ensure the symlink path is updated when a new default version is set.
