### PR TITLE
Change variable name to fix zsh parse issue

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -364,9 +364,9 @@ nvm() {
       echo "Uninstalled node $VERSION"
 
       # Rm any aliases that point to uninstalled version.
-      for A in `\grep -l $VERSION $NVM_DIR/alias/* 2>/dev/null`
+      for ALIAS in `\grep -l $VERSION $NVM_DIR/alias/* 2>/dev/null`
       do
-        nvm unalias `basename $A`
+        nvm unalias `basename $ALIAS`
       done
 
     ;;


### PR DESCRIPTION
Using 'A' as a variable throws the following error using zsh (oh-my-zsh) on OSX 10.9.1 when trying to source `nvm.sh`

``` sh
    $HOME/.nvm/nvm.sh:367: parse error near `|'
```

Not sure why, but changing the variable name to anything _but_ 'A' seems to fix the parse error.
