### PR TITLE
nvm.sh - add NVM_INC for the include path

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2896,6 +2896,7 @@ nvm() {
         fi
       fi
       unset NVM_BIN
+      unset NVM_INC
     ;;
     "use")
       local PROVIDED_VERSION
@@ -2993,6 +2994,7 @@ nvm() {
       export PATH
       hash -r
       export NVM_BIN="${NVM_VERSION_DIR}/bin"
+      export NVM_INC="${NVM_VERSION_DIR}/include/node"
       if [ "${NVM_SYMLINK_CURRENT-}" = true ]; then
         command rm -f "${NVM_DIR}/current" && ln -s "${NVM_VERSION_DIR}" "${NVM_DIR}/current"
       fi
@@ -3542,7 +3544,7 @@ nvm() {
         nvm_curl_libz_support nvm_command_info nvm_is_zsh nvm_stdout_is_terminal \
         >/dev/null 2>&1
       unset NVM_RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR NVM_DIR \
-        NVM_CD_FLAGS NVM_BIN NVM_MAKE_JOBS \
+        NVM_CD_FLAGS NVM_BIN NVM_INC NVM_MAKE_JOBS \
         >/dev/null 2>&1
     ;;
     *)


### PR DESCRIPTION
This is a very simple change that makes it easy to configure include paths when developing node addons in C/C++. I use vscode which is not aware of the nvm. As a result it cannot find node include files and flags them as errors.

I worked on creating a vscode extension that would handle this but it didn't work well and requires significantly more work than this change. The one line change in this PR is a much cleaner approach (provided that one more NVM environment variable is ok).

I opted for `NVM_INC` as opposed to `NVM_INCLUDE` just because all the other NVM env vars were 3 characters or less.

This allows my `c_cpp_properties.json` file to use the env var like:

```
{
    "configurations": [
        {
            "name": "Linux",
            "includePath": [
                "${workspaceFolder}/**",
                "${workspaceFolder}/node_modules/nan",
                "${workspaceFolder}/node_modules/node-addon-api",
                "${env:NVM_INC}"
            ],
            "defines": [],
            "compilerPath": "/usr/bin/gcc",
            "cStandard": "c11",
            "cppStandard": "c++11",
            "intelliSenseMode": "clang-x64"
        }
    ],
    "version": 4
}
```

I have not tested it everywhere because if `export` works for `NVM_BIN` it should work for `NVM_INC` as well.
