### PR TITLE
[Fix] set install dir to $XDG_CONFIG_HOME/nvm, not $XDG_CONFIG_HOME

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ nvm_has() {
 
 nvm_default_install_dir() {
   if [ -n "$XDG_CONFIG_HOME" ]; then
-    printf %s "${XDG_CONFIG_HOME/nvm}"
+    printf %s "${XDG_CONFIG_HOME}/nvm"
   else
     printf %s "$HOME/.nvm"
   fi


### PR DESCRIPTION
seems to be the intent - wasn't happening when running the install script on bash 4.4.19 on Solus 3.9999

test output on my machine for master vs this branch:

```
nvm/test/install_script on master 
» ./nvm_install_dir 
nvm_install_dir should default to $XDG_CONFIG_DIR/.nvm. Current output: /home/ad/.config

nvm/test/install_script on master 
» git checkout -
Switched to branch 'update_install_dir_output'

nvm/test/install_script on update_install_dir_output 
» ./nvm_install_dir

nvm/test/install_script on update_install_dir_output 
» 
```

Marked draft as I still need to run through manually testing the shells listed in the CONTRIBUTING.md 