### PR TITLE
[Fix] make `nvm use` display `.nvmrc`'s version in output messages

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -253,6 +253,11 @@ nvm_ensure_version_installed() {
   LOCAL_VERSION="$(nvm_version "$PROVIDED_VERSION")"
   EXIT_CODE="$?"
   local NVM_VERSION_DIR
+
+  if [ "_$PROVIDED_VERSION" = "_N/A" ] && [ ! -d "$NVM_RC_VERSION" ] ; then
+    PROVIDED_VERSION="$(nvm_ensure_version_prefix "$NVM_RC_VERSION")"
+  fi
+
   if [ "_$EXIT_CODE" != "_0" ] || ! nvm_is_version_installed "$LOCAL_VERSION"; then
     VERSION="$(nvm_resolve_alias "$PROVIDED_VERSION")"
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
Set `$PROVIDED_VERSION` **equals** to `$NVM_RC_VERSION` only if a `.nvmrc` **file is
present** and the **user didn't provided a version to use** (.ie typed `nvm
use`).
- Behavior before this fix :

```
$ nvm use
Found '.nvmrc' with version <v0.10.28>
N/A: version "N/A" is not yet installed.

You need to run "nvm install N/A" to install it before using it.
```
- Behavior after this fix :

```
$ nvm use
Found '.nvmrc' with version <v0.10.28>
N/A: version "v0.10.28" is not yet installed.

You need to run "nvm install v0.10.28" to install it before using it.
```
