### PR TITLE
Add info to restart bash if verification not working in verification section

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ command -v nvm
 
 which should output `nvm` if the installation was successful. Please note that `which nvm` will not work, since `nvm` is a sourced shell function, not an executable binary.
 
+**Note:** On Linux, after running the install script, if you get `nvm: command not found` or see no feedback from your terminal after you type `command -v nvm`, simply close your current terminal, open a new terminal, and try verifying again.
+
 ### Important Notes
 
 If you're running a system without prepackaged binary available, which means you're going to install nodejs or io.js from its source code, you need to make sure your system has a C++ compiler. For OS X, Xcode will work, for Debian/Ubuntu based GNU/Linux, the `build-essential` and `libssl-dev` packages work.


### PR DESCRIPTION
Just added the info to restart the bash terminal if `command -v nvm` does not ouput anything or gives an error after installation. It was mentioned somewhere earlier but when I read it, I just took note of the verification section, not the part before where the info was mentioned.