### PR TITLE
Detect if curl or wget is installed to download NVM_SOURCE

### DIFF
--- a/install-gitless.sh
+++ b/install-gitless.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function fatalExit (){
+fatalExit (){
   echo "$@" && exit 1;
 }
 


### PR DESCRIPTION
Noticed that if I tried installing-gitless and using wget, it failed because curl was being used. This detects if curl or wget is installed and uses it to download $NVM_SOURCE.
