### PR TITLE
[Fix] `nvm_die_on_prefix`: use directory comparison rather than string

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2231,7 +2231,7 @@ nvm_die_on_prefix() {
   local NVM_OS
   NVM_OS="$(nvm_get_os)"
   NVM_NPM_PREFIX="$(npm config --loglevel=warn get prefix)"
-  if [ "${NVM_VERSION_DIR}" != "${NVM_NPM_PREFIX}" ] && ! (nvm_tree_contains_path "${NVM_VERSION_DIR}" "${NVM_NPM_PREFIX}" >/dev/null 2>&1); then
+  if [ ! "${NVM_VERSION_DIR}" -ef "${NVM_NPM_PREFIX}" ] && ! (nvm_tree_contains_path "${NVM_VERSION_DIR}" "${NVM_NPM_PREFIX}" >/dev/null 2>&1); then
     if [ "_${NVM_DELETE_PREFIX}" = "_1" ]; then
       npm config --loglevel=warn delete prefix
     else

--- a/nvm.sh
+++ b/nvm.sh
@@ -1089,6 +1089,7 @@ nvm_ls() {
     esac
 
     nvm_is_zsh && setopt local_options shwordsplit
+    nvm_is_zsh && unsetopt local_options markdirs
 
     local NVM_DIRS_TO_SEARCH1
     NVM_DIRS_TO_SEARCH1=''

--- a/test/fast/Listing versions/Running "nvm ls" should not show a trailing slash
+++ b/test/fast/Listing versions/Running "nvm ls" should not show a trailing slash
@@ -1,0 +1,40 @@
+#!/bin/zsh
+
+\. ../../../nvm.sh
+\. ../../common.sh
+
+if type setopt >/dev/null 2>&1; then setopt local_options markdirs; fi
+
+die () {
+  if type unsetopt >/dev/null 2>&1; then unsetopt local_options markdirs; fi
+  echo "$@";
+  exit 1;
+}
+
+make_fake_node v0.0.1
+make_fake_node v0.0.3
+make_fake_node v0.0.9
+make_fake_node v0.3.1
+make_fake_node v0.3.3
+make_fake_node v0.3.9
+make_fake_node v0.12.87
+make_fake_node v0.12.9
+make_fake_iojs v0.1.2
+make_fake_iojs v0.10.2
+
+OUTPUT="$(nvm_ls)"
+EXPECTED_OUTPUT="v0.0.1
+v0.0.3
+v0.0.9
+iojs-v0.1.2
+v0.3.1
+v0.3.3
+v0.3.9
+iojs-v0.10.2
+v0.12.9
+v0.12.87"
+if nvm_has_system_node || nvm_has_system_iojs; then
+  EXPECTED_OUTPUT="${EXPECTED_OUTPUT}
+system"
+fi
+[ "${OUTPUT-}" = "${EXPECTED_OUTPUT-}" ] || die "expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"

--- a/test/fast/Unit tests/nvm_die_on_prefix
+++ b/test/fast/Unit tests/nvm_die_on_prefix
@@ -1,11 +1,22 @@
 #!/bin/sh
 
+TEST_PWD=$(pwd)
+TEST_DIR="$TEST_PWD/nvm_die_on_prefix_tmp"
+
 cleanup () {
+  rm -rf "$TEST_DIR"
   alias nvm_has='\nvm_has'
   alias npm='\npm'
   unset -f nvm_has npm
 }
-die () { echo "$@" ; exit 1; }
+
+die () {
+  echo "$@";
+  cleanup;
+  exit 1;
+}
+
+[ ! -e "$TEST_DIR" ] && mkdir "$TEST_DIR"
 
 \. ../../../nvm.sh
 
@@ -40,8 +51,23 @@ npm() {
     echo "$(nvm_version_dir new)/good prefix"
   fi
 }
+
 OUTPUT="$(nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
 [ -z "$OUTPUT" ] || die "'nvm_die_on_prefix' was not a noop when prefix is good; got '$OUTPUT'"
+
+mkdir -p "$(nvm_version_dir new)"
+ln -s "$(nvm_version_dir new)" "$TEST_DIR/node"
+
+npm() {
+  local args
+  args="$@"
+  if [ "_$args" = "_config --loglevel=warn get prefix" ]; then
+    echo "$TEST_DIR/node"
+  fi
+}
+
+OUTPUT="$(nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
+[ -z "$OUTPUT" ] || die "'nvm_die_on_prefix' was not a noop when directory is equivalent; got '$OUTPUT'"
 
 OUTPUT="$(PREFIX=bar nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
 EXPECTED_OUTPUT='nvm is not compatible with the "PREFIX" environment variable: currently set to "bar"


### PR DESCRIPTION
Fixes #2315 

This changes out a string comparison to a directory comparison, removes empty lines from versions, and removes trailing slashes from versions.