### PR TITLE
fixes #359

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -140,10 +140,12 @@ colorize_version() {
 }
 
 print_versions() {
+  local VERSION
   for VERSION in $1; do
-    local PADDED_VERSION=`printf '%10s' $VERSION`
     if [[ -d "$NVM_DIR/$VERSION" ]]; then
-      colorize_version "$PADDED_VERSION"
+      colorize_version "$(printf '%10s' $VERSION)"
+    else
+      echo $VERSION
     fi
   done
 }


### PR DESCRIPTION
Not sure why the logic of this function changed in https://github.com/creationix/nvm/commit/13781f242b0f8ae7d55274016884100550f9d6dd.

This puts back listing the uninstalled ls-remote versions.

There was only one use of PADDED_VERSION so it didn't need to be a variable. VERSION was not declared locally in the for loop, so I just added that too.
