### PR TITLE
use `command -p pwd` to use the system default pwd

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -43,7 +43,7 @@ if [ -z "$NVM_DIR" ]; then
   if [ -n "$BASH_SOURCE" ]; then
     NVM_SCRIPT_SOURCE="${BASH_SOURCE[0]}"
   fi
-  export NVM_DIR=$(cd $NVM_CD_FLAGS $(dirname "${NVM_SCRIPT_SOURCE:-$0}") > /dev/null && command -p pwd)
+  export NVM_DIR=$(cd $NVM_CD_FLAGS $(dirname "${NVM_SCRIPT_SOURCE:-$0}") > /dev/null && \pwd)
 fi
 unset NVM_SCRIPT_SOURCE 2> /dev/null
 


### PR DESCRIPTION
`command -p pwd` overrides any aliases a user might have set for `pwd`. In my case, I aliased `pwd` to copy the current directory to the clipboard. While this is an edge case, using `command -p pwd` would ensure aliases are ignored, without having to specify a path.
