### PR TITLE
don't curl if version is specified + installed

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -240,6 +240,8 @@ nvm() {
       if [ "$os" = "freebsd" ]; then
 	nobinary=1
       fi
+      
+      [ -d "$NVM_DIR/$1" ] && echo "$1 is already installed." && return
 
       VERSION=`nvm_remote_version $1`
       ADDITIONAL_PARAMETERS=''


### PR DESCRIPTION
Removes CURL to match the version pattern if an explicit version (e.g. `v0.10.25`) is specified and already installed.

Means `nvm install v0.10.25` can be used without an internet connection, will speed up the code and reduce number of requests to the server.

No actual functionality changed - just a quicker exit.
