### PR TITLE
Universal test of unsetopt command

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -9,7 +9,7 @@
 
 # Make zsh glob matching behave same as bash
 # This fixes the "zsh: no matches found" errors
-if [ ! -z "$(which unsetopt 2>/dev/null)" ]; then
+if type "unsetopt" > /dev/null; then
     unsetopt nomatch 2>/dev/null
     NVM_CD_FLAGS="-q"
 fi


### PR DESCRIPTION
`which` can output undesired output on solaris (see #300).

According to http://stackoverflow.com/a/7522866/189431 this should work in "bash, zsh, ksh and sh (as provided by dash)".
