### PR TITLE
`nvm install` and `nvm run` use .nvmrc when version not provided

### DIFF
--- a/test/slow/nvm install/install version specified in .nvmrc from binary
+++ b/test/slow/nvm install/install version specified in .nvmrc from binary
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+. ../../../nvm.sh
+
+NVM_TEST_VERSION=v0.10.7
+
+# Remove the stuff we're clobbering.
+[ -e ../../../$NVM_TEST_VERSION ] && rm -R ../../../$NVM_TEST_VERSION
+
+# Install from binary
+cat "$NVM_TEST_VERSION" > .nvmrc
+
+nvm install
+
+# Check
+[ -d ../../../$NVM_TEST_VERSION ]
+nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION
+
+

--- a/test/slow/nvm install/install version specified in .nvmrc from source
+++ b/test/slow/nvm install/install version specified in .nvmrc from source
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+. ../../../nvm.sh
+
+NVM_TEST_VERSION=v0.10.7
+
+# Remove the stuff we're clobbering.
+[ -e ../../../$NVM_TEST_VERSION ] && rm -R ../../../$NVM_TEST_VERSION
+
+# Install from binary
+cat "$NVM_TEST_VERSION" > .nvmrc
+
+nvm install -s
+
+# Check
+[ -d ../../../$NVM_TEST_VERSION ]
+nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION
+
+


### PR DESCRIPTION
Fixes #318.
