### PR TITLE
Fixed links

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,8 +5,8 @@
 First you'll need to make sure your system has a c++ compiler. For OSX, XCode will work, for Ubuntu, the build-essential and libssl-dev packages work.
 
 Note: `nvm` does not support Windows (see [#284](https://github.com/creationix/nvm/issues/284)). Two alternatives exist, which are not supported nor developed by us:
- - [nvmw](hakobera/nvmw)
- - [nvm-windows](coreybutler/nvm-windows)
+ - [nvmw](http://github.com/hakobera/nvmw)
+ - [nvm-windows](http://github.com/coreybutler/nvm-windows)
 
 ### Install script
 


### PR DESCRIPTION
The links were relative to github.com/creationix/nvm/master instead of the intended sites.
