### PR TITLE
Use awk for reliable path stripping

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -698,13 +698,12 @@ nvm_strip_path() {
     nvm_err '${NVM_DIR} not set!'
     return 1
   fi
-  nvm_echo "${1-}" | command sed \
-    -e "s#${NVM_DIR}/[^/]*${2-}[^:]*:##g" \
-    -e "s#:${NVM_DIR}/[^/]*${2-}[^:]*##g" \
-    -e "s#${NVM_DIR}/[^/]*${2-}[^:]*##g" \
-    -e "s#${NVM_DIR}/versions/[^/]*/[^/]*${2-}[^:]*:##g" \
-    -e "s#:${NVM_DIR}/versions/[^/]*/[^/]*${2-}[^:]*##g" \
-    -e "s#${NVM_DIR}/versions/[^/]*/[^/]*${2-}[^:]*##g"
+  command printf %s "${1-}" | command awk -v NVM_DIR="${NVM_DIR}" -v RS=: '
+  index($0, NVM_DIR) == 1 {
+    path = substr($0, length(NVM_DIR) + 1)
+    if (path ~ "^(/versions/[^/]*)?/[^/]*'"${2-}"'.*$") { next }
+  }
+  { print }' | command paste -s -d: -
 }
 
 nvm_change_path() {

--- a/test/fast/Unit tests/nvm_strip_path
+++ b/test/fast/Unit tests/nvm_strip_path
@@ -9,3 +9,10 @@ TEST_PATH=$NVM_DIR/v0.10.5/bin:/usr/bin:$NVM_DIR/v0.11.5/bin:$NVM_DIR/v0.9.5/bin
 STRIPPED_PATH=`nvm_strip_path "$TEST_PATH" "/bin"`
 
 [ "$STRIPPED_PATH" = "/usr/bin:/usr/local/bin" ] || die "Not correctly stripped: $STRIPPED_PATH "
+
+NVM_DIR='/#*.^$[]'
+TEST_PATH="$NVM_DIR/v0.10.5/bin:/usr/bin:$NVM_DIR/v0.11.5/bin:$NVM_DIR/v0.9.5/bin:/usr/local/bin:$NVM_DIR/v0.2.5/bin:$NVM_DIR/versions/node/v0.12.0/bin:$NVM_DIR/versions/io.js/v1.0.0/bin"
+
+STRIPPED_PATH=`nvm_strip_path "$TEST_PATH" "/bin"`
+
+[ "$STRIPPED_PATH" = "/usr/bin:/usr/local/bin" ] || die "Not correctly stripped: $STRIPPED_PATH "


### PR DESCRIPTION
`nvm_strip_path()` will fail if `NVM_DIR` contains meta characters such as `#*.^$[]\`.

```bash
$ NVM_DIR='/#'
$ echo "${NVM_DIR}/1/bin:${NVM_DIR}/2/bin:${NVM_DIR}/3/bin:/usr/bin" | sed \
  -e "s#${NVM_DIR}/[^/]*/bin[^:]*:##g" \
  -e "s#:${NVM_DIR}/[^/]*/bin[^:]*##g" \
  -e "s#${NVM_DIR}/[^/]*/bin[^:]*##g"

sed: 1: "s#/#/[^/]*/bin[^:]*:##g
": bad flag in substitute command: '#'
```

`awk` is capable to solve this problem.

```bash
$ NVM_DIR='/#*.^$[]'
$ printf %s "${NVM_DIR}/1/bin:${NVM_DIR}/2/bin:${NVM_DIR}/3/bin:/usr/bin" |
  awk -v NVM_DIR="${NVM_DIR}" -v RS=: '
  index($0, NVM_DIR) == 1 {
    path = substr($0, length(NVM_DIR) + 1)
    if (path ~ "^/[^/]*'"${2-}"'.*$") { next }
  }
  { print }' | paste -s -d: -

/usr/bin
```