### PR TITLE
Installs Node.js and ends the setup process automatically

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,8 +42,8 @@ or Wget:
 
 <sub>The script clones the nvm repository to `~/.nvm` and adds the source line to your profile (`~/.bash_profile`, `~/.zshrc`, `~/.profile`, or `~/.bashrc`).</sub>
 
-You can customize the install source, directory and profile using the `NVM_SOURCE`, `NVM_DIR`, and `PROFILE` variables.
-Eg: `curl ... | NVM_DIR="path/to/nvm" bash`
+You can customize the install source, directory, profile, and version using the `NVM_SOURCE`, `NVM_DIR`, `PROFILE`, and `NODE_VERSION` variables.
+Eg: `curl ... | NVM_DIR=/usr/local/nvm bash` for a global install.
 
 <sub>*NB. The installer can use `git`, `curl`, or `wget` to download `nvm`, whatever is available.*</sub>
 

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,13 @@ nvm_source() {
   echo "$NVM_SOURCE_URL"
 }
 
+# 
+# Node.js version to install
+#
+nvm_node_version() {
+  echo "$NODE_VERSION"
+}
+
 nvm_download() {
   if nvm_has "curl"; then
     curl -q $*
@@ -82,6 +89,30 @@ install_nvm_from_git() {
     fi
   fi
   return
+}
+
+#
+# Automatically install Node.js
+#
+nvm_install_node() {
+  local NODE_VERSION
+  NODE_VERSION="$(nvm_node_version)"
+
+  if [ -z "$NODE_VERSION" ]; then
+    echo "=> You can now install Node.js by running \`nvm install\`"
+    return 0
+  fi
+
+  echo "=> Installing Node.js version $NODE_VERSION"
+  nvm install "$NODE_VERSION"
+  local CURRENT_NVM_NODE
+
+  CURRENT_NVM_NODE="$(nvm_version current)"
+  if [ "$(nvm_version "$NODE_VERSION")" == "$CURRENT_NVM_NODE" ]; then
+    echo "=> Node.js version $NODE_VERSION has been successfully installed"
+  else
+    echo >&2 "Failed to install Node.js $NODE_VERSION"
+  fi
 }
 
 install_nvm_as_script() {
@@ -255,9 +286,13 @@ nvm_do_install() {
     fi
   fi
 
+  # Sourcing $PROFILE to take into account the new environment
+  . "$NVM_PROFILE"
+
   nvm_check_global_modules
 
-  echo "=> Close and reopen your terminal to start using nvm"
+  nvm_install_node
+
   nvm_reset
 }
 
@@ -269,7 +304,7 @@ nvm_reset() {
   unset -f nvm_reset nvm_has nvm_latest_version \
     nvm_source nvm_download install_nvm_as_script install_nvm_from_git \
     nvm_detect_profile nvm_check_global_modules nvm_do_install \
-    nvm_install_dir
+    nvm_install_dir nvm_node_version nvm_install_node
 }
 
 [ "_$NVM_ENV" = "_testing" ] || nvm_do_install


### PR DESCRIPTION
Many people around me don't read enough of the README and expect Node.js to be installed after running the install script.

Based on a Gist I've written for my coworkers (https://gist.github.com/xcambar/2f88b912b7d40fe605c5), we thought it could be beneficial to NVM that the install script actually installs Node.js.

This is what this PR does, with a configurable Node.js version (defaulting to `stable`).
