### PR TITLE
Remove ShellCheck Segmentation fault workaround in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,10 +69,8 @@ RUN apt update         && \
 RUN wget https://storage.googleapis.com/shellcheck/shellcheck-v$SHELLCHECK_VERSION.linux.x86_64.tar.xz -O- | \
     tar xJvf - shellcheck-v$SHELLCHECK_VERSION/shellcheck          && \
     mv shellcheck-v$SHELLCHECK_VERSION/shellcheck /bin             && \
-    rmdir shellcheck-v$SHELLCHECK_VERSION                          && \
-    touch /tmp/libc.so.6                                           && \
-    echo "alias shellcheck='LD_LIBRARY_PATH=/tmp /bin/shellcheck'" >> /etc/bash.bashrc
-RUN LD_LIBRARY_PATH=/tmp shellcheck -V
+    rmdir shellcheck-v$SHELLCHECK_VERSION
+RUN shellcheck -V
 
 # Set locale
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
The workaround came from this GitHub issue comment:
https://github.com/koalaman/shellcheck/issues/1053#issuecomment-357816927

Looks like the problem doesn't exist any more:

```
.
.
.
Step 14/33 : RUN shellcheck -V
 ---> Running in 4b7a718c1cbf
ShellCheck - shell script analysis tool
version: 0.7.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
.
.
.
```

The workaround should be removed so that the Dockerfile will be easier
to be understand and read.