### PR TITLE
"Latest" branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,8 @@ release: verify-tag
 	@ OLD_TAG=`git describe --abbrev=0 --tags` && \
 		replace "$${OLD_TAG/v/}" "$(TAG)" -- nvm.sh install.sh README.markdown package.json && \
 		git commit -m "v$(TAG)" nvm.sh install.sh README.markdown package.json && \
-		git tag "v$(TAG)"
+		git tag "v$(TAG)" && \
+		git checkout latest && \
+		git reset --hard && \
+		git merge "v$(TAG)"
 

--- a/README.markdown
+++ b/README.markdown
@@ -12,11 +12,11 @@ Note: `nvm` does not support Windows (see [#284](https://github.com/creationix/n
 
 To install you could use the [install script][2] using cURL:
 
-    curl https://raw.githubusercontent.com/creationix/nvm/v0.17.3/install.sh | bash
+    curl https://raw.githubusercontent.com/creationix/nvm/latest/install.sh | bash
 
 or Wget:
 
-    wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.17.3/install.sh | bash
+    wget -qO- https://raw.githubusercontent.com/creationix/nvm/latest/install.sh | bash
 
 <sub>The script clones the nvm repository to `~/.nvm` and adds the source line to your profile (`~/.bash_profile`, `~/.zshrc` or `~/.profile`).</sub>
 
@@ -186,7 +186,7 @@ After the v0.8.6 release of node, nvm tries to install from binary packages. But
     nvm install -s 0.8.6
 
 [1]: https://github.com/creationix/nvm.git
-[2]: https://github.com/creationix/nvm/blob/v0.17.3/install.sh
+[2]: https://github.com/creationix/nvm/blob/latest/install.sh
 [3]: https://travis-ci.org/creationix/nvm
 [Urchin]: https://github.com/scraperwiki/urchin
 

--- a/install.sh
+++ b/install.sh
@@ -44,13 +44,13 @@ install_nvm_from_git() {
     mkdir -p "$NVM_DIR"
     git clone "$NVM_SOURCE" "$NVM_DIR"
   fi
-  cd "$NVM_DIR" && git checkout v0.17.3 && git branch -D master >/dev/null 2>&1
+  cd "$NVM_DIR" && git checkout latest && git branch -D master >/dev/null 2>&1
   return
 }
 
 install_nvm_as_script() {
   if [ -z "$NVM_SOURCE" ]; then
-    NVM_SOURCE="https://raw.githubusercontent.com/creationix/nvm/v0.17.3/nvm.sh"
+    NVM_SOURCE="https://raw.githubusercontent.com/creationix/nvm/latest/nvm.sh"
   fi
 
   # Downloading to $NVM_DIR


### PR DESCRIPTION
This proposes using a "latest" branch, instead of the latest version number for the install script. IE: 

```
curl https://raw.githubusercontent.com/creationix/nvm/latest/install.sh | bash
```

It updates the build tool to merge the most recent tag into the "latest" branch as part of the `make release` process. Internally, the version numbers still operate as before.
