### PR TITLE
Fix bug in fish example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ function load_nvm --on-variable="PWD"
   if test -n "$nvmrc_path"
     set -l nvmrc_node_version (nvm version (cat $nvmrc_path))
     if test "$nvmrc_node_version" = "N/A"
-      nvm install $nvmrc_node_version
+      nvm install (cat $nvmrc_path)
     else if test nvmrc_node_version != node_version
       nvm use $nvmrc_node_version
     end


### PR DESCRIPTION
Fix fish `load_nvm function` in readme.

The `load_nvm` function for fish contained an error on line 8 where it would try to install "N/A" as a node version, instead of the version listed in the `.nvmrc` file. 