### PR TITLE
Fixes #346

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ else
   fi
 fi
 
-SOURCE_STR="[ -s \$HOME/.nvm/nvm.sh ] && . \$HOME/.nvm/nvm.sh  # This loads NVM"
+SOURCE_STR="[[ -s \$HOME/.nvm/nvm.sh ]] && . \$HOME/.nvm/nvm.sh  # This loads NVM"
 
 if [ -z "$PROFILE" ] || [ ! -f "$PROFILE" ] ; then
   if [ -z $PROFILE ]; then


### PR DESCRIPTION
Ubuntu's `sh` is `dash` by default.
