### PR TITLE
[New] adding default and alias option to `nvm install`

### DIFF
--- a/test/installation_node/install with --alias
+++ b/test/installation_node/install with --alias
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../nvm.sh
+
+nvm install --alias=9 9.11.2 || die '`nvm install --alias=9 9.11.2` failed'
+
+TERM=dumb nvm alias | grep '9 -> 9.11.2 (-> v9.11.2 \*)' || die 'did not make the expected alias'

--- a/test/installation_node/install with --default
+++ b/test/installation_node/install with --default
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../nvm.sh
+
+nvm install --default node || die '`nvm install --default` failed'
+
+TERM=dumb nvm alias | grep "default -> node (-> $(nvm version node) \*)" || die 'did not make the expected alias'


### PR DESCRIPTION
For: `nvm install 8.12.0` after install:

--alias=8 is equivalent to `nvm alias 8 8.12.0`
--default is equivalent to `nvm alias default 8.12.0`

implements #1867