### PR TITLE
Should escape grep in nvm_ls

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -159,7 +159,7 @@ nvm_ls() {
     fi
   else
     VERSIONS=`find "$NVM_DIR/" -maxdepth 1 -type d -name "$(nvm_format_version $PATTERN)*" -exec basename '{}' ';' \
-      | sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n | grep -v '^ *\.'`
+      | sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n | \grep -v '^ *\.'`
   fi
   if [ -z "$VERSIONS" ]; then
     echo "N/A"


### PR DESCRIPTION
Without the \grep escaping I kept getting output like this:

``` bash
$ nvm ls
   (standard
input):2:v0.10.29
```

and

``` bash
nvm use 0.10
(standard input):1:v0.10.29 version is not installed yet
```

Because I have `grep` to a crazy alias.

Strange thing is that tests worked in both cases... But this fixed the problem of `nvm ls` and `nvm use` for me.
