### PR TITLE
NVM_NOUSE on install.sh to pass --no-use to nvm.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -394,7 +394,11 @@ nvm_do_install() {
 
   # Source nvm
   # shellcheck source=/dev/null
-  \. "$(nvm_install_dir)/nvm.sh"
+  if [ -z "${NVM_NOUSE-}" ] ; then
+    \. "$(nvm_install_dir)/nvm.sh"
+  else
+    \. "$(nvm_install_dir)/nvm.sh" --no-use
+  fi
 
   nvm_check_global_modules
 

--- a/test/install_script/nvm_do_install
+++ b/test/install_script/nvm_do_install
@@ -1,8 +1,27 @@
 #!/bin/sh
 
+setup () {
+  #nvm_do_install is available
+  type nvm_do_install > /dev/null 2>&1 || die 'nvm_do_install is not available'
+}
+
+cleanup () {
+  unset NVM_ENV
+  unset NVM_NOUSE
+  rm -rf "$NVM_DIR/lib" >/dev/null 2>&1
+}
+
 die () { echo "$@" ; exit 1; }
 
+#nvm install
 NVM_ENV=testing \. ../../install.sh
 
-#nvm_do_install is available
-type nvm_do_install > /dev/null 2>&1 || die 'nvm_do_install is not available'
+setup
+
+cleanup
+
+#nvm install --no-use
+NVM_NOUSE=true
+NVM_ENV=testing \. ../../install.sh > /dev/null
+
+setup


### PR DESCRIPTION
Similar to my other PR (#2131) I figured I would see if this idea was good and I can flesh out the PR more if it is good.

This adds a `NVM_NOUSE` environment variable to the `install.sh` script so you can still use the install script but also pass `--no-use`.

Example:

```
$ curl -o- ... | NVM_NOUSE=true bash
```

Thoughts?