### PR TITLE
nvm exec wrapper to execute commands with a specific node version

### DIFF
--- a/nvm-exec
+++ b/nvm-exec
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+DIR="$(command cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$DIR/nvm.sh"
+
+if [ ! "$NODE_VERSION" ]; then
+  echo 'NODE_VERSION not set'
+  exit 1
+fi
+
+nvm use $NODE_VERSION
+
+exec $@


### PR DESCRIPTION
I've created a very basic wrapper for sourcing nvm and setting a node version with `nvm use` to easily run a command with a specific node version.

``` sh
NODE_VERSION=0.10 ~/.nvm/nvm-exec node -V
```

I'm currently using this as a solution for using [nvm in capistrano deployment](https://github.com/koenpunt/capistrano-nvm).

Suggestions for improvements are welcome.
