### PR TITLE
Update docs and add warning for 'nvm is not compatible with the npm config "prefix" option' edgecase error on Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,6 +805,16 @@ sudo chmod ugo-x /usr/libexec/path_helper
 
 More on this issue in [dotphiles/dotzsh](https://github.com/dotphiles/dotzsh#mac-os-x).
 
+**nvm is not compatible with the npm config "prefix" option**
+
+Some solutions for this issue can be found [here](https://github.com/nvm-sh/nvm/issues/1245)
+
+There is one more edge case causing this issue, and that's a **mismatch between the `$HOME` path and the user's home directory's actual name**.
+
+You have to make sure that the user directory name in `$HOME` and the user directory name you'd see from running `ls /Users/` **are capitalized the same way** ([See this issue](https://github.com/nvm-sh/nvm/issues/2261)).
+
+To change the user directory and/or account name follow the instructions [here](https://support.apple.com/en-us/HT201548)
+
 [1]: https://github.com/nvm-sh/nvm.git
 [2]: https://github.com/nvm-sh/nvm/blob/v0.35.3/install.sh
 [3]: https://travis-ci.org/nvm-sh/nvm

--- a/nvm.sh
+++ b/nvm.sh
@@ -2201,6 +2201,8 @@ nvm_die_on_prefix() {
   fi
 
   local NVM_NPM_PREFIX
+  local NVM_OS
+  NVM_OS="$(nvm_get_os)"
   NVM_NPM_PREFIX="$(npm config --loglevel=warn get prefix)"
   if ! (nvm_tree_contains_path "${NVM_DIR}" "${NVM_NPM_PREFIX}" >/dev/null 2>&1); then
     if [ "_${NVM_DELETE_PREFIX}" = "_1" ]; then
@@ -2212,6 +2214,10 @@ nvm_die_on_prefix() {
         nvm_err "Run \`npm config delete prefix\` or \`${NVM_COMMAND}\` to unset it."
       else
         nvm_err "Run \`${NVM_COMMAND}\` to unset it."
+      fi
+      if [ "${NVM_OS}" = 'darwin' ]; then
+        nvm_err "Make sure your username ($(whoami)) matches the one in your \$HOME path."
+        nvm_err "See the \"macOS Troubleshooting\" section in the docs for more information."
       fi
       return 10
     fi


### PR DESCRIPTION
Addresses https://github.com/nvm-sh/nvm/issues/2261

My first thought was to somehow compare the capitalisation between the user directory name displayed from `$HOME` and the one you'd get from an `ls /Users/`, but that exceeds my bash scripting skills 😅

So all I did was add an extra subsection in the `macOS Troubleshooting` section of the docs, and also add an extra warning when that error appears, if we are on a Mac machine. 

I also made a small update to the `.gitignore` file.