### PR TITLE
Fix bash auto-use nvm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ cdnvm(){
         # If there are multiple matching versions, take the latest one
         # Remove the `->` and `*` characters and spaces
         # `locally_resolved_nvm_version` will be `N/A` if no local versions are found
-        locally_resolved_nvm_version=$(nvm ls --no-colors $(<"./.nvmrc") | tail -1 | tr -d '\->*' | tr -d '[:space:]')
+        locally_resolved_nvm_version=$(nvm ls --no-colors "$nvm_version" | tail -1 | tr -d '\->*' | tr -d '[:space:]')
 
         # If it is not already installed, install it
         # `nvm install` will implicitly use the newly-installed version


### PR DESCRIPTION
It was trying to read ./.nvmrc if you cd'ed into a subdirectory of the directory that has .nvmrc, which would give print `-bash: ./.nvmrc: No such file or directory` to stderr and potentially not doing the `nvm install`.