### PR TITLE
Added travis config, fixed tests for use on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: bash
+before_script:
+  - curl -o /tmp/urchin https://raw.github.com/scraperwiki/urchin/master/urchin && chmod +x /tmp/urchin
+script:
+  - NVM_DIR=$TRAVIS_BUILD_DIR /tmp/urchin test

--- a/test/fast/Running "nvm alias" should create a file in the alias directory.
+++ b/test/fast/Running "nvm alias" should create a file in the alias directory.
@@ -2,4 +2,4 @@
 
 . ../../nvm.sh
 nvm alias test v0.1.2
-[ $(cat ../../alias/test) = 'v0.1.2' ]
+[ "$(cat ../../alias/test)" = "v0.1.2" ]

--- a/test/fast/teardown_dir
+++ b/test/fast/teardown_dir
@@ -6,7 +6,7 @@
   # Restore
   if [ -d bak ]
     then
-    mv bak/* . || sleep 0s
+    mv bak/* . > /dev/null 2>&1 || sleep 0s
     rmdir bak
   fi
   mkdir -p src alias


### PR DESCRIPTION
I've added travis configuration and updated the tests to work with travis.

@ljharb If you can enable the hook, then this PR should already show that it's working.

Current travis build: https://travis-ci.org/koenpunt/nvm/builds/20936607

~~Although there is still an issue with urchin; it always exits with zero, so a failed build will not show as such, but [I've filed an issue](https://github.com/scraperwiki/urchin/issues/5) with urchin for this. I think we can easily resolve this issue ourselves as well.~~ 
**The issue has been resolved and urchin exits with non-zero status on failures.**
