### PR TITLE
`npm` produces escape sequences that `nvm` should filter out when not a tty

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -126,11 +126,7 @@ nvm_detect_profile() {
   SHELLTYPE="$(basename "/$SHELL")"
 
   if [ "$SHELLTYPE" = "bash" ]; then
-    if [ -f "$HOME/.bashrc" ]; then
-      DETECTED_PROFILE="$HOME/.bashrc"
-    elif [ -f "$HOME/.bash_profile" ]; then
-      DETECTED_PROFILE="$HOME/.bash_profile"
-    fi
+    DETECTED_PROFILE="$HOME/.bash_profile"
   elif [ "$SHELLTYPE" = "zsh" ]; then
     DETECTED_PROFILE="$HOME/.zshrc"
   fi
@@ -138,8 +134,6 @@ nvm_detect_profile() {
   if [ -z "$DETECTED_PROFILE" ]; then
     if [ -f "$HOME/.profile" ]; then
       DETECTED_PROFILE="$HOME/.profile"
-    elif [ -f "$HOME/.bashrc" ]; then
-      DETECTED_PROFILE="$HOME/.bashrc"
     elif [ -f "$HOME/.bash_profile" ]; then
       DETECTED_PROFILE="$HOME/.bash_profile"
     elif [ -f "$HOME/.zshrc" ]; then
@@ -229,7 +223,7 @@ nvm_do_install() {
   local NVM_PROFILE
   NVM_PROFILE=$(nvm_detect_profile)
 
-  SOURCE_STR="\nexport NVM_DIR=\"$NVM_DIR\"\n[ -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\"  # This loads nvm"
+  SOURCE_STR="\nexport NVM_DIR=\"$NVM_DIR\"\n[ \"\$PS1\" -s \"\$NVM_DIR/nvm.sh\" ] && . \"\$NVM_DIR/nvm.sh\"  # This loads nvm"
 
   if [ -z "$NVM_PROFILE" ] ; then
     echo "=> Profile not found. Tried $NVM_PROFILE (as defined in \$PROFILE), ~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile."


### PR DESCRIPTION
i.e.  avoid using it on non-interactive or non-login shells

There is a big problem with the usage of `.bashrc` for outputing escape sequences (as-is), because it can corrupt the communication of other tools that are doing non-login SSH sessions (yes, some even use an interactive shell for non-interactive use). One of such problems we have with Ansible (see ansible/ansible#14282), but the same could happen to other tools.

So my prefered solution is to avoid using `.bashrc` to ensure we have a login-shell. But you may also want to ensure that you have an interactive shell before appending your own stuff. So I added that snippet as well. I am not sure if this would work on all distributions, so please test !

References:
https://www.gnu.org/software/bash/manual/html_node/Is-this-Shell-Interactive_003f.html
http://superuser.com/questions/183870/difference-between-bashrc-and-bash-profile
