### PR TITLE
Do not fail .bashrc if nvm is not installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -327,10 +327,10 @@ nvm_do_install() {
   local PROFILE_INSTALL_DIR
   PROFILE_INSTALL_DIR="$(nvm_install_dir | command sed "s:^$HOME:\$HOME:")"
 
-  SOURCE_STR="\\nexport NVM_DIR=\"${PROFILE_INSTALL_DIR}\"\\n[ -s \"\$NVM_DIR/nvm.sh\" ] && \\. \"\$NVM_DIR/nvm.sh\"  # This loads nvm\\n"
+  SOURCE_STR="\\nexport NVM_DIR=\"${PROFILE_INSTALL_DIR}\"\\n[ ! -s \"\$NVM_DIR/nvm.sh\" ] || \\. \"\$NVM_DIR/nvm.sh\"  # This loads nvm\\n"
 
   # shellcheck disable=SC2016
-  COMPLETION_STR='[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion\n'
+  COMPLETION_STR='[ ! -s "$NVM_DIR/bash_completion" ] || \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion\n'
   BASH_OR_ZSH=false
 
   if [ -z "${NVM_PROFILE-}" ] ; then


### PR DESCRIPTION
Currently installing nvm might add something like this into your `.bashrc`:

```
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
```

This will unfortunately cause bash to spawn with a return-code of 1.

My fix will solve this issue and make sure that it will work if those files exist, and that it won't throw an error should they not exist:

```
    [ ! -s ~/.bashrc ] || echo yes; echo $? # file exists, outputs "yes", rc=0
yes
0
    [ ! -s ~/.bashrrc ] || echo yes; echo $? # file does not exist, outputs nothing, rc=0
0
    [ -s ~/.bashrc ] && echo yes; echo $? # file exists, outputs "yes", rc=0
yes
0
    [ -s ~/.bashrrc ] && echo yes; echo $? # file does not exist, outputs nothing, rc=1
1
```
