### PR TITLE
Hotfix: correctly map curl's `-C -` to wget

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ nvm_download() {
     ARGS=${ARGS/-I /}
     ARGS=${ARGS/-s /-q }
     ARGS=${ARGS/-o /-O }
-    ARGS=${ARGS/-C /-c }
+    ARGS=${ARGS/-C - /-c }
     wget $ARGS
   fi
 }

--- a/nvm.sh
+++ b/nvm.sh
@@ -23,7 +23,7 @@ nvm_download() {
     ARGS=${ARGS/-I /}
     ARGS=${ARGS/-s /-q }
     ARGS=${ARGS/-o /-O }
-    ARGS=${ARGS/-C /-c }
+    ARGS=${ARGS/-C - /-c }
     wget $ARGS
   fi
 }


### PR DESCRIPTION
wget doesn't need or accept the `-` parameter to `-c`

Without it, on a `curl`-less OS `nvm install` doesn't work since wget tries to download from `http://-/` apart from the real Node file which causes the process to fail and makes nvm think the binary download didn't succeed.

So this is pretty critical to wget users.

Should wget `nvm install` be tested somehow? If it was, this issue wouldn't happen.
