### PR TITLE
Allow nvm-exec to be linked into individual .nvm directories for system-wide installs with a localized Nodes

### DIFF
--- a/nvm-exec
+++ b/nvm-exec
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 SOURCE=${BASH_SOURCE[0]}
-test -L "$SOURCE" && SOURCE=$(readlink "$SOURCE")
+test -L "$SOURCE" && command cd "$( dirname "$SOURCE" )" && \
+  SOURCE=$(readlink "$SOURCE")
 DIR="$(command cd "$( dirname "$SOURCE" )" && pwd )"
 
 unset NVM_CD_FLAGS

--- a/nvm-exec
+++ b/nvm-exec
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-DIR="$(command cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOURCE=${BASH_SOURCE[0]}
+test -L "$SOURCE" && SOURCE=`readlink "$SOURCE"`
+DIR="$(command cd "$( dirname "$SOURCE" )" && pwd )"
 
 unset NVM_CD_FLAGS
 

--- a/nvm-exec
+++ b/nvm-exec
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SOURCE=${BASH_SOURCE[0]}
-test -L "$SOURCE" && SOURCE=`readlink "$SOURCE"`
+test -L "$SOURCE" && SOURCE=$(readlink "$SOURCE")
 DIR="$(command cd "$( dirname "$SOURCE" )" && pwd )"
 
 unset NVM_CD_FLAGS

--- a/nvm.sh
+++ b/nvm.sh
@@ -3872,7 +3872,7 @@ nvm() {
         fi
       fi
       NVM_EXEC="$NVM_DIR/nvm-exec"
-      test ! -f "$NVM_EXEC" && NVM_EXEC=`dirname ${BASH_SOURCE[0]-}`/nvm-exec
+      test ! -f "$NVM_EXEC" && NVM_EXEC="$(dirname "${BASH_SOURCE[0]-}")/nvm-exec"
       NODE_VERSION="$VERSION" "$NVM_EXEC" "$@"
     ;;
     "ls" | "list")

--- a/nvm.sh
+++ b/nvm.sh
@@ -3871,7 +3871,9 @@ nvm() {
           nvm_echo "Running node ${VERSION}$(nvm use --silent "${VERSION}" && nvm_print_npm_version)"
         fi
       fi
-      NODE_VERSION="${VERSION}" "${NVM_DIR}/nvm-exec" "$@"
+      NVM_EXEC="$NVM_DIR/nvm-exec"
+      test ! -f "$NVM_EXEC" && NVM_EXEC=`dirname ${BASH_SOURCE[0]-}`/nvm-exec
+      NODE_VERSION="$VERSION" "$NVM_EXEC" "$@"
     ;;
     "ls" | "list")
       local PATTERN

--- a/nvm.sh
+++ b/nvm.sh
@@ -2384,12 +2384,12 @@ nvm_extract_tarball() {
 
   if [ "${NVM_OS}" = 'openbsd' ]; then
     if [ "${tar_compression_flag}" = 'J' ]; then
-      command xzcat "${TARBALL}" | "${tar}" -xf - -C "${TMPDIR}" -s '/[^\/]*\///' || return 1
+      command xzcat "${TARBALL}" | "${tar}" --no-same-owner -xf - -C "${TMPDIR}" -s '/[^\/]*\///' || return 1
     else
-      command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" -s '/[^\/]*\///' || return 1
+      command "${tar}" --no-same-owner -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" -s '/[^\/]*\///' || return 1
     fi
   else
-    command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" --strip-components 1 || return 1
+    command "${tar}" --no-same-owner -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" --strip-components 1 || return 1
   fi
 }
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -1122,10 +1122,9 @@ nvm_list_aliases() {
         if [ -n "${LTS_ALIAS}" ]; then
           nvm_echo "${LTS_ALIAS}"
         fi
-      } &
+      }
     done
-    wait
-  ) | command sort
+  )
   return
 }
 

--- a/test/slow/nvm exec/Running "nvm exec --lts" when NVM_DIR differs from nvm
+++ b/test/slow/nvm exec/Running "nvm exec --lts" when NVM_DIR differs from nvm
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; exit 1; }
+
+INSTPATH="$(mktemp -p "$(pwd)" -d)"
+trap 'test ! -z "${INSTPATH-}" && test -d "$INSTPATH" && rm -rf "$INSTPATH"' EXIT
+declare -x NVM_DIR=$INSTPATH
+\. ../../../nvm.sh
+
+nvm install --lts || die 'nvm install --lts failed'
+nvm exec --lts npm --version || die "`nvm exec` failed to run"
+declare -x NODE_VERSION="$(nvm exec --lts --silent node --version)"
+
+ln -s ../../../../nvm-exec "$INSTPATH/nvm-exec" || die "failed to create a symlink to $INSTPATH/"
+"$INSTPATH/nvm-exec" npm ls > /dev/null || die "`nvm exec` failed to run using nvm-exec helper"
+


### PR DESCRIPTION
Let's say we have nvm installed in a separate mount, /.socket. NVM_DIR is $HOME/.nvm in /etc/profile.d/nvm.sh. With this setup, users can install Node versions to their home directories without each installing nvm.

nvm install --lts

This works fine as does nvm use --lts. When nvm exec is used though, it fails because it looks for nvm-exec in $NVM_DIR. First fix is to look for nvm-exec in $NVM_DIR. If NVM_DIR does not contain nvm-exec, check $BASH_SOURCE[0]. The second fix is to follow nvm-exec if a symbolic link to determine the proper location of nvm's home. Alternatively we could use a second environment variable, NVM_HOME in exec instead of relying on the directory name of nvm-exec.