### PR TITLE
Fix which to use conventional direct path to program

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -982,7 +982,7 @@ nvm() {
         echo "$VERSION version is not installed yet" >&2
         return 1
       fi
-      echo $(nvm use "$VERSION" >/dev/null 2>&1 && which node)
+      echo $NVM_DIR/$VERSION/bin/node
     ;;
     "alias" )
       mkdir -p "$NVM_DIR/alias"

--- a/test/fast/Listing paths/Running "nvm which 0.0.2" should display only version 0.0.2.
+++ b/test/fast/Listing paths/Running "nvm which 0.0.2" should display only version 0.0.2.
@@ -9,12 +9,13 @@ die () { echo $@ ; exit 1; }
 
 # The result should contain only the appropriate version numbers.
 
-nvm which 0.0.2 | grep "$NVM_DIR/v0.0.2/bin" > /dev/null
+nvm which 0.0.2
+nvm which 0.0.2 | grep "$NVM_DIR/v0.0.2/bin/node" > /dev/null
 if [ $? -ne 0 ]; then
   die '"nvm which 0.0.2" did not contain the correct path'
 fi
 
-nvm which 0.0.20 | grep "$NVM_DIR/v0.0.20/bin" > /dev/null
+nvm which 0.0.20 | grep "$NVM_DIR/v0.0.20/bin/node" > /dev/null
 if [ $? -ne 0 ]; then
   die '"nvm which 0.0.2" did not contain the correct path'
 fi


### PR DESCRIPTION
Also fixes `nvm which system`  so it doesn't echo anything extra.
