### PR TITLE
add yarn to nvm_print_npm_version

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -136,6 +136,9 @@ nvm_print_npm_version() {
   if nvm_has "npm"; then
     command printf " (npm v$(npm --version 2>/dev/null))"
   fi
+  if nvm_has "yarn"; then
+    command printf " (yarn v$(yarn --version 2>/dev/null))"
+  fi
 }
 
 nvm_install_latest_npm() {

--- a/test/fast/Unit tests/nvm_print_npm_version
+++ b/test/fast/Unit tests/nvm_print_npm_version
@@ -21,8 +21,16 @@ npm() {
     echo "error"
   fi
 }
+yarn() {
+  if [ "_$@" = "_--version" ]; then
+    echo "1.2.3"
+  else
+    echo "error"
+  fi
+}
+
 OUTPUT="$(nvm_print_npm_version)"
-EXPECTED_OUTPUT=" (npm v1.2.3)"
+EXPECTED_OUTPUT=" (npm v1.2.3) (yarn v1.2.3)"
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_print_npm_version did not provided '$EXPECTED_OUTPUT', got '$OUTPUT'"
 
 cleanup


### PR DESCRIPTION
Prints yarn version when using `npm use`.

For example:
```
$ nvm use default
Now using node v8.9.3 (npm v5.6.0) (yarn v1.3.2)
```