### PR TITLE
Use sed -e instead of -E

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -98,7 +98,7 @@ nvm_format_version() {
 }
 
 nvm_strip_path() {
-  echo "$1" | sed -e "s#$NVM_DIR/[^/]*$2[^:]*##g" | sed -e "s/::/:/g" | sed -e "s/:$//g"
+  echo "$1" | sed -e "s#$NVM_DIR/[^/]*$2[^:]*:##g" -e "s#:$NVM_DIR/[^/]*$2[^:]*##g" -e "s#$NVM_DIR/[^/]*$2[^:]*##g"
 }
 
 nvm_binary_available() {

--- a/test/fast/Unit tests/nvm_strip_path
+++ b/test/fast/Unit tests/nvm_strip_path
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+TEST_PATH=$NVM_DIR/v0.10.5/bin:/usr/bin:$NVM_DIR/v0.11.5/bin:$NVM_DIR/v0.9.5/bin:/usr/local/bin:$NVM_DIR/v0.2.5/bin
+
+STRIPPED_PATH=`nvm_strip_path "$TEST_PATH" "/bin"`
+
+[ "$STRIPPED_PATH" = "/usr/bin:/usr/local/bin" ] || die "Not correctly stripped: $STRIPPED_PATH "


### PR DESCRIPTION
Simplify regex, not replacing trailing colon (:), fixes #411

~~But this could result in double colons or trailing colons at the end of the PATH..~~ 
Now using multiple `sed` calls as a fix. Should probably be refactored.
