### PR TITLE
[new] better error message for `nvm install lts`

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2641,7 +2641,11 @@ nvm() {
         else
           REMOTE_CMD='nvm ls-remote'
         fi
-        nvm_err "Version '$provided_version' ${LTS_MSG-}not found - try \`${REMOTE_CMD}\` to browse available versions."
+        if [ "${provided_version}" = 'lts' ]; then
+          nvm_err "To install the latest LTS version of Node.js use the command \`nvm install --lts\`."
+        else
+          nvm_err "Version '$provided_version' ${LTS_MSG-}not found - try \`${REMOTE_CMD}\` to browse available versions."
+        fi
         return 3
       fi
 


### PR DESCRIPTION
An alternative to https://github.com/creationix/nvm/pull/1892

Catches the error later in the code path and prints a better message.