### PR TITLE
[readme] bash shell integration: Amended example to call cd when booting a terminal (previously only called on cd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ If you prefer a lighter-weight solution, the recipes below have been contributed
 Put the following at the end of your `$HOME/.bashrc`:
 
 ```bash
-find-up () {
+find-up() {
     path=$(pwd)
     while [[ "$path" != "" && ! -e "$path/$1" ]]; do
         path=${path%/*}
@@ -471,7 +471,7 @@ find-up () {
     echo "$path"
 }
 
-cdnvm(){
+cdnvm() {
     cd "$@";
     nvm_path=$(find-up .nvmrc | tr -d '\n')
 
@@ -514,6 +514,7 @@ cdnvm(){
     fi
 }
 alias cd='cdnvm'
+cd $PWD
 ```
 
 This alias would search 'up' from your current directory in order to detect a `.nvmrc` file. If it finds it, it will switch to that version; if not, it will use the default version.


### PR DESCRIPTION
Automatically call `nvm use`: Ammended the bash script example to call `nvm use` when booting a terminal (previously only called on `cd`).
It means the node version is correctly set for example in VS Code's integrated terminal.