### PR TITLE
Add -v Flag #2200

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -3580,7 +3580,7 @@ nvm() {
       esac
       NVM_VERSION_ONLY=true NVM_LTS="${NVM_LTS-}" nvm_remote_version "${PATTERN:-node}"
     ;;
-    "--version")
+    "--version" | "-v")
       nvm_echo '0.35.3'
     ;;
     "unload")


### PR DESCRIPTION
### Issue
resolves https://github.com/nvm-sh/nvm/issues/2200

nvm --version for me returns:
0.35.3
nvm -v returns the output of an unrecognized command.

This is issue proposes adding -v as an alias for --version as it is for node, npm, and many other commands. 


### Tests 

I did not add this to any tests.