### PR TITLE
Hide Error message when manpath is not installed

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -696,7 +696,7 @@ nvm() {
       # Prepend current version
       PATH=`nvm_prepend_path "$PATH" "$NVM_VERSION_DIR/bin"`
       if [ -z "$MANPATH" ]; then
-        MANPATH=$(manpath)
+        MANPATH=$(manpath 2> /dev/null)
       fi
       # Strip other version from MANPATH
       MANPATH=`nvm_strip_path "$MANPATH" "/share/man"`


### PR DESCRIPTION
Not all systems have a manpath executable installed.

Therefore this patch hides the error messages when manpath failed.
