### PR TITLE
[Fix] Determine correct sub directory if XDG_CONFIG_HOME is set

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,10 +7,10 @@ nvm_has() {
 }
 
 nvm_default_install_dir() {
-  if [ -n "$XDG_CONFIG_HOME" ]; then
-    printf %s "${XDG_CONFIG_HOME/nvm}"
+  if [ -n "${XDG_CONFIG_HOME-}" ]; then
+    printf %s "${XDG_CONFIG_HOME}/nvm"
   else
-    printf %s "$HOME/.nvm"
+    printf %s "${HOME}/.nvm"
   fi
 }
 


### PR DESCRIPTION
With the environment variable XDG_CONFIG_HOME set, the installation
script uses the directory $XDG_CONFIG_HOME/nvm now. Before the change
the variable's value with "/nvm" cut off was used, which usually results
in an installation without any subdirectory.