### PR TITLE
chore: improve performance of nvm version command

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -338,16 +338,7 @@ nvm_tree_contains_path() {
     return 2
   fi
 
-  local previous_pathdir
-  previous_pathdir="${node_path}"
-  local pathdir
-  pathdir=$(dirname "${previous_pathdir}")
-  while [ "${pathdir}" != '' ] && [ "${pathdir}" != '.' ] && [ "${pathdir}" != '/' ] &&
-      [ "${pathdir}" != "${tree}" ] && [ "${pathdir}" != "${previous_pathdir}" ]; do
-    previous_pathdir="${pathdir}"
-    pathdir=$(dirname "${previous_pathdir}")
-  done
-  [ "${pathdir}" = "${tree}" ]
+  [ "$tree${node_path#$tree}" = "${node_path}" ]
 }
 
 nvm_find_project_dir() {
@@ -1043,12 +1034,9 @@ nvm_ls_current() {
     nvm_add_iojs_prefix "$(iojs --version 2>/dev/null)"
   elif nvm_tree_contains_path "${NVM_DIR}" "${NVM_LS_CURRENT_NODE_PATH}"; then
     local VERSION
-    VERSION="$(node --version 2>/dev/null)"
-    if [ "${VERSION}" = "v0.6.21-pre" ]; then
-      nvm_echo 'v0.6.21'
-    else
-      nvm_echo "${VERSION}"
-    fi
+    local VERSION_SUFFIX=${NVM_LS_CURRENT_NODE_PATH#$NVM_DIR/versions/node/}
+    VERSION=${VERSION_SUFFIX%/bin/node}
+    nvm_echo "${VERSION}"
   else
     nvm_echo 'system'
   fi


### PR DESCRIPTION
fix #1694

This pull request reduces CPU time from **50ms** to **15ms**.

What was done:

1. ~~I have changed `command printf` on `echo` because `printf` is slower than echo
(printf - 2ms, echo - 0.09ms)~~
https://github.com/creationix/nvm/pull/1695#discussion_r158586266
2. Replace *while* cycle from `nvm_tree_contains_path` on string comparison
(while - 14ms, str comparison - 0.06ms)
3. Changed getting node version in `nvm_ls_current` from `node --version` to getting it from `NVM_LS_CURRENT_NODE_PATH`.
(node --version - 13ms, from string - 0.09ms)

**Before**:
```
v6.8.0
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    2          28.13    14.07   51.58%     28.13    14.07   51.58%  nvm_tree_contains_path
 2)    1          45.82    45.82   84.01%     15.08    15.08   27.65%  nvm_ls_current
 3)    2          54.51    27.26   99.96%      8.61     4.31   15.79%  nvm
 4)    1           2.61     2.61    4.79%      2.61     2.61    4.79%  nvm_echo
 5)    1          45.90    45.90   84.17%      0.08     0.08    0.15%  nvm_version
 6)    1          54.54    54.54  100.00%      0.02     0.02    0.04%  run-test

-----------------------------------------------------------------------------------

 6)    1          54.54    54.54  100.00%      0.02     0.02    0.04%  run-test
       1/2        54.51    54.51   99.96%      4.50     4.50             nvm [3]

-----------------------------------------------------------------------------------

       1/2        54.51    54.51   99.96%      4.50     4.50             run-test [6]
       1/2        50.01    50.01   91.70%      4.11     4.11             nvm [3]
 3)    2          54.51    27.26   99.96%      8.61     4.31   15.79%  nvm
       1/1        45.90    45.90   84.17%      0.08     0.08             nvm_version [5]
       1/2        50.01    50.01   91.70%      4.11     4.11             nvm [3]

-----------------------------------------------------------------------------------

       1/1        45.90    45.90   84.17%      0.08     0.08             nvm [3]
 5)    1          45.90    45.90   84.17%      0.08     0.08    0.15%  nvm_version
       1/1        45.82    45.82   84.01%     15.08    15.08             nvm_ls_current [2]

-----------------------------------------------------------------------------------

       1/1        45.82    45.82   84.01%     15.08    15.08             nvm_version [5]
 2)    1          45.82    45.82   84.01%     15.08    15.08   27.65%  nvm_ls_current
       1/1         2.61     2.61    4.79%      2.61     2.61             nvm_echo [4]
       2/2        28.13    14.07   51.58%     28.13    14.07             nvm_tree_contains_path [1]

-----------------------------------------------------------------------------------

       2/2        28.13    14.07   51.58%     28.13    14.07             nvm_ls_current [2]
 1)    2          28.13    14.07   51.58%     28.13    14.07   51.58%  nvm_tree_contains_path

-----------------------------------------------------------------------------------

       1/1         2.61     2.61    4.79%      2.61     2.61             nvm_ls_current [2]
 4)    1           2.61     2.61    4.79%      2.61     2.61    4.79%  nvm_echo
```

**After**:
```
v6.8.0
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    2          11.88     5.94   99.83%      8.06     4.03   67.76%  nvm
 2)    1           3.75     3.75   31.51%      3.55     3.55   29.82%  nvm_ls_current
 3)    2           0.11     0.06    0.93%      0.11     0.06    0.93%  nvm_tree_contains_path
 4)    1           0.09     0.09    0.76%      0.09     0.09    0.76%  nvm_echo
 5)    1           3.82     3.82   32.06%      0.07     0.07    0.55%  nvm_version
 6)    1          11.90    11.90  100.00%      0.02     0.02    0.17%  run-test

-----------------------------------------------------------------------------------

 6)    1          11.90    11.90  100.00%      0.02     0.02    0.17%  run-test
       1/2        11.88    11.88   99.83%      4.06     4.06             nvm [1]

-----------------------------------------------------------------------------------

       1/2        11.88    11.88   99.83%      4.06     4.06             run-test [6]
       1/2         7.82     7.82   65.74%      4.01     4.01             nvm [1]
 1)    2          11.88     5.94   99.83%      8.06     4.03   67.76%  nvm
       1/1         3.82     3.82   32.06%      0.07     0.07             nvm_version [5]
       1/2         7.82     7.82   65.74%      4.01     4.01             nvm [1]

-----------------------------------------------------------------------------------

       1/1         3.82     3.82   32.06%      0.07     0.07             nvm [1]
 5)    1           3.82     3.82   32.06%      0.07     0.07    0.55%  nvm_version
       1/1         3.75     3.75   31.51%      3.55     3.55             nvm_ls_current [2]

-----------------------------------------------------------------------------------

       1/1         3.75     3.75   31.51%      3.55     3.55             nvm_version [5]
 2)    1           3.75     3.75   31.51%      3.55     3.55   29.82%  nvm_ls_current
       1/1         0.09     0.09    0.76%      0.09     0.09             nvm_echo [4]
       2/2         0.11     0.06    0.93%      0.11     0.06             nvm_tree_contains_path [3]

-----------------------------------------------------------------------------------

       2/2         0.11     0.06    0.93%      0.11     0.06             nvm_ls_current [2]
 3)    2           0.11     0.06    0.93%      0.11     0.06    0.93%  nvm_tree_contains_path

-----------------------------------------------------------------------------------

       1/1         0.09     0.09    0.76%      0.09     0.09             nvm_ls_current [2]
 4)    1           0.09     0.09    0.76%      0.09     0.09    0.76%  nvm_echo
```