### PR TITLE
Use bash, not sh for install scritps

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,11 +8,11 @@ First you'll need to make sure your system has a c++ compiler.  For OSX, XCode w
 
 To install you could use the [install script][2] using cURL:
 
-    curl https://raw.githubusercontent.com/creationix/nvm/v0.10.0/install.sh | sh
+    curl https://raw.githubusercontent.com/creationix/nvm/v0.10.0/install.sh | bash
 
 or Wget:
 
-    wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.10.0/install.sh | sh
+    wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.10.0/install.sh | bash
 
 <sub>The script clones the nvm repository to `~/.nvm` and adds the source line to your profile (`~/.bash_profile`, `~/.zshrc` or `~/.profile`).</sub>
 


### PR DESCRIPTION
Install scripts don't work in pure sh; they may work on some systems where
the /bin/sh binary actually implements more than the pure Bourne Shell but
fail on other ones (e.g. Ubuntu).

Just using bash works.
