### PR TITLE
Add missing apt pacakge `locales` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt update         && \
         file                  \
         openssl               \
         libssl-dev            \
+        locales               \
         ca-certificates       \
         ssh                   \
         wget                  \


### PR DESCRIPTION
locale-gen command seems missing since uncertain point for a while:

```
Step 15/33 : RUN locale-gen en_US.UTF-8
 ---> Running in fae073c89c01
 /bin/bash: locale-gen: command not found
 The command '/bin/bash -o pipefail -c locale-gen en_US.UTF-8' returned
 a non-zero code: 127
```

This patch should fix the Docker image build