### PR TITLE
Changed prefix check to work in case NVM_DIR is a link

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2187,7 +2187,7 @@ nvm_die_on_prefix() {
   if [ -n "${NVM_NPM_CONFIG_PREFIX_ENV-}" ]; then
     local NVM_CONFIG_VALUE
     eval "NVM_CONFIG_VALUE=\"\$${NVM_NPM_CONFIG_PREFIX_ENV}\""
-    if [ -n "${NVM_CONFIG_VALUE-}" ] && ! nvm_tree_contains_path "${NVM_DIR}" "${NVM_CONFIG_VALUE}"; then
+    if [ -n "${NVM_CONFIG_VALUE-}" ] && ! nvm_tree_contains_path "$(cd -P "${NVM_DIR}" && pwd)" "${NVM_CONFIG_VALUE}"; then
       nvm deactivate >/dev/null 2>&1
       nvm_err "nvm is not compatible with the \"${NVM_NPM_CONFIG_PREFIX_ENV}\" environment variable: currently set to \"${NVM_CONFIG_VALUE}\""
       nvm_err "Run \`unset ${NVM_NPM_CONFIG_PREFIX_ENV}\` to unset it."


### PR DESCRIPTION
When NVM_DIR is a link, nvm mistakenly returns the error

nvm is not compatible with the npm config "prefix" option: currently set to "/data/jenkins-misc/nvm/versions/node/v8.10.0"
Run `npm config delete prefix` or `nvm use --delete-prefix v8.10.0` to unset it.

With this fix nvm will check correctly that the prefix is inside the NVM_DIR