### PR TITLE
[readme] Add documentation for LTS updates which reinstall existing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,12 @@ Node has a [schedule](https://github.com/nodejs/Release#release-schedule) for lo
 
 Any time your local copy of `nvm` connects to https://nodejs.org, it will re-create the appropriate local aliases for all available LTS lines. These aliases (stored under `$NVM_DIR/alias/lts`), are managed by `nvm`, and you should not modify, remove, or create these files - expect your changes to be undone, and expect meddling with these files to cause bugs that will likely not be supported.
 
+To get the latest LTS version of node and migrate your existing installed packages, use
+
+```sh
+nvm install --lts --reinstall-packages-from=current
+```
+
 ### Migrating Global Packages While Installing
 
 If you want to install a new version of Node.js and migrate npm packages from a previous version:


### PR DESCRIPTION
Added an example for LTS updates that also reinstall the existing packages.
This is useful for individuals who run the latest LTS version along with global packages and need to update when the LTS version gets bumped