### PR TITLE
Makefile enhanced to error out with instructions if invoked without a target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test/bak
 .urchin_stdout
 
 node_modules/
+npm-debug.log
 
 .DS_Store
 current

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - '[ -z "$WITHOUT_CURL" ] || wget -O /tmp/urchin https://raw.githubusercontent.com/scraperwiki/urchin/master/urchin'
   - chmod +x /tmp/urchin
 script:
-  - NVM_DIR=$TRAVIS_BUILD_DIR make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin $SHELL
+  - NVM_DIR=$TRAVIS_BUILD_DIR make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin test-$SHELL
 env:
   - SHELL=sh TEST_SUITE=install_script
   - SHELL=dash TEST_SUITE=install_script

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,72 @@
-URCHIN=`which urchin`
-SHELLS=sh bash dash ksh zsh
-TEST_SUITE=fast
+	# Note: With Travis CI:
+	#  - the path to urchin is passed via the command line.
+	#  - the other utilties are NOT needed, so we skip the test for their existence.
+URCHIN := urchin
+ifeq ($(findstring /,$(URCHIN)),) # urchin path was NOT passed in.
+		# Add the local npm packages' bin folder to the PATH, so that `make` can find them, when invoked directly.
+	export PATH := $(shell printf '%s' "$$(npm bin):$$PATH")
+		# The list of all supporting utilities, installed with `npm install`.
+	UTILS := $(URCHIN) replace semver
+		# Make sure that all required utilities can be located.
+	UTIL_CHECK := $(or $(shell PATH="$(PATH)" which $(UTILS) >/dev/null && echo 'ok'),$(error Did you forget to run `npm install` after cloning the repo? At least one of the required supporting utilities not found: $(UTILS)))
+endif
+	# The files that need updating when incrementing the version number.
+VERSIONED_FILES := nvm.sh install.sh README.markdown package.json
+	# Define all shells to test with. Can be overridden with `make SHELLS=... <target>`.
+SHELLS := sh bash dash ksh zsh
+	# Generate 'test-<shell>' target names from specified shells.
+	# The embedded shell names are extracted on demand inside the recipes.
+SHELL_TARGETS := $(addprefix test-,$(SHELLS))
+	# Define the default test suite(s). This can be overridden with `make TEST_SUITE=<...>  <target>`.
+	# Test suites are the names of subfolders of './test'.
+TEST_SUITE := $(shell find ./test -type d -mindepth 1 -maxdepth 1 -exec basename {} +)
 
-.PHONY: $(SHELLS) test verify-tag release
+# Default target (by virtue of being the first non '.'-prefixed in the file).
+.PHONY: _no-target-specified
+_no-target-specified:
+	$(error Please specify the target to make - `make list` shows targets. Alternatively, use `npm test` to run the default tests; `npm run` shows all tests)
 
-$(SHELLS):
-	@printf '\n\033[0;34m%s\033[0m\n' "Running tests in $@"
-	@$@ $(URCHIN) -f test/$(TEST_SUITE)
+# Lists all targets defined in this makefile.
+.PHONY: list
+list:
+	@$(MAKE) -pRrn : -f $(MAKEFILE_LIST) 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | sort
 
