### PR TITLE
[WIP][CI] Enable clang v3.8 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
       - gcc-4.8
       - g++-4.8
       - clang-3.8
-      - lldb-3.8
       - stack
       - bc
       - zsh
@@ -24,10 +23,8 @@ before_install:
   - $SHELL --version 2> /dev/null || dpkg -s $SHELL 2> /dev/null || which $SHELL
   - curl --version
   - wget --version
-  - clang --version
-  - clang++ --version
   - if [ -n "${SHELLCHECK-}" ]; then stack setup && stack install ShellCheck && shellcheck --version ; fi
-  - if [ -z "${SHELLCHECK-}" ]; then sudo ln -sf /usr/bin/clang-3.8 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-3.8 /usr/bin/clang++ && clang --version ; fi
+  - mkdir -p $HOME/bin && ln -s /usr/bin/clang-3.8 $HOME/bin/clang && ln -s /usr/bin/clang++-3.8 $HOME/bin/clang++
 install:
   - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
   - chmod +x /tmp/urchin/package/urchin

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ addons:
       - llvm-toolchain-precise
       - llvm-toolchain-precise-3.8
     packages:
-      - gcc-4.8
-      - g++-4.8
       - clang-3.8
       - stack
       - bc
@@ -24,7 +22,7 @@ before_install:
   - curl --version
   - wget --version
   - if [ -n "${SHELLCHECK-}" ]; then stack setup && stack install ShellCheck && shellcheck --version ; fi
-  - mkdir -p $HOME/bin && ln -s /usr/bin/clang-3.8 $HOME/bin/clang && ln -s /usr/bin/clang++-3.8 $HOME/bin/clang++
+  - mkdir -p "$HOME"/bin && ln -s /usr/bin/clang-3.8 "$HOME"/bin/clang && ln -s /usr/bin/clang++-3.8 "$HOME"/bin/clang++
 install:
   - (mkdir /tmp/urchin && cd /tmp/urchin && curl -s "$(curl -s https://registry.npmjs.com/urchin | grep -Eo '"tarball":\s*"[^"]+"' | tail -n 1 | awk -F\" '{ print $4 }')" -O && tar -x -f urchin*)
   - chmod +x /tmp/urchin/package/urchin
@@ -34,8 +32,6 @@ script:
   - if [ -z "${SHELLCHECK-}" ]; then make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL ; fi
 env:
   global:
-    - CXX=g++-4.8
-    - CC=gcc-4.8
     - PATH=$(echo $PATH | sed 's/::/:/')
     - NVM_DIR="${TRAVIS_BUILD_DIR}"
   matrix:


### PR DESCRIPTION
- Clean up clang related codes and config
- Remove lldb-3.8 package since we don't need, though it's on llvm install instructions.
- The origin codes have a bug about the PATH which makes clang would not be detected/used correctly.
- Remove clang version print.
- Remove useless gcc/g++ related packages and variables.