### PR TITLE
Fix for nvm not being sourced to bash when using gnome-terminal in Ubuntu 14.04

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -111,7 +111,7 @@ SOURCE_STR="\nexport NVM_DIR=\"$NVM_DIR\"\n[ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$
 
 if [ -z "$PROFILE" ] || [ ! -f "$PROFILE" ] ; then
   if [ -z "$PROFILE" ]; then
-    echo "=> Profile not found. Tried ~/.bash_profile, ~/.zshrc, and ~/.profile."
+    echo "=> Profile not found. Tried ~/.bash_profile, ~/bashrc, ~/.zshrc, and ~/.profile."
     echo "=> Create one of them and run this script again"
   else
     echo "=> Profile $PROFILE not found"


### PR DESCRIPTION
I just checked out the latest version of nvm using the install script but I see it only adds the source line to bash_profile which in ubuntu is not created by default, and to .profile which is only used for login shells. Adding this extra check before .profile will add it to .bashrc which is executed for shells run by terminal emulators like gnome-terminal.
