### PR TITLE
fix copy-packages

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -484,9 +484,10 @@ nvm() {
           nvm help
           return
         fi
-        VERSION=`nvm_version $2`
-        ROOT=`nvm use $VERSION && npm -g root`
-        INSTALLS=`nvm use $VERSION > /dev/null && npm -g -p ll | \grep "$ROOT\/[^/]\+$" | cut -d '/' -f 8 | cut -d ":" -f 2 | \grep -v npm | tr "\n" " "`
+        local VERSION=`nvm_version $2`
+        local ROOT=`nvm use $VERSION && npm -g root`
+        local ROOTDEPTH=$((`echo $ROOT | sed 's/[^\/]//g'|wc -m` -1))
+        local INSTALLS=`nvm use $VERSION > /dev/null && npm -g -p ll | \grep "$ROOT\/[^/]\+$" | cut -d '/' -f $(($ROOTDEPTH + 2)) | cut -d ":" -f 2 | \grep -v npm | tr "\n" " "`
         npm install -g $INSTALLS
     ;;
     "clear-cache" )


### PR DESCRIPTION
`copy-packages` assumes that the `$ROOT` is exactly 6 levels deep, but this isn't always the case. This pull request calculates the depth so that the package names can be found. This should address #314
