### PR TITLE
Copy system cert configs when installing new versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [Long-term support](#long-term-support)
   - [Migrating global packages while installing](#migrating-global-packages-while-installing)
   - [Default global packages from file while installing](#default-global-packages-from-file-while-installing)
+  - [Copy system certificate preferences when installing](#copy-system-certificate-preferences-when-installing)
   - [io.js](#iojs)
   - [System version of node](#system-version-of-node)
   - [Listing versions](#listing-versions)
@@ -309,6 +310,10 @@ rimraf
 object-inspect@1.0.2
 stevemao/left-pad
 ```
+
+### Copy system certificate preferences when installing
+
+If you have any of `ca`, `cafile`, or `cert` present in your npm config when installing a new version, those keys will be copied into the newly-installed version's global config file. If you don't want this behavior, pass the `--skip-system-certs` flag when installing a new version
 
 ### io.js
 

--- a/test/installation_node/install while copying certs
+++ b/test/installation_node/install while copying certs
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# Save the PATH as it was when the test started to restore it when it
+# finishes
+ORIG_PATH=$PATH
+
+cleanup() {
+  # Restore the PATH as it was when the test started
+  export PATH=ORIG_PATH
+  rm $TEMPFILE
+  unset TEMPFILE
+}
+
+die () { cleanup; echo "$@" ; exit 1; }
+
+\. ../../nvm.sh
+
+# Directory where mocked npm-config is located
+MOCKS_DIR=`pwd`/../../mocks
+TEMPFILE="${MOCKS_DIR}/temp"
+
+# Sets the PATH for these tests to include the symlinks to the mocked
+# binaries
+export PATH=.:${PATH}
+
+# Remove the stuff we're clobbering.
+[ -e "${NVM_DIR}/versions/node/v9.7.0" ] && rm -R "${NVM_DIR}/versions/node/v9.7.0"
+[ -e "${NVM_DIR}/versions/node/v9.10.0" ] && rm -R "${NVM_DIR}/versions/node/v9.10.0"
+
+# set the
+# Install from binary
+nvm install 9.7.0
+
+# Check
+[ -d "${NVM_DIR}/versions/node/v9.7.0" ] || die "nvm install 9.7.0 didn't install"
+
+nvm use 9.7.0
+
+node --version | grep v9.7.0 > /dev/null || die "nvm use 9.7.0 failed"
+
+npm install -g object-is@0.0.0 || die "npm install -g object-is failed"
+npm list --global | grep object-is > /dev/null || die "object-is isn't installed"
+
+nvm ls 9 | grep v9.7.0 > /dev/null || die "nvm ls 9 didn't show v9.7.0"
+
+nvm install 9.10.0 --reinstall-packages-from=9 || die "nvm install 9.10.0 --reinstall-packages-from=9 failed"
+
+[ -d "${NVM_DIR}/versions/node/v9.10.0" ] || die "nvm install 9.10.0 didn't install"
+
+nvm use 9
+node --version | grep v9.10.0 > /dev/null || die "nvm ls 9 didn't use v9.10.0"
+
+npm list --global | grep object-is > /dev/null || die "object-is isn't installed"

--- a/test/mocks/npm_config
+++ b/test/mocks/npm_config
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+shift
+
+if [ "$1" = "get" ]; then
+  cat "$TEMPFILE"
+elif [ "$1" = "set" ]; then
+  shift
+  name="$1"
+  shift
+  val="$*"
+  echo "${name} = ${val}" >> "$TEMPFILE"
+fi


### PR DESCRIPTION
This PR adds support for copying any `ca`, `cert`, or `cafile` configs from the system's npm config file to the newly-installed npm prefix's config. It does this by default, but can be disabled with the `--skip-system-certs` flag.

Manually tested in `sh`, `bash`, and `zsh`. Also tested in `ksh` (per CONTRIBUTING.md), but that doesn't seem to work unrelated to my changes.

Any suggestions on how I could approach automated testing for these changes? Specifically, how I would mock out the `nvm system exec npm config ls` call.