### PR TITLE
[readme] Update shell profile file install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 ```
 
-Running either of the above commands downloads a script and runs it. The script clones the nvm repository to `~/.nvm`, and attempts to add the source lines from the snippet below to the correct profile file (`~/.bash_profile`, `~/.zshrc`, `~/.profile`, or `~/.bashrc`).
+Running either of the above commands downloads a script and runs it. The script clones the nvm repository to `~/.nvm`, and attempts to add the source lines from the snippet below to the correct profile file (`~/.bashrc`, `~/.bash_profile`, `~/.zshrc`, or `~/.profile`). If you find the install script is updating the wrong profile file, set the `$PROFILE` env var to the profile file’s path, and then rerun the installation script.
 
 <a id="profile_snippet"></a>
 ```sh


### PR DESCRIPTION
* Changes the suggested shell when running the install script to $SHELL
  which will return the default shell.
* Adds a note for how to fix the issue when the install script is not
  updating the correct profile file.
* Reorders the list of profile files to match the order of files the install script looks for.

NOTES ON CHANGES:
This documentation change is to help users who are finding that the install script is not updating the correct shell profile file. `$SHELL` will return the path to the default shell used, which will set the environment variables used by the install script to decide which profile file to update. There are reports of users not sure why their preferred profile file is not being updated here https://github.com/nvm-sh/nvm/issues/2196.

I suspect that many of these are from people running the given curl command, which currently pipes the install script into bash explicitly, even if the user has zsh or another shell as their default. This will especially bite MacOS Catalina users who now have zsh as their default shell.

There is also a way for users to explicitly set which profile file to change by the install script, which some users have asked for not knowing it already exists. Here https://github.com/nvm-sh/nvm/issues/2188, https://github.com/nvm-sh/nvm/issues/869       . This lets them know how to do that.

CAVEATS:
I would prefer to use an variable like `$0` instead of `$SHELL` as `$SHELL` does not return the currently used shell, but the default shell. The reason why `$0` can't be used is that it returns the current shell with a `-` in front of it. Once you switch to another shell and then back, the `-` is gone, but its there for all uses before switching to another shell and back. `$SHELL` however is better than the current example which states `bash` explicitly.

Also, it would be better for the install script to be a smarter about which profile file to change. Right now it is using the existence of `$BASH_VERSION`, `.bashrc`, `.bash_profile`, `$ZSH_VERSION`, `.zshrc`, and then `.profile`, in that order, to decide. It could instead look at which shell is being used and then set the corresponding profile file, through something like `$SHELL` or `$0`. I'm not versed in shell script so will leave those changes to someone with more experience.