### PR TITLE
Support `--install` option on sourcing `nvm.sh`

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1102,7 +1102,7 @@ nvm() {
       echo "0.21.0"
     ;;
     "unload" )
-      unset -f nvm nvm_print_versions nvm_checksum nvm_ls_remote nvm_ls nvm_remote_version nvm_version nvm_rc_version nvm_version_greater nvm_version_greater_than_or_equal_to > /dev/null 2>&1
+      unset -f nvm nvm_print_versions nvm_checksum nvm_ls_remote nvm_ls nvm_remote_version nvm_version nvm_rc_version nvm_version_greater nvm_version_greater_than_or_equal_to nvm_supports_source_options > /dev/null 2>&1
       unset RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_DIR NVM_CD_FLAGS > /dev/null 2>&1
     ;;
     * )
@@ -1111,7 +1111,11 @@ nvm() {
   esac
 }
 
-if [ "_$1" = "_--install" ]; then
+nvm_supports_source_options() {
+  [ "_$(echo 'echo $1' | . /dev/stdin yes)" = "_yes" ]
+}
+
+if nvm_supports_source_options && [ "_$1" = "_--install" ]; then
   VERSION="$(nvm_alias default 2>/dev/null)"
   if [ -n "$VERSION" ]; then
     nvm install "$VERSION" >/dev/null

--- a/test/sourcing/Sourcing nvm.sh with --install and .nvmrc should install it
+++ b/test/sourcing/Sourcing nvm.sh with --install and .nvmrc should install it
@@ -1,6 +1,14 @@
 #!/bin/sh
 
 die () { echo $@ ; exit 1; }
+supports_source_options () {
+  [ "_$(echo 'echo $1' | . /dev/stdin yes)" = "_yes" ]
+}
+
+if ! supports_source_options; then
+  echo 'this shell does not support passing options on sourcing'
+  exit 0;
+fi
 
 echo '0.10.2' > ../../.nvmrc || die 'creation of .nvmrc failed'
 

--- a/test/sourcing/Sourcing nvm.sh with --install should install the default
+++ b/test/sourcing/Sourcing nvm.sh with --install should install the default
@@ -1,6 +1,14 @@
 #!/bin/sh
 
 die () { echo $@ ; exit 1; }
+supports_source_options () {
+  [ "_$(echo 'echo $1' | . /dev/stdin yes)" = "_yes" ]
+}
+
+if ! supports_source_options; then
+  echo 'this shell does not support passing options on sourcing'
+  exit 0;
+fi
 
 echo '0.10.2' > ../../alias/default || die 'creation of default alias failed'
 


### PR DESCRIPTION
Fixes #545.

Note that per http://unix.stackexchange.com/questions/5024/passing-a-variable-to-a-bash-script-when-sourcing-it-in-another-bash-script , `dash` and `sh` (and possibly other shells) do not support passing arguments to a script when sourcing - the `nvm_supports_source_options` method determines support for this, and the same method is used to bail out of the tests so that they don't fail on `dash` and `sh`. Yay for progressive enhancement :-)
