### PR TITLE
Fixed a bug where --silent mode was failing for nvm use

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -3155,10 +3155,15 @@ nvm() {
       # run given version of node
 
       local NVM_SILENT
+      local NVM_SILENT_ARG
       local NVM_LTS
       while [ $# -gt 0 ]; do
         case "$1" in
-          --silent) NVM_SILENT='--silent' ; shift ;;
+          --silent)
+            NVM_SILENT=1
+            NVM_SILENT_ARG='--silent'
+            shift
+          ;;
           --lts) NVM_LTS='*' ; shift ;;
           --lts=*) NVM_LTS="${1##--lts=}" ; shift ;;
           *)
@@ -3172,11 +3177,7 @@ nvm() {
       done
 
       if [ $# -lt 1 ] && [ -z "${NVM_LTS-}" ]; then
-        if [ -n "${NVM_SILENT-}" ]; then
-          nvm_rc_version >/dev/null 2>&1 && has_checked_nvmrc=1
-        else
-          nvm_rc_version && has_checked_nvmrc=1
-        fi
+        NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
         if [ -n "${NVM_RC_VERSION-}" ]; then
           VERSION="$(nvm_version "${NVM_RC_VERSION-}")" ||:
         fi
@@ -3194,11 +3195,7 @@ nvm() {
           if [ "_${VERSION:-N/A}" = '_N/A' ] && ! nvm_is_valid_version "${provided_version}"; then
             provided_version=''
             if [ $has_checked_nvmrc -ne 1 ]; then
-              if [ -n "${NVM_SILENT-}" ]; then
-                nvm_rc_version >/dev/null 2>&1 && has_checked_nvmrc=1
-              else
-                nvm_rc_version && has_checked_nvmrc=1
-              fi
+              NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
             fi
             VERSION="$(nvm_version "${NVM_RC_VERSION}")" ||:
             unset NVM_RC_VERSION
@@ -3224,9 +3221,9 @@ nvm() {
       if [ "_${VERSION}" = "_N/A" ]; then
         nvm_ensure_version_installed "${provided_version}"
       elif [ "${NVM_IOJS}" = true ]; then
-        nvm exec "${NVM_SILENT-}" "${LTS_ARG-}" "${VERSION}" iojs "$@"
+        nvm exec "${NVM_SILENT_ARG-}" "${LTS_ARG-}" "${VERSION}" iojs "$@"
       else
-        nvm exec "${NVM_SILENT-}" "${LTS_ARG-}" "${VERSION}" node "$@"
+        nvm exec "${NVM_SILENT_ARG-}" "${LTS_ARG-}" "${VERSION}" node "$@"
       fi
       EXIT_CODE="$?"
       return $EXIT_CODE
@@ -3236,7 +3233,7 @@ nvm() {
       local NVM_LTS
       while [ $# -gt 0 ]; do
         case "$1" in
-          --silent) NVM_SILENT='--silent' ; shift ;;
+          --silent) NVM_SILENT=1 ; shift ;;
           --lts) NVM_LTS='*' ; shift ;;
           --lts=*) NVM_LTS="${1##--lts=}" ; shift ;;
           --) break ;;
@@ -3262,11 +3259,7 @@ nvm() {
       elif [ -n "${provided_version}" ]; then
         VERSION="$(nvm_version "${provided_version}")" ||:
         if [ "_${VERSION}" = '_N/A' ] && ! nvm_is_valid_version "${provided_version}"; then
-          if [ -n "${NVM_SILENT-}" ]; then
-            nvm_rc_version >/dev/null 2>&1
-          else
-            nvm_rc_version
-          fi
+          NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
           provided_version="${NVM_RC_VERSION}"
           unset NVM_RC_VERSION
           VERSION="$(nvm_version "${provided_version}")" ||:
@@ -3281,7 +3274,7 @@ nvm() {
         return $EXIT_CODE
       fi
 
-      if [ -z "${NVM_SILENT-}" ]; then
+      if [ "${NVM_SILENT:-0}" -ne 1 ]; then
         if [ "${NVM_LTS-}" = '*' ]; then
           nvm_echo "Running node latest LTS -> $(nvm_version "${VERSION}")$(nvm use --silent "${VERSION}" && nvm_print_npm_version)"
         elif [ -n "${NVM_LTS-}" ]; then

--- a/test/slow/nvm use/Running "nvm use node --silent" doesn't print anything
+++ b/test/slow/nvm use/Running "nvm use node --silent" doesn't print anything
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+nvm deactivate 2>&1 >/dev/null || die 'deactivate failed'
+
+OUTPUT=$(nvm use node --silent || die 'nvm use node failed')
+EXPECTED_OUTPUT=""
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use node --silent' output was not silenced to '$EXPECTED_OUTPUT'; got '$OUTPUT'"


### PR DESCRIPTION
## Overview
I ran a test that just ran ```nvm use node --silent``` that I wrote by myself. Unfortunately, I noticed a bug where it still prints out some messages in different cases. This pull request is to fix that bug.
## List of Updates
* Added in an argument called ***quiet***  to the nvm_rc_version() function at *line 339*
* Printed anything inside the nvm_rc_version() only in the scenario where quiet mode is off
* Ran the nvm_rc_version() function in quiet mode only if silent mode is on in the "use" command of nvm at *line 2990*
* Ran *nvm_echo* and *nvm_err* inside the "use" command of nvm only in the scenario where silent mode is off (There were 4 scenarios where this was forgotten)
* Created aliases for the --silent flag in ```nvm deactivate``` and ```nvm use```
* Changed the unrequited local declaration of the NVM_NODE_PREFIX
* Edited the ```nvm deactivate``` command to include a silent mode
* Used silent mode inside the ```nvm use``` when running ```nvm deactivate``` inside it and silent mode is on
* Updated the help page to include the --silent flag for ```nvm deactivate```
## Tests
A test is attached in the 'test/slow/nvm use' directory. It is named *Running "nvm use node --silent" doesn't print anything*. It runs ```nvm use node --silent and checks``` and succeeds if the OUTPUT matches the EXPECTED_OUTPUT which is *null*  or *''*. When the test was run locally, it still ouputed results if someone deleted some contents of the *.nvm/* folder. This output was given from the ```nvm deactivate command```. This was the reason that the ```nvm deactivate``` was edited to include silent mode.

*Note: line numbers may be a bit off due to recent changes*

Fixes #2239