### PR TITLE
[readme] add `nvshim` tool alongside `avn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ The contents of a `.nvmrc` file **must** be the `<version>` (as described by `nv
 
 You can use [`avn`](https://github.com/wbyoung/avn) to deeply integrate into your shell and automatically invoke `nvm` when changing directories. `avn` is **not** supported by the `nvm` maintainers. Please [report issues to the `avn` team](https://github.com/wbyoung/avn/issues/new).
 
+You can also use [`nvshim`](https://github.com/iamogbz/nvshim) to shim the `node`, `npm`, and `npx` bins to automatically use the `nvm` config in the current directory. `nvshim` is **not** supported by the `nvm` maintainers. Please [report issues to the `nvshim` team](https://github.com/iamogbz/nvshim/issues/new).
+
 If you prefer a lighter-weight solution, the recipes below have been contributed by `nvm` users. They are **not** supported by the `nvm` maintainers. We are, however, accepting pull requests for more examples.
 
 #### bash


### PR DESCRIPTION
Made a tool, [`nvshim`](https://github.com/iamogbz/nvshim), for shimming `node` binaries using `nvm`. Useful as an option for people that do not want to add auto loading script to their shell.

Unsure of the community rules about self promotion, just thought to share since it's been working for myself and a couple others.