### PR TITLE
Small nvm_auto optimization

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -3788,11 +3788,10 @@ nvm_supports_xz() {
 }
 
 nvm_auto() {
-  local NVM_CURRENT
-  NVM_CURRENT="$(nvm_ls_current)"
   local NVM_MODE
   NVM_MODE="${1-}"
   local VERSION
+  local NVM_CURRENT
   if [ "_${NVM_MODE}" = '_install' ]; then
     VERSION="$(nvm_alias default 2>/dev/null || nvm_echo)"
     if [ -n "${VERSION}" ]; then
@@ -3801,6 +3800,7 @@ nvm_auto() {
       nvm install >/dev/null
     fi
   elif [ "_$NVM_MODE" = '_use' ]; then
+    NVM_CURRENT="$(nvm_ls_current)"
     if [ "_${NVM_CURRENT}" = '_none' ] || [ "_${NVM_CURRENT}" = '_system' ]; then
       VERSION="$(nvm_resolve_local_alias default 2>/dev/null || nvm_echo)"
       if [ -n "${VERSION}" ]; then


### PR DESCRIPTION
This is a small optimization of the nvm_auto function: $NVM_CURRENT is only used in the `elif [ "_$NVM_MODE" = '_use' ]; then` part of the conditional, so it should only be set if it's needed.

I source nvm.sh with `--no-use` so this change takes the load time of the whole script from about 40ms down to about 5ms