### PR TITLE
Suppress error message when node is not in path

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -161,7 +161,7 @@ nvm_binary_available() {
 
 nvm_ls_current() {
   local NODE_PATH
-  NODE_PATH="$(which node)"
+  NODE_PATH="$(which node 2>/dev/null)"
   if [ $? -ne 0 ]; then
     echo 'none'
   elif nvm_tree_contains_path "$NVM_DIR" "$NODE_PATH"; then


### PR DESCRIPTION
When nvm.sh is sourced in bashrc or zshrc, and if node is not
found in the path, an error message is shown since which node
fails. The patch suppresses this error message.
