### PR TITLE
Do not log when user has requested no profile modifications

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -358,7 +358,10 @@ nvm_do_install() {
   COMPLETION_STR='[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion\n'
   BASH_OR_ZSH=false
 
-  if [ -z "${NVM_PROFILE-}" ] ; then
+  if [ "${PROFILE-}" = '/dev/null' ] ; then
+    # the user has specifically requested NOT to have nvm touch their profile
+    echo
+  elif [ -z "${NVM_PROFILE-}" ] ; then
     local TRIED_PROFILE
     if [ -n "${PROFILE}" ]; then
       TRIED_PROFILE="${NVM_PROFILE} (as defined in \$PROFILE), "


### PR DESCRIPTION
Currently when you run the following command it will not modify the profile, but it still logs a complaint and asks the user to add it.

```
$ PROFILE="/dev/null" ./install.sh
...
=> Profile not found. Tried  (as defined in $PROFILE), ~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile.
=> Create one of them and run this script again
   OR
=> Append the following lines to the correct file yourself:
...
```

This changes the behavior so that explicitly setting to `/dev/null` does not nag you again.   The change was simple so I figured I would submit a PR rather than an issue to discuss.  Also, I looked at writing a test but having really no experience writing tests for a bash app like this I figured I should see if this seems good before spending too much time.