### PR TITLE
Stop removing spaces from nvm_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ find-up () {
 
 cdnvm(){
     cd "$@";
-    nvm_path=$(find-up .nvmrc | tr -d '[:space:]')
+    nvm_path=$(find-up .nvmrc | tr -d '\n')
 
     # If there are no .nvmrc file, use the default nvm version
     if [[ ! $nvm_path = *[^[:space:]]* ]]; then


### PR DESCRIPTION
It brakes switching version of node through nvm in directories with space somewhere in it's path:
https://youtu.be/dW1cxfElF5U

I can't imagine why creator of this script is removing spaces from the path, maybe there is a reason for that but I don't know it, please review it then.