-test: $(SHELLS)
-	@$(URCHIN) -f test/slow
+# Set of test-<shell> targets; each runs the specified test suites for a single shell.
+# Note that preexisting NVM_* variables are unset to avoid interfering with tests, except when running the Travis tests (where NVM_DIR must be passed in and the env. is assumed to be pristine).
+.PHONY: $(SHELL_TARGETS)
+$(SHELL_TARGETS):
+	@shell='$@'; shell=$${shell##*-}; which "$$shell" >/dev/null || { printf '\033[0;31m%s\033[0m\n' "WARNING: Cannot test with shell '$$shell': not found." >&2; exit 0; } && \
+	 printf '\n\033[0;34m%s\033[0m\n' "Running tests in $$shell"; \
+	 [ -z "$$TRAVIS_BUILD_DIR" ] && for v in $$(export -p | awk -F'[ =]' '$$2 ~ "^NVM_" { print $$2 }'); do unset $$v; done && unset v; \
+	 for suite in $(TEST_SUITE); do $$shell $(URCHIN) -f test/$$suite || exit; done
 
-default: test
+# All-tests target: invokes the specified test suites for ALL shells defined in $(SHELLS).
+.PHONY: test
+test: $(SHELL_TARGETS)
 
-verify-tag:
+.PHONY: _ensure-tag
+_ensure-tag:
 ifndef TAG
-	$(error TAG is undefined)
+	$(error Please invoke with `make TAG=<new-version> release`, where <new-version> is either an increment specifier (patch, minor, major, prepatch, preminor, premajor, prerelease), or an explicit major.minor.patch version number)
 endif
 
-release: verify-tag
-	@ OLD_TAG=`git describe --abbrev=0 --tags` && \
-		replace "$${OLD_TAG/v/}" "$(TAG)" -- nvm.sh install.sh README.markdown package.json && \
-		git commit -m "v$(TAG)" nvm.sh install.sh README.markdown package.json && \
-		git tag "v$(TAG)"
+# Ensures that the git workspace is clean.
+.PHONY: _ensure-clean
+_ensure-clean:
+	@[ -z "$$(git status --porcelain --untracked-files=no || echo err)" ] || { echo "Workspace is not clean; please commit changes first." >&2; exit 2; }
 
+# Makes a release; invoke with `make TAG=<versionOrIncrementSpec> release`.
+.PHONY: release
+release: _ensure-tag _ensure-clean
+	@old_ver=`git describe --abbrev=0 --tags --match 'v[0-9]*.[0-9]*.[0-9]*'` || { echo "Failed to determine current version." >&2; exit 1; }; old_ver=$${old_ver#v}; \
+	 new_ver=`echo "$(TAG)" | sed 's/^v//'`; new_ver=$${new_ver:-patch}; \
+	 if printf "$$new_ver" | grep -q '^[0-9]'; then \
+	   semver "$$new_ver" >/dev/null || { echo 'Invalid version number specified: $(TAG) - must be major.minor.patch' >&2; exit 2; }; \
+	   semver -r "> $$old_ver" "$$new_ver" >/dev/null || { echo 'Invalid version number specified: $(TAG) - must be HIGHER than current one.' >&2; exit 2; } \
+	 else \
+	   new_ver=`semver -i "$$new_ver" "$$old_ver"` || { echo 'Invalid version-increment specifier: $(TAG)' >&2; exit 2; } \
+	 fi; \
+	 printf "=== Bumping version **$$old_ver** to **$$new_ver** before committing and tagging:\n=== TYPE 'proceed' TO PROCEED, anything else to abort: " && read response && [ "$$response" = 'proceed' ] || { echo 'Aborted.' >&2; exit 2; };  \
+	 replace "$$old_ver" "$$new_ver" -- $(VERSIONED_FILES) && \
+	 git commit -m "v$$new_ver" $(VERSIONED_FILES) && \
+	 git tag -a -m "v$$new_ver" "v$$new_ver"

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "test": "test"
   },
   "scripts": {
-    "test": "urchin test",
-    "test/fast": "urchin -f test/fast",
-    "test/slow": "urchin -f test/slow",
-    "test/install_script": "urchin -f test/install_script",
-    "test/installation": "urchin -f test/installation",
-    "test/sourcing": "urchin -f test/sourcing"
+    "test": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make test-$shell",
+    "test/fast": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=fast test-$shell",
+    "test/slow": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=slow test-$shell",
+    "test/install_script": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=install_script test-$shell",
+    "test/installation": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=installation test-$shell",
+    "test/sourcing": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=sourcing test-$shell"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,8 @@
   },
   "homepage": "https://github.com/creationix/nvm",
   "devDependencies": {
+    "replace": "~0.3.0",
+    "semver": "~4.1.0",
     "urchin": "~0.0.2"
   }
 }
-


### PR DESCRIPTION
`Makefile` enhanced to install required test utility `urchin` on demand locally, via `npm install`. The shell command that locates the urchin executable was amended to also find a locally installed version, not just a global one as before.

Note that invoking just `make` (without a goal) currently (still) only runs the `sh` test (at least on my OS X 10.9.5 machine). Is that the intent?
