### PR TITLE
ls-remote accepts versions ending with a dot

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1240,6 +1240,10 @@ nvm_ls_remote_index_tab() {
   local PATTERN
   PATTERN="${3-}"
 
+  if [ "${PATTERN#"${PATTERN%?}"}" = '.' ]; then
+    PATTERN="${PATTERN%.}"
+  fi
+
   local VERSIONS
   if [ -n "${PATTERN}" ] && [ "${PATTERN}" != '*' ]; then
     if [ "${FLAVOR}" = 'iojs' ]; then

--- a/test/fast/Unit tests/nvm_ls_remote
+++ b/test/fast/Unit tests/nvm_ls_remote
@@ -40,6 +40,19 @@ v0.3.8"
 
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_ls_remote 0.3 did not output 0.3.x versions; got $OUTPUT"
 
+OUTPUT="$(nvm_ls_remote 0.3.)"
+EXPECTED_OUTPUT="v0.3.0
+v0.3.1
+v0.3.2
+v0.3.3
+v0.3.4
+v0.3.5
+v0.3.6
+v0.3.7
+v0.3.8"
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "nvm_ls_remote 0.3. did not output 0.3.x versions; got $OUTPUT"
+
 # Sanity checks
 OUTPUT="$(nvm_print_implicit_alias remote stable)"
 EXPECTED_OUTPUT_PATH="${MOCKS_DIR}/nvm_print_implicit_alias remote stable.txt"


### PR DESCRIPTION
## Issue:
nvm ls-remote will not filter versions ending with "."
Resolves issue #983.

### Example: 
```
$ nvm ls-remote 5
->       v5.0.0
         v5.1.0
         v5.1.1
         v5.2.0
         v5.3.0
         v5.4.0
         v5.4.1
         v5.5.0
         v5.6.0
         v5.7.0
         v5.7.1
         v5.8.0
         v5.9.0
         v5.9.1
        v5.10.0
        v5.10.1
        v5.11.0
        v5.11.1
        v5.12.0
```
 
```
$ nvm ls-remote 5.
            N/A
```
### After change: 
```
$ nvm ls-remote 5.
->       v5.0.0
         v5.1.0
         v5.1.1
         v5.2.0
         v5.3.0
         v5.4.0
         v5.4.1
         v5.5.0
         v5.6.0
         v5.7.0
         v5.7.1
         v5.8.0
         v5.9.0
         v5.9.1
        v5.10.0
        v5.10.1
        v5.11.0
        v5.11.1
        v5.12.0
  ```