### PR TITLE
[Fix] ensure `--help` is intercepted on any command 

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2345,6 +2345,94 @@ nvm() {
     return $?
   fi
 
+  for i in "$@"
+  do
+    case $i in
+      '-h'|'help'|'--help')
+        local NVM_IOJS_PREFIX
+        NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+        local NVM_NODE_PREFIX
+        NVM_NODE_PREFIX="$(nvm_node_prefix)"
+        NVM_VERSION="$(nvm --version)"
+        nvm_echo
+        nvm_echo "Node Version Manager (v${NVM_VERSION})"
+        nvm_echo
+        nvm_echo 'Note: <version> refers to any version-like string nvm understands. This includes:'
+        nvm_echo '  - full or partial version numbers, starting with an optional "v" (0.10, v0.1.2, v1)'
+        nvm_echo "  - default (built-in) aliases: ${NVM_NODE_PREFIX}, stable, unstable, ${NVM_IOJS_PREFIX}, system"
+        nvm_echo '  - custom aliases you define with `nvm alias foo`'
+        nvm_echo
+        nvm_echo ' Any options that produce colorized output should respect the `--no-colors` option.'
+        nvm_echo
+        nvm_echo 'Usage:'
+        nvm_echo '  nvm --help                                  Show this message'
+        nvm_echo '  nvm --version                               Print out the installed version of nvm'
+        nvm_echo '  nvm install [-s] [<version>]                Download and install a <version>, [-s] from source. Uses .nvmrc if available'
+        nvm_echo '    --reinstall-packages-from=<version>       When installing, reinstall packages installed in <node|iojs|node version number>'
+        nvm_echo '    --lts                                     When installing, only select from LTS (long-term support) versions'
+        nvm_echo '    --lts=<LTS name>                          When installing, only select from versions for a specific LTS line'
+        nvm_echo '    --skip-default-packages                   When installing, skip the default-packages file if it exists'
+        nvm_echo '    --latest-npm                              After installing, attempt to upgrade to the latest working npm on the given node version'
+        nvm_echo '    --no-progress                             Disable the progress bar on any downloads'
+        nvm_echo '    --alias=<name>                            After installing, set the alias specified to the version specified. (same as: nvm alias <name> <version>)'
+        nvm_echo '    --default                                 After installing, set default alias to the version specified. (same as: nvm alias default <version>)'
+        nvm_echo '  nvm uninstall <version>                     Uninstall a version'
+        nvm_echo '  nvm uninstall --lts                         Uninstall using automatic LTS (long-term support) alias `lts/*`, if available.'
+        nvm_echo '  nvm uninstall --lts=<LTS name>              Uninstall using automatic alias for provided LTS line, if available.'
+        nvm_echo '  nvm use [--silent] [<version>]              Modify PATH to use <version>. Uses .nvmrc if available'
+        nvm_echo '    --lts                                     Uses automatic LTS (long-term support) alias `lts/*`, if available.'
+        nvm_echo '    --lts=<LTS name>                          Uses automatic alias for provided LTS line, if available.'
+        nvm_echo '  nvm exec [--silent] [<version>] [<command>] Run <command> on <version>. Uses .nvmrc if available'
+        nvm_echo '    --lts                                     Uses automatic LTS (long-term support) alias `lts/*`, if available.'
+        nvm_echo '    --lts=<LTS name>                          Uses automatic alias for provided LTS line, if available.'
+        nvm_echo '  nvm run [--silent] [<version>] [<args>]     Run `node` on <version> with <args> as arguments. Uses .nvmrc if available'
+        nvm_echo '    --lts                                     Uses automatic LTS (long-term support) alias `lts/*`, if available.'
+        nvm_echo '    --lts=<LTS name>                          Uses automatic alias for provided LTS line, if available.'
+        nvm_echo '  nvm current                                 Display currently activated version of Node'
+        nvm_echo '  nvm ls [<version>]                          List installed versions, matching a given <version> if provided'
+        nvm_echo '    --no-colors                               Suppress colored output'
+        nvm_echo '    --no-alias                                Suppress `nvm alias` output'
+        nvm_echo '  nvm ls-remote [<version>]                   List remote versions available for install, matching a given <version> if provided'
+        nvm_echo '    --lts                                     When listing, only show LTS (long-term support) versions'
+        nvm_echo '    --lts=<LTS name>                          When listing, only show versions for a specific LTS line'
+        nvm_echo '    --no-colors                               Suppress colored output'
+        nvm_echo '  nvm version <version>                       Resolve the given description to a single local version'
+        nvm_echo '  nvm version-remote <version>                Resolve the given description to a single remote version'
+        nvm_echo '    --lts                                     When listing, only select from LTS (long-term support) versions'
+        nvm_echo '    --lts=<LTS name>                          When listing, only select from versions for a specific LTS line'
+        nvm_echo '  nvm deactivate                              Undo effects of `nvm` on current shell'
+        nvm_echo '  nvm alias [<pattern>]                       Show all aliases beginning with <pattern>'
+        nvm_echo '    --no-colors                               Suppress colored output'
+        nvm_echo '  nvm alias <name> <version>                  Set an alias named <name> pointing to <version>'
+        nvm_echo '  nvm unalias <name>                          Deletes the alias named <name>'
+        nvm_echo '  nvm install-latest-npm                      Attempt to upgrade to the latest working `npm` on the current node version'
+        nvm_echo '  nvm reinstall-packages <version>            Reinstall global `npm` packages contained in <version> to current version'
+        nvm_echo '  nvm unload                                  Unload `nvm` from shell'
+        nvm_echo '  nvm which [current | <version>]             Display path to installed node version. Uses .nvmrc if available'
+        nvm_echo '  nvm cache dir                               Display path to the cache directory for nvm'
+        nvm_echo '  nvm cache clear                             Empty cache directory for nvm'
+        nvm_echo
+        nvm_echo 'Example:'
+        nvm_echo '  nvm install 8.0.0                     Install a specific version number'
+        nvm_echo '  nvm use 8.0                           Use the latest available 8.0.x release'
+        nvm_echo '  nvm run 6.10.3 app.js                 Run app.js using node 6.10.3'
+        nvm_echo '  nvm exec 4.8.3 node app.js            Run `node app.js` with the PATH pointing to node 4.8.3'
+        nvm_echo '  nvm alias default 8.1.0               Set default node version on a shell'
+        nvm_echo '  nvm alias default node                Always default to the latest available node version on a shell'
+        nvm_echo
+        nvm_echo '  nvm install node                      Install the latest available version'
+        nvm_echo '  nvm use node                          Use the latest version'
+        nvm_echo '  nvm install --lts                     Install the latest LTS version'
+        nvm_echo '  nvm use --lts                         Use the latest LTS version'
+        nvm_echo
+        nvm_echo 'Note:'
+        nvm_echo '  to remove, delete, or uninstall nvm - just remove the `$NVM_DIR` folder (usually `~/.nvm`)'
+        nvm_echo
+        return 0;
+      ;;
+    esac
+  done
+
   local COMMAND
   COMMAND="${1-}"
   shift
