### PR TITLE
Should escape grep in copy-packages.

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -748,7 +748,7 @@ nvm() {
 
       # declare local INSTALLS first, otherwise it doesn't work in zsh
       local INSTALLS
-      INSTALLS=$(nvm use $VERSION > /dev/null && npm list --global --parseable --depth=0 2> /dev/null | tail -n +2 | grep -o -e '/[^/]*$' | cut -c 2- | xargs)
+      INSTALLS=$(nvm use $VERSION > /dev/null && npm list --global --parseable --depth=0 2> /dev/null | tail -n +2 | \grep -o -e '/[^/]*$' | cut -c 2- | xargs)
 
       npm install -g --quiet $INSTALLS
     ;;


### PR DESCRIPTION
Seems this is the last on the non-escaped "grep" command left. 

Since it seems I am the only one running grep with crazy defaults and test run in isolated environments I don't think this should have anything but a positive effect. 
