### PR TITLE
Set colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
   - [io.js](#iojs)
   - [System Version of Node](#system-version-of-node)
   - [Listing Versions](#listing-versions)
+  - [Setting Custom Colors](#setting-custom-colors)
+    - [Persisting custom colors](#persisting-custom-colors)
     - [Suppressing colorized output](#suppressing-colorized-output)
   - [.nvmrc](#nvmrc)
   - [Deeper Shell Integration](#deeper-shell-integration)
@@ -380,12 +382,48 @@ If you want to see what versions are available to install:
 nvm ls-remote
 ```
 
+### Setting Custom Colors
+
+You can set five colors that will be used to display version and alias information. These colors replace the default colors.
+  Initial colors are: g b y r e
+
+  Color codes:
+
+    r/R = red / bold red
+
+    g/G = green / bold green
+
+    b/B = blue / bold blue
+
+    c/C = cyan / bold cyan
+
+    m/M = magenta / bold magenta
+
+    y/Y = yellow / bold yellow
+
+    k/K = black / bold black
+
+    e/W = light grey / white
+
+```sh
+nvm set-colors rgBcm
+```
+
+#### Persisting custom colors
+
+If you want the custom colors to persist after terminating the shell, export the NVM_COLORS variable in your shell profile. For example, if you want to use cyan, magenta, green, bold red and bold yellow, add the following line:
+
+```sh
+export NVM_COLORS='cmgRY'
+```
+
 #### Suppressing colorized output
 
-`nvm ls`, `nvm ls-remote` and `nvm alias` usually produce colorized output. You can disable colors with the `--no-colors` option (or by setting the environment variable `TERM=dumb`):
+`nvm help (or -h or --help)`, `nvm ls`, `nvm ls-remote` and `nvm alias` usually produce colorized output. You can disable colors with the `--no-colors` option (or by setting the environment variable `TERM=dumb`):
 
 ```sh
 nvm ls --no-colors
+nvm help --no-colors
 TERM=dumb nvm ls
 ```
 

--- a/test/fast/Aliases/nvm_list_aliases calls nvm_get_colors
+++ b/test/fast/Aliases/nvm_list_aliases calls nvm_get_colors
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+\. ../../../nvm.sh
+
+die () {
+  echo "nvm_list_aliases did not call nvm_get_colors. Expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+  exit 1
+}
+
+set -e
+
+nvm_get_colors(){
+  echo "0;95m"
+}
+
+nvm_alias_path() {
+  nvm_echo "../../../alias"
+}
+
+OUTPUT=$(command printf %b $(nvm_list_aliases test-stable-1) | awk '{ print substr($0, 1, 19); }')
+
+EXPECTED_OUTPUT=$(command printf %b "\033[0;95mtest-stable-1" | awk '{ print substr($0, 1, 19); }')
+echo "\033[0m"
+
+[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die

--- a/test/fast/Aliases/nvm_print_alias_path calls nvm_get_colors
+++ b/test/fast/Aliases/nvm_print_alias_path calls nvm_get_colors
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+\. ../../../nvm.sh
+
+die () {
+  # echo "$@" ;
+  echo "Expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+  exit 1
+}
+
+set -e
+
+nvm_get_colors(){
+  echo "0;95m"
+}
+
+# nvm_print_alias_path call nvm_print_formatted_alias which calls nvm_get-colors
+# the output of nvm_print_alias_path uses the color code returned by nvm_get_colors (redefined above)
+NVM_ALIAS_DIR='../../../alias'
+
+OUTPUT=$(command printf %b $(nvm_print_alias_path "$NVM_ALIAS_DIR" "$NVM_ALIAS_DIR"/test-stable-1) | awk '{ print substr($0, 1, 24); }')
+
+EXPECTED_OUTPUT=$(command printf %b "\033[0;95mtest-stable-1\033[0m")
+
+[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die
+
+
+set +e

--- a/test/fast/Aliases/nvm_print_formatted_alias calls nvm_get_colors
+++ b/test/fast/Aliases/nvm_print_formatted_alias calls nvm_get_colors
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+\. ../../../nvm.sh
+
+die () {
+  echo "Expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+  exit 1
+}
+
+set -e
+# # # expecting in red and two grays:
+OUTPUT=$(echo $(nvm_print_formatted_alias fakealias fakedest) | awk '{ print substr($0, 1, 21); }')
+EXPECTED_OUTPUT="$(command printf %b "\033[0;31mfakealias\033[0m ")"
+[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die
+
+# expecting in bold yellow and two grays:
+nvm set-colors bbbYb
+OUTPUT=$(echo $(nvm_print_formatted_alias fakealias fakedest) | awk '{ print substr($0, 1, 21); }')
+EXPECTED_OUTPUT="$(command printf %b "\033[1;33mfakealias\033[0m ")"
+
+[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die

--- a/test/fast/Set Colors/nvm_echo_with_colors
+++ b/test/fast/Set Colors/nvm_echo_with_colors
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -ex
+
+die () {
+  echo "Expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+  exit 1
+}
+
+cleanup() {
+  echo "Tested nvm_echo_with_colors"
+}
+
+\. ../../../nvm.sh
+
+OUTPUT="$(nvm_echo_with_colors "\033[0;36mCyan-colored text")"
+EXPECTED_OUTPUT=$(printf "\033[0;36mCyan-colored text")
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die
+
+cleanup

--- a/test/fast/Set Colors/nvm_err_with_colors
+++ b/test/fast/Set Colors/nvm_err_with_colors
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; cleanup ; exit 1; }
+
+cleanup() {
+  echo "Tested nvm_err_with_colors"
+}
+
+\. ../../../nvm.sh
+
+set +ex
+OUTPUT="$(nvm_err_with_colors "\033[0;35mMagenta-colored text" 2>&1)"
+set -ex
+EXPECTED_OUTPUT=$(printf "\033[0;35mMagenta-colored text")
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die
+
+cleanup

--- a/test/fast/Set Colors/nvm_print_default_alias calls nvm_get_colors
+++ b/test/fast/Set Colors/nvm_print_default_alias calls nvm_get_colors
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+\. ../../../nvm.sh
+
+die () {
+  # echo "$@" ;
+  echo "Expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+  exit 1
+}
+
+set -e
+
+nvm_get_colors(){
+    echo "0;95m"
+}
+
+# nvm_print_default_alias call nvm_print_formatted_alias which calls nvm_get-colors
+# the output of nvm_print_default_alias uses the color code returned by nvm_get_colors (redefined above)
+OUTPUT=$(command printf %b $(nvm_print_default_alias node ./alias v14.7.0) | awk '{ print substr($0, 1, 11); }')
+EXPECTED_OUTPUT=$(command printf %b "\033[0;95mnode")
+
+[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die
+
+set +e

--- a/test/fast/Set Colors/nvm_print_versions calls nvm_get_colors
+++ b/test/fast/Set Colors/nvm_print_versions calls nvm_get_colors
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+\. ../../../nvm.sh
+
+set -e
+
+die () {
+  # echo "$@" ;
+  echo "Expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+  exit 1
+}
+cleanup() {
+  if [ -n TEMP_NVM_COLORS ]; then
+    export NVM_COLORS=TEMP_NVM_COLORS
+  fi
+  unset TEMP_NVM_COLORS
+}
+
+if [ -n ${NVM_COLORS} ]; then
+  export TEMP_NVM_COLORS=NVM_COLORS
+  unset NVM_COLORS
+fi
+
+# default system color
+nvm use system
+OUTPUT=$(nvm_print_versions system)
+FORMAT="\033[0;32m-> %12s\033[0m"
+VERSION='system'
+EXPECTED_OUTPUT=$(command printf -- "${FORMAT}\\n" "${VERSION}")
+
+[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die
+
+nvm_ls_current() { echo "current";}
+
+# default current color
+OUTPUT=$(nvm_print_versions current)
+FORMAT="\033[0;32m-> %12s\033[0m"
+VERSION="current"
+EXPECTED_OUTPUT=$(command printf -- "${FORMAT}\\n" "${VERSION}")
+
+[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die
+
+# custom current color
+nvm set-colors YCMGR
+OUTPUT=$(nvm_print_versions current)
+FORMAT="\033[1;35m-> %12s\033[0m"
+VERSION="current"
+EXPECTED_OUTPUT=$(command printf -- "${FORMAT}\\n" "${VERSION}")
+
+[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die
+
+cleanup

--- a/test/fast/Unit tests/nvm ls-remote
+++ b/test/fast/Unit tests/nvm ls-remote
@@ -6,9 +6,17 @@ die () { echo "$@" ; cleanup ; exit 1; }
 
 cleanup() {
   unset -f nvm_download nvm_ls_remote nvm_ls_remote_iojs
+  if [ -n TEMP_NVM_COLORS ]; then
+    export NVM_COLORS=TEMP_NVM_COLORS
+  fi
+  unset TEMP_NVM_COLORS
 }
 
 \. ../../../nvm.sh
+if [ -n ${NVM_COLORS} ]; then
+  export TEMP_NVM_COLORS=NVM_COLORS
+  unset NVM_COLORS
+fi
 
 nvm deactivate 2>/dev/null || die 'unable to deactivate'
 

--- a/test/fast/Unit tests/nvm set_colors
+++ b/test/fast/Unit tests/nvm set_colors
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; cleanup ; exit 1; }
+
+cleanup() {
+  unset NVM_COLORS
+  unset -f nvm_has_colors
+  if [ -n TEMP_NVM_COLORS ]; then
+    export NVM_COLORS=TEMP_NVM_COLORS
+  fi
+  unset TEMP_NVM_COLORS
+}
+
+\. ../../../nvm.sh
+# NVM_COLORS is not set
+if [ -n ${NVM_COLORS} ]; then
+  export TEMP_NVM_COLORS=NVM_COLORS
+  unset NVM_COLORS
+fi
+
+# test valid setting colors/
+nvm set-colors rgbyc
+OUTPUT="${NVM_COLORS}"
+EXPECTED_OUTPUT="rgbyc"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "NVM_SET_COLORS failed with valid input; got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+# test invalid 4 colors
+set +ex
+OUTPUT="$(echo $(nvm set-colors rgby 2>&1) | awk '{ print substr($0, length($0)-92, 93); }')"
+EXPECTED_OUTPUT="$(command printf %b "\033[1;37mPlease pass in five \033[1;31mvalid color codes\033[1;37m. Choose from: rRgGbBcCyYmMkKeW\033[0m")"
+set -ex
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "NVM_SET_COLORS did not fail with invalid input; got >${OUTPUT}, < expected >${EXPECTED_OUTPUT}<"
+
+# test invalid color codes
+set +ex
+OUTPUT="$(echo $(nvm set-colors p3gq7 2>&1) | awk '{ print substr($0, length($0)-92, 93); }')"
+EXPECTED_OUTPUT="$(command printf %b "\033[1;37mPlease pass in five \033[1;31mvalid color codes\033[1;37m. Choose from: rRgGbBcCyYmMkKeW\033[0m")"
+set -ex
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "NVM_SET_COLORS did not fail with invalid input; got >${OUTPUT}<, expected >${EXPECTED_OUTPUT}<"
+
+#test system does not support at least 8 colors
+nvm_has_colors() { return 1; }
+set +ex
+OUTPUT="$(echo $(nvm set-colors mcyGb 2>&1) | awk '{ print substr($0, length($0)-76, 77); }')"
+set -ex
+EXPECTED_OUTPUT="WARNING: Colors may not display because they are not supported in this shell."
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "NVM_SET_COLORS did not recognize lack of color support; got >${OUTPUT}<, expected >${EXPECTED_OUTPUT}<"
+
+cleanup

--- a/test/fast/Unit tests/nvm_get_colors
+++ b/test/fast/Unit tests/nvm_get_colors
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; cleanup ; exit 1; }
+
+cleanup() {
+  unset NVM_COLORS
+  if [ -n TEMP_NVM_COLORS ]; then
+    export NVM_COLORS=TEMP_NVM_COLORS
+  fi
+  unset TEMP_NVM_COLORS
+}
+
+\. ../../../nvm.sh
+
+# NVM_COLORS is not set
+if [ -n ${NVM_COLORS} ]; then
+  export TEMP_NVM_COLORS=NVM_COLORS
+  unset NVM_COLORS
+fi
+OUTPUT=$(nvm_get_colors 1)
+EXPECTED_OUTPUT='0;34m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (INSTALLED_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 2)
+EXPECTED_OUTPUT='0;33m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (SYSTEM_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 3)
+EXPECTED_OUTPUT='0;32m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (CURRENT_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 4)
+EXPECTED_OUTPUT='0;31m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (NOT_INSTALLED_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 5)
+EXPECTED_OUTPUT='0;37m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (DEFAULT_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 6)
+EXPECTED_OUTPUT='1;33m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (LTS_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+# bad parameter
+set +ex # needed for stderr
+OUTPUT=$(nvm_get_colors bad 2>&1)
+set -ex
+EXPECTED_OUTPUT="Invalid color index, bad"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors did not have an error with bad output; got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+# NVM_COLORS is set
+nvm set-colors rgbyc
+OUTPUT=$(nvm_get_colors 1)
+EXPECTED_OUTPUT='0;31m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (INSTALLED_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 2)
+EXPECTED_OUTPUT='0;32m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (SYSTEM_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 3)
+EXPECTED_OUTPUT='0;34m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (CURRENT_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 4)
+EXPECTED_OUTPUT='0;33m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (NOT_INSTALLED_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 5)
+EXPECTED_OUTPUT='0;36m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (DEFAULT_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+OUTPUT=$(nvm_get_colors 6)
+EXPECTED_OUTPUT='1;32m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_get_colors failed to return default color (LTS_COLOR); got >${OUTPUT}< expected >${EXPECTED_OUTPUT}<"
+
+cleanup

--- a/test/fast/Unit tests/nvm_print_color_code
+++ b/test/fast/Unit tests/nvm_print_color_code
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+# Testing valid input
+OUTPUT=$(nvm_print_color_code m)
+EXPECTED_OUTPUT='0;35m'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_print_color_code returned wrong code; got $(echo ">$OUTPUT<") expected $(echo ">$EXPECTED_OUTPUT<")"
+
+# Testing invalid input
+set +x # needed for stderr
+OUTPUT="$(nvm_print_color_code q 2>&1)" ||:
+set -x
+echo "OUTPUT WAS SET TO: $OUTPUT"
+EXPECTED_OUTPUT="Invalid color code"
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_print_color_code did not recognize the invalid input; got $(echo ">$OUTPUT<") expected $(echo ">$EXPECTED_OUTPUT<")"


### PR DESCRIPTION
Fixes #1000 : Configurable output colors

We've added a --set-colors command and a related message in the help menu to let the user pass in five color codes and we replaced the colors in the ls, alias and ls-remote functions with the color codes set to the original defaults so that they can be changed by the user's choice.

We looked for other functions that might output in color but didn't see others. Please advise if there are others that need colors.

We tested by running the commands in the terminal, but did not add tests for these changes.
