### PR TITLE
adjust for symbolic links

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -407,6 +407,12 @@ nvm_tree_contains_path() {
   previous_pathdir="${node_path}"
   local pathdir
   pathdir=$(dirname "${previous_pathdir}")
+
+  # get real directory in case of symbolic links
+  if [ -d "${pathdir-}" ]; then
+    pathdir="$(nvm_cd -P "${pathdir}" && pwd)"
+  fi
+
   while [ "${pathdir}" != '' ] && [ "${pathdir}" != '.' ] && [ "${pathdir}" != '/' ] &&
       [ "${pathdir}" != "${tree}" ] && [ "${pathdir}" != "${previous_pathdir}" ]; do
     previous_pathdir="${pathdir}"

--- a/test/fast/Unit tests/nvm_tree_contains_path
+++ b/test/fast/Unit tests/nvm_tree_contains_path
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 cleanup () {
+  rm tmp3/tmp2
+  rmdir tmp3
   rm tmp/node
   rmdir tmp
   rm tmp2/node
@@ -14,6 +16,8 @@ mkdir -p tmp
 touch tmp/node
 mkdir -p tmp2
 touch tmp2/node
+mkdir -p tmp3
+ln -s tmp2 tmp3/
 
 [ "$(nvm_tree_contains_path 2>&1)" = "both the tree and the node path are required" ] || die 'incorrect error message with no args'
 [ "$(nvm_tree_contains_path > /dev/null 2>&1 ; echo $?)" = "2" ] || die 'incorrect error code with no args'
@@ -27,5 +31,7 @@ nvm_tree_contains_path tmp tmp2/node && die '"tmp" should not contain "tmp2/node
 nvm_tree_contains_path tmp2 tmp2/node || die '"tmp2" should contain "tmp2/node"'
 
 nvm_tree_contains_path tmp2 tmp/node && die '"tmp2" should not contain "tmp/node"'
+
+nvm_tree_contains_path tmp2 tmp3 && die 'no idea'
 
 cleanup


### PR DESCRIPTION
Currently the **nvm.sh** script does not handle directories that are symbolic links.  This is a common problem on servers that use symbolic links to persistent drives.  For example, an admin might want to install nvm into **/opt/local/node**, but the real location (without the symlinks) is **/files2/opt-local/node/nvm**.  This results in:

```
export NVM_DIR=/opt/local/node/nvm && . "$NVM_DIR/nvm.sh"
nvm is not compatible with the npm config "prefix" option: currently set to "/files2/opt-local/node/nvm/versions/node/v8.11.3"
Run `npm config delete prefix` or `nvm use --delete-prefix v8.11.3 --silent` to unset it.
```

Assuming the admin knows this issue and uses the real directory, there is no problem:
```
export NVM_DIR=/files2/opt-local/node/nvm && . "$NVM_DIR/nvm.sh"
```

The small change I am providing will get the real directory to avoid the problem with symbolic links.  

I don't know if **cd -P** is available on all Linux systems, but I have tested in MacOS, RedHat, AWS AMI and Debian.