### PR TITLE
Normalize paths in `nvm_tree_contains_path` before comparing

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -317,9 +317,9 @@ unset NVM_SCRIPT_SOURCE 2>/dev/null
 
 nvm_tree_contains_path() {
   local tree
-  tree="${1-}"
+  tree=$(realpath --canonicalize-missing "${1-}")
   local node_path
-  node_path="${2-}"
+  node_path=$(realpath --canonicalize-missing "${2-}")
 
   if [ "@${tree}@" = "@@" ] || [ "@${node_path}@" = "@@" ]; then
     nvm_err "both the tree and the node path are required"

--- a/test/fast/Unit tests/nvm_die_on_prefix
+++ b/test/fast/Unit tests/nvm_die_on_prefix
@@ -186,4 +186,18 @@ Run \`foo\` to unset it."
   [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has globalconfig did not exit with 10; got '$EXIT_CODE'"
 )
 
+npm() {
+  local args
+  args="$@"
+  if [ "_$args" = "_config --loglevel=warn get prefix" ]; then
+    echo "/home/foo/.nvm/path/to/version"
+  fi
+}
+NON_NORMALIZED_NVM_DIR="//home//foo//.nvm/"
+OUTPUT="$(export NVM_DIR="$NON_NORMALIZED_NVM_DIR" ; nvm_die_on_prefix 0 foo 2>&1)"
+EXPECTED_OUTPUT=''
+EXIT_CODE="$(export NVM_DIR="$NON_NORMALIZED_NVM_DIR" ; nvm_die_on_prefix 0 foo >/dev/null 2>&1; echo $?)"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT' with non-normalized NVM_DIR; got '$OUTPUT'"
+[ "_$EXIT_CODE" = "_0" ] || die "'nvm_die_on_prefix 0 foo' did not exit with 0 with non-normalized NVM_DIR; got '$EXIT_CODE'"
+
 cleanup


### PR DESCRIPTION
It's possible that `tree` and `node_path` both refer to the same
directory, but are lexically different. This converts both paths
into a canonical form so that any lexical-only differences are
removed.

This solves a problem where setting `NVM_DIR` to /home/user//.nvm
instead of /home/user/.nvm results in the infamous:
nvm is not compatible with the npm config "prefix" option

This adds a test that the above case no longer results in an error. An
existing test stopped failing as expected as a result, as the test set
the npm prefix to a local-directory-relative path, which resolved to
a directory inside the `NVM_DIR` when running the tests from within the
`NVM_DIR`. This test is updated to use an absolute path.