### PR TITLE
[Tests] Add markdown-link-check on Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,7 @@ my_alias        default        v10.22.0       v12.18.3      v14.8.0
 
 ## Compatibility Issues
 
-`nvm` will encounter some issues if you have some non-default settings set. (see [#606](/../../issues/606))
+`nvm` will encounter some issues if you have some non-default settings set. (see [#606](https://github.com/creationix/nvm/issues/606))
 The following are known to cause issues:
 
 Inside `~/.npmrc`:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "doctoc:check": "diff -q README.md v-README.md.orig",
     "postdoctoc:check": "mv v-README.md.orig README.md",
     "eclint": "eclint check $(git ls-tree --name-only HEAD | xargs)",
-    "dockerfile_lint": "dockerfile_lint"
+    "dockerfile_lint": "dockerfile_lint",
+    "markdown-link-check": "git ls-files | command grep -E '\\.md$' | xargs -n 1 markdown-link-check -p"
   },
   "repository": {
     "type": "git",
@@ -42,6 +43,7 @@
     "dockerfile_lint": "^0.3.4",
     "doctoc": "^2.0.0",
     "eclint": "^2.8.1",
+    "markdown-link-check": "^3.1.4",
     "replace": "^1.2.1",
     "semver": "^7.3.5",
     "urchin": "^0.0.5"


### PR DESCRIPTION
This test use the npm package: markdown-link-check to help check if all the links in the documentation is alive.

Since markdown-link-check hasn't support relative links, to make the test passed, move this link to use absolute URL so that we can introduce the new test. cc tcort/markdown-link-check#10

