### PR TITLE
Add --alias and --default to Install

### DIFF
--- a/test/installation_node/install with --alias
+++ b/test/installation_node/install with --alias
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../nvm.sh
+
+nvm install --alias=9 9.11.2 || die '`nvm install --alias=9 9.11.2` failed'
+
+TERM=dumb nvm alias | grep '9 -> 9.11.2 (-> v9.11.2 \*)' || die 'did not make the expected alias'

--- a/test/installation_node/install with --default
+++ b/test/installation_node/install with --default
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../nvm.sh
+
+nvm install --default node || die '`nvm install --default` failed'
+
+TERM=dumb nvm alias | grep "default -> node (-> $(nvm version node) \*)" || die 'did not make the expected alias'


### PR DESCRIPTION
Resolves #1867 

This is a follow up the work in PR #1929
I could not push to @kaltepeter 's remote so I have made a new PR. 

## Issue :

> It'd be nice if I could combine
> ✗ nvm install 8 && nvm alias default 8
> into:
> ✗ nvm install --default 8

> Seems like a reasonable request - we could also add --alias=foo (and have --default be a shortcut for --alias=default) to cover the generic case.

## Tests: 
ran with:
` --alias=* version`
` --alias=* no-version`
`--default --alias=* version`

Does not return err
` --alias=*  version --default`