### PR TITLE
Use symlinks for aliases

### DIFF
--- a/test/fast/Running "nvm alias" should create a file in the alias directory.
+++ b/test/fast/Running "nvm alias" should create a file in the alias directory.
@@ -2,4 +2,4 @@
 
 . ../../nvm.sh
 nvm alias test v0.1.2
-[ $(cat ../../alias/test) = 'v0.1.2' ]
+[ -h ../../alias/test ] && [ $(readlink ../../alias/test) = '../v0.1.2' ]

--- a/test/fast/Running "nvm unalias" should remove the alias file.
+++ b/test/fast/Running "nvm unalias" should remove the alias file.
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo v0.1.2 > ../../alias/test
+ln -s ../v0.1.2 ../../alias/test
 . ../../nvm.sh
 nvm unalias test
-! [ -e ../../alias/test ]
+! [ -h ../../alias/test ]


### PR DESCRIPTION
This is something I've seen mentioned in another issue, and something that would greatly simplify my own CI setup, and allow me to use nvm in more versatile ways.

I didn't try for backwards compatibility, so yes these are indeed breaking changes. If this is rejected I won't bother, but if you are interested in merging, but want backwards compatibility, then I have another idea of using symlinks in addition to files.

One thing to note is why I am removing the link if it exists before creating it instead of just using `ln -f`. This is because (on OS X at least) if you `ln -sf path/to/dir existing/link/to/old/dir` then it creates a link inside of `existing/link/to/old/dir`. This essentially gives you `existing/link/to/old/dir/dir`, which points to nothing if `path/to/dir` is relative.

---

This is my first contribution to nvm so wanted to note a few of issues I came across. These are not related to this pull request:
- `nvm deactivate` fails in OS X Mavericks, and fails test of course (might be if PATH is set by launchd).
- Not sure what is the preferred shell compatibility nvm is going for. It looks to be bash, but there's many inconsistencies between using bash only things versus sh compatible things.
- There are quite a few variables not declared as local (ALIAS being one of them).

If you are interested in further pull requests for these, please let me know.
