### PR TITLE
Drop deprecated `sudo:` option in TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: generic
 dist: xenial
-sudo: required
 addons:
   apt:
     packages:


### PR DESCRIPTION
That config was deprecated for a while, reference:
- https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures