### PR TITLE
Changes $path var to $node_path

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -56,10 +56,10 @@ fi
 nvm_tree_contains_path() {
   local tree
   tree="$1"
-  local path
-  path="$2"
+  local node_path
+  node_path="$2"
   local pathdir
-  pathdir=$(dirname "$path")
+  pathdir=$(dirname "$node_path")
   while [ "$pathdir" != "" ] && [ "$pathdir" != "." ] && [ "$pathdir" != "/" ] && [ "$pathdir" != "$tree" ]; do
     pathdir=$(dirname "$pathdir")
   done


### PR DESCRIPTION
Avoids obliteration of $path [set earlier by Prezto/zsh](https://github.com/sorin-ionescu/prezto/blob/master/runcoms/zprofile#L45). Stomping on $path causes dirname to not be in the PATH resulting in an error.
