### PR TITLE
[Fix] system manpages unaccessible

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2861,7 +2861,7 @@ nvm() {
         if [ "_${MANPATH}" = "_${NEWPATH}" ]; then
           nvm_err "Could not find ${NVM_DIR}/*/share/man in \${MANPATH}"
         else
-          export MANPATH="${NEWPATH}"
+          export MANPATH=":${NEWPATH}"
           nvm_echo "${NVM_DIR}/*/share/man removed from \${MANPATH}"
         fi
       fi
@@ -2961,7 +2961,7 @@ nvm() {
           MANPATH=$(manpath)
         fi
         # Change current version
-        MANPATH="$(nvm_change_path "${MANPATH}" "/share/man" "${NVM_VERSION_DIR}")"
+        MANPATH=":$(nvm_change_path "${MANPATH}" "/share/man" "${NVM_VERSION_DIR}")"
         export MANPATH
       fi
       export PATH


### PR DESCRIPTION
Currently there is a problem that _nvm_ sets `MANPATH` explicitly to a value. Therefore the configuration in `/etc/manpath.config` gets ignored.

According to `man manpath`:


**MANPATH**
If  $MANPATH  is  set,  manpath  displays its value rather than determining it on the fly.  If $MANPATH is prefixed by a colon, then the value of the variable is appended to the list determined from the content of  the  configuration  files. If  the  colon comes at the end of the value in the variable, then the determined list is appended to the content of the variable.  If the value of the variable contains a double colon (::), then the determined list is inserted in the middle of the value, between the two colons.


This pull request adds the specified colon `:` in front of the two places in `nvm.sh` it sets the `MANPATH` variable and exports it.

I have tested this on the current LTS version of Ubuntu (18.04).