@@ -2354,88 +2442,6 @@ nvm() {
   local ADDITIONAL_PARAMETERS
 
   case $COMMAND in
-    'help' | '--help')
-      local NVM_IOJS_PREFIX
-      NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-      local NVM_NODE_PREFIX
-      NVM_NODE_PREFIX="$(nvm_node_prefix)"
-      NVM_VERSION="$(nvm --version)"
-      nvm_echo
-      nvm_echo "Node Version Manager (v${NVM_VERSION})"
-      nvm_echo
-      nvm_echo 'Note: <version> refers to any version-like string nvm understands. This includes:'
-      nvm_echo '  - full or partial version numbers, starting with an optional "v" (0.10, v0.1.2, v1)'
-      nvm_echo "  - default (built-in) aliases: ${NVM_NODE_PREFIX}, stable, unstable, ${NVM_IOJS_PREFIX}, system"
-      nvm_echo '  - custom aliases you define with `nvm alias foo`'
-      nvm_echo
-      nvm_echo ' Any options that produce colorized output should respect the `--no-colors` option.'
-      nvm_echo
-      nvm_echo 'Usage:'
-      nvm_echo '  nvm --help                                  Show this message'
-      nvm_echo '  nvm --version                               Print out the installed version of nvm'
-      nvm_echo '  nvm install [-s] [<version>]                Download and install a <version>, [-s] from source. Uses .nvmrc if available'
-      nvm_echo '    --reinstall-packages-from=<version>       When installing, reinstall packages installed in <node|iojs|node version number>'
-      nvm_echo '    --lts                                     When installing, only select from LTS (long-term support) versions'
-      nvm_echo '    --lts=<LTS name>                          When installing, only select from versions for a specific LTS line'
-      nvm_echo '    --skip-default-packages                   When installing, skip the default-packages file if it exists'
-      nvm_echo '    --latest-npm                              After installing, attempt to upgrade to the latest working npm on the given node version'
-      nvm_echo '    --no-progress                             Disable the progress bar on any downloads'
-      nvm_echo '    --alias=<name>                            After installing, set the alias specified to the version specified. (same as: nvm alias <name> <version>)'
-      nvm_echo '    --default                                 After installing, set default alias to the version specified. (same as: nvm alias default <version>)'
-      nvm_echo '  nvm uninstall <version>                     Uninstall a version'
-      nvm_echo '  nvm uninstall --lts                         Uninstall using automatic LTS (long-term support) alias `lts/*`, if available.'
-      nvm_echo '  nvm uninstall --lts=<LTS name>              Uninstall using automatic alias for provided LTS line, if available.'
-      nvm_echo '  nvm use [--silent] [<version>]              Modify PATH to use <version>. Uses .nvmrc if available'
-      nvm_echo '    --lts                                     Uses automatic LTS (long-term support) alias `lts/*`, if available.'
-      nvm_echo '    --lts=<LTS name>                          Uses automatic alias for provided LTS line, if available.'
-      nvm_echo '  nvm exec [--silent] [<version>] [<command>] Run <command> on <version>. Uses .nvmrc if available'
-      nvm_echo '    --lts                                     Uses automatic LTS (long-term support) alias `lts/*`, if available.'
-      nvm_echo '    --lts=<LTS name>                          Uses automatic alias for provided LTS line, if available.'
-      nvm_echo '  nvm run [--silent] [<version>] [<args>]     Run `node` on <version> with <args> as arguments. Uses .nvmrc if available'
-      nvm_echo '    --lts                                     Uses automatic LTS (long-term support) alias `lts/*`, if available.'
-      nvm_echo '    --lts=<LTS name>                          Uses automatic alias for provided LTS line, if available.'
-      nvm_echo '  nvm current                                 Display currently activated version of Node'
-      nvm_echo '  nvm ls [<version>]                          List installed versions, matching a given <version> if provided'
-      nvm_echo '    --no-colors                               Suppress colored output'
-      nvm_echo '    --no-alias                                Suppress `nvm alias` output'
-      nvm_echo '  nvm ls-remote [<version>]                   List remote versions available for install, matching a given <version> if provided'
-      nvm_echo '    --lts                                     When listing, only show LTS (long-term support) versions'
-      nvm_echo '    --lts=<LTS name>                          When listing, only show versions for a specific LTS line'
-      nvm_echo '    --no-colors                               Suppress colored output'
-      nvm_echo '  nvm version <version>                       Resolve the given description to a single local version'
-      nvm_echo '  nvm version-remote <version>                Resolve the given description to a single remote version'
-      nvm_echo '    --lts                                     When listing, only select from LTS (long-term support) versions'
-      nvm_echo '    --lts=<LTS name>                          When listing, only select from versions for a specific LTS line'
-      nvm_echo '  nvm deactivate                              Undo effects of `nvm` on current shell'
-      nvm_echo '  nvm alias [<pattern>]                       Show all aliases beginning with <pattern>'
-      nvm_echo '    --no-colors                               Suppress colored output'
-      nvm_echo '  nvm alias <name> <version>                  Set an alias named <name> pointing to <version>'
-      nvm_echo '  nvm unalias <name>                          Deletes the alias named <name>'
-      nvm_echo '  nvm install-latest-npm                      Attempt to upgrade to the latest working `npm` on the current node version'
-      nvm_echo '  nvm reinstall-packages <version>            Reinstall global `npm` packages contained in <version> to current version'
-      nvm_echo '  nvm unload                                  Unload `nvm` from shell'
-      nvm_echo '  nvm which [current | <version>]             Display path to installed node version. Uses .nvmrc if available'
-      nvm_echo '  nvm cache dir                               Display path to the cache directory for nvm'
-      nvm_echo '  nvm cache clear                             Empty cache directory for nvm'
-      nvm_echo
-      nvm_echo 'Example:'
-      nvm_echo '  nvm install 8.0.0                     Install a specific version number'
-      nvm_echo '  nvm use 8.0                           Use the latest available 8.0.x release'
-      nvm_echo '  nvm run 6.10.3 app.js                 Run app.js using node 6.10.3'
-      nvm_echo '  nvm exec 4.8.3 node app.js            Run `node app.js` with the PATH pointing to node 4.8.3'
-      nvm_echo '  nvm alias default 8.1.0               Set default node version on a shell'
-      nvm_echo '  nvm alias default node                Always default to the latest available node version on a shell'
-      nvm_echo
-      nvm_echo '  nvm install node                      Install the latest available version'
-      nvm_echo '  nvm use node                          Use the latest version'
-      nvm_echo '  nvm install --lts                     Install the latest LTS version'
-      nvm_echo '  nvm use --lts                         Use the latest LTS version'
-      nvm_echo
-      nvm_echo 'Note:'
-      nvm_echo '  to remove, delete, or uninstall nvm - just remove the `$NVM_DIR` folder (usually `~/.nvm`)'
-      nvm_echo
-    ;;
-
     "cache")
       case "${1-}" in
         dir) nvm_cache_dir ;;

--- a/test/fast/Unit tests/nvm_check_for_help
+++ b/test/fast/Unit tests/nvm_check_for_help
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+TERM=dumb nvm clear-cache --help | grep 'Usage:' || die 'did not print help menu'
+TERM=dumb nvm cache help version | grep 'Usage:' || die 'did not print help menu'
+TERM=dumb nvm cache -h version| grep 'Usage:' || die 'did not print help menu'


### PR DESCRIPTION
This fixes #911 

Issue: Prevent flags from being parsed if the help flag is present in the list of arguments to nvm

> Even if nvm doesn't support the --help flag on individual tasks it would be more user friendly to prevent any action being carried out if the --help flag is present

What we did: Check arguments list for help flag and display help then exit without parsing other flags

Test added: nvm_check_for_help