### PR TITLE
Reinstalling should not echo an error

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2724,7 +2724,7 @@ nvm() {
       fi
 
       if nvm_is_version_installed "${VERSION}"; then
-        nvm_err "${VERSION} is already installed."
+        nvm_echo "${VERSION} is already installed."
         if nvm use "${VERSION}"; then
           if [ "${NVM_UPGRADE_NPM}" = 1 ]; then
             nvm install-latest-npm


### PR DESCRIPTION
My humble suggestion is that a request to install an existing version should not result in a message to stderr because it's not a failure. Things are gonna work out just fine. 