### PR TITLE
Fixed `nvm_version_greater` has syntax error in zsh-builtin command `[`

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -100,7 +100,7 @@ nvm_version_greater() {
   LHS=$(echo "$1" | awk -F. '{for (i=1;i<=NF;++i) printf "%010d",$i}')
   local RHS
   RHS=$(echo "$2" | awk -F. '{for (i=1;i<=NF;++i) printf "%010d",$i}')
-  [ $LHS \> $RHS ];
+  [ $LHS -gt $RHS ];
 }
 
 nvm_version_dir() {


### PR DESCRIPTION
The following error now occurs when you load a nvm.sh in zsh-5.0.5. 

```
nvm_version_greater: 5: condition expected:> 
```

Cause Because zsh-built-in `[` can not understand the operator ">".
I have to fix the above error so that it does not appear to fix the -gt operators in this pull-reqest.
