### PR TITLE
Set NVM_DIR to real path to avoid symlink issues in #617

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -461,6 +461,29 @@ else
 fi
 unset NVM_SCRIPT_SOURCE 2>/dev/null
 
+# Convert NVM_DIR to actual path if symlinked
+export NVM_DIR=$(nvm_real_dir "${NVM_DIR}")
+
+nvm_real_dir() {
+  local NVM_DIR_INPUT
+  NVM_DIR_INPUT="${1}"
+
+  if [ -z "${NVM_DIR_INPUT}" ]; then
+    nvm_err '$NVM_DIR cannot be empty'
+    return 2
+  fi
+
+  local NVM_REAL_DIR
+  NVM_REAL_DIR=$(command cd "${NVM_DIR_INPUT}" && command pwd -P)
+
+  if [ -z "${NVM_REAL_DIR}" ] || [ ! -d "${NVM_REAL_DIR}" ]; then
+    nvm_err "NVM_DIR is not a valid path"
+    return 2
+  fi
+
+  nvm_echo "${NVM_REAL_DIR}"
+}
+
 nvm_tree_contains_path() {
   local tree
   tree="${1-}"


### PR DESCRIPTION
Proposed solution for #617 

This pull request modifies NVM_DIR early in nvm.sh to point to the actual target of the symlink if the path is a symlink.

This way we don't have to worry about nvm actually working on a symlinked path. Is there a downside to this?

I commented a solution I am using on #855, but it used readlink which is non-Posix. The following is the alternative using `pwd -P` in the same way that this pull request does.

```
export NVM_DIR=$(cd ~/.nvm && pwd -P)
[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
```
