### PR TITLE
Add info on how to enable version auto switching using .bashrc file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -210,7 +210,7 @@ cd() {
 
 Note for [`rvm`](https://github.com/rvm/rvm) users: rvm overrides builtin `cd` function so code should be a bit
 different to make `rvm` and `nvm` work both without conflicts and you should place it after `rvm` sourcing its scripts.
-For example, on Ubuntu it should be placed into `$HOME/.bash_profil`:
+For example, on Ubuntu it should be placed into `$HOME/.bash_profile`:
 
 ```bash
 cd() {

--- a/README.markdown
+++ b/README.markdown
@@ -211,7 +211,7 @@ cd .
 
 Note for [`rvm`](https://github.com/rvm/rvm) users: rvm overrides builtin `cd` function so code should be a bit
 different to make `rvm` and `nvm` work both without conflicts and you should place it after `rvm` sourcing its scripts.
-For example, on Ubuntu it should be placed into `$HOME/.bash_profile`:
+For example, on Ubuntu it should be placed at the very bottom of `$HOME/.bash_profile`:
 
 ```bash
 cd() {

--- a/README.markdown
+++ b/README.markdown
@@ -201,9 +201,9 @@ Put this into your `$HOME/.bashrc` to enable automatic version swithing whenever
 cd() {
   builtin cd "$@"
   if [[ -f .nvmrc && -r .nvmrc ]]; then
-    nvm use
+    nvm use --silent
   elif [[ `nvm current` != `nvm version default` ]]; then
-    nvm use default
+    nvm use --silent default
   fi
 }
 cd .
@@ -217,9 +217,9 @@ For example, on Ubuntu it should be placed at the very bottom of `$HOME/.bash_pr
 cd() {
   __zsh_like_cd cd "$@"
   if [[ -f .nvmrc && -r .nvmrc ]]; then
-    nvm use
+    nvm use --silent
   elif [[ `nvm current` != `nvm version default` ]]; then
-    nvm use default
+    nvm use --silent default
   fi
 }
 cd .

--- a/README.markdown
+++ b/README.markdown
@@ -206,6 +206,7 @@ cd() {
     nvm use default
   fi
 }
+cd .
 ```
 
 Note for [`rvm`](https://github.com/rvm/rvm) users: rvm overrides builtin `cd` function so code should be a bit
@@ -221,6 +222,7 @@ cd() {
     nvm use default
   fi
 }
+cd .
 ```
 
 ## License

--- a/README.markdown
+++ b/README.markdown
@@ -192,6 +192,36 @@ load-nvmrc() {
 }
 add-zsh-hook chpwd load-nvmrc
 ```
+##### Automatic version switching for `.bashrc` with fallback to `nvm use default`
+
+Put this into your `$HOME/.bashrc` to enable automatic version swithing whenever you enter a directory than contains an
+`.node-version` file with a string telling nvm which node to `use`:
+
+```bash
+cd() {
+  builtin cd "$@"
+  if [[ -f .node-version && -r .node-version ]]; then
+    nvm use "`cat .node-version`"
+  elif [[ `nvm current` != `nvm version default` ]]; then
+    nvm use default
+  fi
+}
+```
+
+Note for [`rvm`](https://github.com/rvm/rvm) users: rvm overrides builtin `cd` function so code should be a bit
+different to make `rvm` and `nvm` work both without conflicts and you should place it after `rvm` sourcing its scripts.
+For example, on Ubuntu it should be placed into `$HOME/.bash_profil`:
+
+```bash
+cd() {
+  __zsh_like_cd cd "$@"
+  if [[ -f .node-version && -r .node-version ]]; then
+    nvm use "`cat .node-version`"
+  elif [[ `nvm current` != `nvm version default` ]]; then
+    nvm use default
+  fi
+}
+```
 
 ## License
 

--- a/README.markdown
+++ b/README.markdown
@@ -195,13 +195,13 @@ add-zsh-hook chpwd load-nvmrc
 ##### Automatic version switching for `.bashrc` with fallback to `nvm use default`
 
 Put this into your `$HOME/.bashrc` to enable automatic version swithing whenever you enter a directory than contains an
-`.node-version` file with a string telling nvm which node to `use`:
+`.nvmrc` file with a string telling nvm which node to `use`:
 
 ```bash
 cd() {
   builtin cd "$@"
-  if [[ -f .node-version && -r .node-version ]]; then
-    nvm use "`cat .node-version`"
+  if [[ -f .nvmrc && -r .nvmrc ]]; then
+    nvm use
   elif [[ `nvm current` != `nvm version default` ]]; then
     nvm use default
   fi
@@ -216,8 +216,8 @@ For example, on Ubuntu it should be placed into `$HOME/.bash_profile`:
 ```bash
 cd() {
   __zsh_like_cd cd "$@"
-  if [[ -f .node-version && -r .node-version ]]; then
-    nvm use "`cat .node-version`"
+  if [[ -f .nvmrc && -r .nvmrc ]]; then
+    nvm use
   elif [[ `nvm current` != `nvm version default` ]]; then
     nvm use default
   fi


### PR DESCRIPTION
Add info on how to enable version auto switching using `.bashrc` file when entering directory that contains `.node-version` file and fallback to default version on entering directory that doesn't contain `.node-version` file
