### PR TITLE
[Tests] add tests for "make 'nvm use' display '.nvmrc' version" 

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -486,6 +486,11 @@ nvm_ensure_version_installed() {
   LOCAL_VERSION="$(nvm_version "${PROVIDED_VERSION}")"
   EXIT_CODE="$?"
   local NVM_VERSION_DIR
+
+  if [ "_$PROVIDED_VERSION" = "_N/A" ] && [ ! -d "$NVM_RC_VERSION" ] ; then
+    PROVIDED_VERSION="$(nvm_ensure_version_prefix "$NVM_RC_VERSION")"
+  fi
+
   if [ "${EXIT_CODE}" != "0" ] || ! nvm_is_version_installed "${LOCAL_VERSION}"; then
     if VERSION="$(nvm_resolve_alias "${PROVIDED_VERSION}")"; then
       nvm_err "N/A: version \"${PROVIDED_VERSION} -> ${VERSION}\" is not yet installed."

--- a/test/slow/nvm use/Running 'nvm use' displays .nvmrc version in output messages
+++ b/test/slow/nvm use/Running 'nvm use' displays .nvmrc version in output messages
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo $@ ; exit 1; }
+
+. ../../../nvm.sh
+
+echo "v0.10.28" > .nvmrc
+OUTPUT="$(nvm use 2>&1 >/dev/null | awk 'NR==1')"
+EXPECTED_OUTPUT='N/A: version "v0.10.28" is not yet installed.'
+TESTTT="$(nvm use 2>&1 >/dev/null)"
+TESTT="$(nvm use 2>&1)"
+TEST="$(nvm use)"
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use' did not output: '$EXPECTED_OUTPUT'; got: '$OUTPUT'; Normal: $TEST; with 2>&1: $TESTT; with /null: $TESTTT"
+
+OUTPUT="$(nvm use 2>&1 >/dev/null | awk 'NR==3')"
+EXPECTED_OUTPUT='You need to run "nvm install v0.10.28" to install it before using it.'
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use' did not output: '$EXPECTED_OUTPUT'; got: '$OUTPUT'"

--- a/test/slow/nvm use/setup_dir
+++ b/test/slow/nvm use/setup_dir
@@ -19,5 +19,9 @@ for VERSION in "1.0.0" "1.0.1"; do
   nvm install "iojs-v$VERSION"
 done
 
+if [ -f ".nvmrc" ]; then
+  mv .nvmrc .nvmrc.bak
+fi
+
 nvm_make_alias lts/testing 0.10.1
 nvm_make_alias 'lts/*' lts/testing

--- a/test/slow/nvm use/teardown_dir
+++ b/test/slow/nvm use/teardown_dir
@@ -20,3 +20,9 @@ if [ -d "${NVM_DIR}/.nvm_use_lts_alias_bak" ]; then
   mv "${NVM_DIR}/.nvm_use_lts_alias_bak/*" "${NVM_DIR}/alias/lts/"
   rmdir "${NVM_DIR}/.nvm_use_lts_alias_bak"
 fi
+
+rm .nvmrc
+
+if [ -f ".nvmrc.bak" ]; then
+  mv .nvmrc.bak .nvmrc
+fi


### PR DESCRIPTION
Addition of tests was asked by @ljharb for the pull request #1187 started by @anchnk, which was to display the versions of .nvmrc when "nvm use" is called.

This PR is a continuation of #1187 to add tests.

Let me know if anything needs to be changed!

EDIT:   Added .nvmrc setup and cleanup in setup_dir and teardown_dir
EDIT2: Better error message
