### PR TITLE
Set $NVM_DIR to ".nvm" instead of "nvm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
 <sub>**Note:** If the environment variable `$XDG_CONFIG_HOME` is present, it will place the `nvm` files there.</sub>
 
 ```sh
-export NVM_DIR="${XDG_CONFIG_HOME/:-$HOME/.}nvm"
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -7,11 +7,7 @@ nvm_has() {
 }
 
 nvm_default_install_dir() {
-  if [ -n "${XDG_CONFIG_HOME-}" ]; then
-    printf %s "${XDG_CONFIG_HOME}/nvm"
-  else
-    printf %s "${HOME}/.nvm"
-  fi
+  [ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm"
 }
 
 nvm_install_dir() {


### PR DESCRIPTION
<!-- Thank you for being interested in nvm! Please help us by filling out the following form if you‘re having trouble. If you have a feature request, or some other question, please feel free to clear out the form. Thanks! -->

- Operating system and version: Mac OS X Mojave

- `nvm debug` output:
  <details>
  <!-- do not delete the following blank line -->

  ```sh

  ```
  </details>

- `nvm ls` output:
  <details>
  <!-- do not delete the following blank line -->

  ```sh

  ```
  </details>

- How did you install `nvm`? (e.g. install script in readme, Homebrew): Install script

- What steps did you perform? Ran the wget install script

- What happened? $NVM_DIR was set to nvm

- What did you expect to happen? $NVM_DIR should be set to .nvm
I added the following line from the README to my .zshrc:
```
export NVM_DIR="${XDG_CONFIG_HOME/:-$HOME/.}nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
```

I couldn't figure out why nvm wasn't loading, until I realized that 
`echo NVM_DIR="${XDG_CONFIG_HOME/:-$HOME/.}nvm"` outputs `NVM_DIR=nvm`.

Changing the line to `export NVM_DIR="${XDG_CONFIG_HOME/:-$HOME/}.nvm"` fixed the problem. This outputs `NVM_DIR=.nvm` as expected. I tested this and the same behavior holds true in Bash as well.

- Is there anything in any of your profile files (`.bashrc`, `.bash_profile`, `.zshrc`, etc) that modifies the `PATH`? Nope

<!-- if this does not apply, please delete this section -->
- If you are having installation issues, or getting "N/A", what does `curl -I --compressed -v https://nodejs.org/dist/` print out?
  <details>
  <!-- do not delete the following blank line -->

  ```sh

  ```
  </details>