### PR TITLE
add nvm script for use by other shells

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -109,7 +109,7 @@ Add `<prefix>/bin` and `<prefix>/current/bin` to your PATH and use nvm transpara
 
 Where nvm is installed at `~/.nvm`
 
-    set -x fish_user_paths $PATH $HOME/.nvm/current/bin $HOME/.nvm/bin
+    set -x fish_user_paths $PATH $NVM_DIR/current/bin $NVM_DIR/bin
 
 ## License
 

--- a/bin/nvm
+++ b/bin/nvm
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# For non bash-shells (fish, etc)
-# add <prefix>/nvm/bin and <prefix>/nvm/current/bin to PATH
-
 export NVM_SYMLINK_CURRENT=true
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
- adds `bin/nvm` for use as a script by any shell
- updates documentation on how to use script
