### PR TITLE
[Perf] `use`/`nvm_die_on_prefix`: replicate npm config algorithm and remove `npm config` call

### DIFF
--- a/test/fast/Unit tests/nvm_die_on_prefix
+++ b/test/fast/Unit tests/nvm_die_on_prefix
@@ -3,6 +3,10 @@
 TEST_PWD=$(pwd)
 TEST_DIR="$TEST_PWD/nvm_die_on_prefix_tmp"
 
+\. ../../../nvm.sh
+
+TEST_VERSION_DIR="${TEST_DIR}/version"
+
 cleanup () {
   rm -rf "$TEST_DIR"
   alias nvm_has='\nvm_has'
@@ -17,8 +21,6 @@ die () {
 }
 
 [ ! -e "$TEST_DIR" ] && mkdir "$TEST_DIR"
-
-\. ../../../nvm.sh
 
 OUTPUT="$(nvm_die_on_prefix 2>&1)"
 EXPECTED_OUTPUT="First argument \"delete the prefix\" must be zero or one"
@@ -43,14 +45,6 @@ OUTPUT="$(nvm_die_on_prefix 0 version_dir foo 2>&1)"
 [ -z "$OUTPUT" ] || die "nvm_die_on_prefix was not a noop when nvm_has returns 1, got '$OUTPUT'"
 
 nvm_has() { return 0; }
-
-npm() {
-  local args
-  args="$@"
-  if [ "_$args" = "_config --loglevel=warn get prefix" ]; then
-    echo "$(nvm_version_dir new)/good prefix"
-  fi
-}
 
 OUTPUT="$(nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
 [ -z "$OUTPUT" ] || die "'nvm_die_on_prefix' was not a noop when prefix is good; got '$OUTPUT'"
@@ -90,18 +84,106 @@ EXIT_CODE="$(export npm_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo "$(nvm_versi
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
 [ "_$EXIT_CODE" = "_4" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 4; got '$EXIT_CODE'"
 
-npm() {
-  local args
-  args="$@"
-  if [ "_$args" = "_config --loglevel=warn get prefix" ]; then
-    echo "./bad prefix"
-  fi
-}
-OUTPUT="$(nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
-EXPECTED_OUTPUT="nvm is not compatible with the npm config \"prefix\" option: currently set to \"./bad prefix\"
-Run \`npm config delete prefix\` or \`foo\` to unset it."
-EXIT_CODE="$(nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" >/dev/null 2>&1; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT' with bad prefix set; got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' did not exit with 10 with bad prefix set; got '$EXIT_CODE'"
+# npmrc tests
+(
+  cd "${TEST_DIR}"
+  touch package.json
+
+  # project: prefix
+  echo 'prefix=garbage' > .npmrc
+  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  EXPECTED_OUTPUT="Your project npmrc file ($(nvm_sanitize_path "${TEST_DIR}")/.npmrc)
+has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
+Run \`foo\` to unset it."
+  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
+  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has prefix did not exit with 10; got '$EXIT_CODE'"
+
+  # project: globalconfig
+  echo 'globalconfig=garbage' > .npmrc
+  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  EXPECTED_OUTPUT="Your project npmrc file ($(nvm_sanitize_path "${TEST_DIR}")/.npmrc)
+has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
+Run \`foo\` to unset it."
+  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
+  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has globalconfig did not exit with 10; got '$EXIT_CODE'"
+
+  rm "${TEST_DIR}/.npmrc" || die '.npmrc could not be removed'
+
+  mkdir -p "${TEST_VERSION_DIR}"
+  GLOBAL_NPMRC="${TEST_VERSION_DIR}/etc/npmrc"
+  mkdir -p "${TEST_VERSION_DIR}/etc"
+
+  BUILTIN_NPMRC="${TEST_VERSION_DIR}/lib/node_modules/npm/npmrc"
+  mkdir -p "${TEST_VERSION_DIR}/lib/node_modules/npm/"
+
+  export HOME="${TEST_VERSION_DIR}"
+  USER_NPMRC="${TEST_VERSION_DIR}/.npmrc"
+
+  # global: prefix
+  echo 'prefix=garbage' > "${GLOBAL_NPMRC}"
+  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  EXPECTED_OUTPUT="Your global npmrc file ($(nvm_sanitize_path "${GLOBAL_NPMRC}"))
+has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
+Run \`foo\` to unset it."
+  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
+  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has prefix did not exit with 10; got '$EXIT_CODE'"
+
+  # global: globalconfig
+  echo 'globalconfig=garbage' > "${GLOBAL_NPMRC}"
+  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  EXPECTED_OUTPUT="Your global npmrc file ($(nvm_sanitize_path "${GLOBAL_NPMRC}"))
+has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
+Run \`foo\` to unset it."
+  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
+  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has globalconfig did not exit with 10; got '$EXIT_CODE'"
+
+  rm "${GLOBAL_NPMRC}" || die "${GLOBAL_NPMRC} could not be removed"
+
+  # builtin: prefix
+  echo 'prefix=garbage' > "${BUILTIN_NPMRC}"
+  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  EXPECTED_OUTPUT="Your builtin npmrc file ($(nvm_sanitize_path "${BUILTIN_NPMRC}"))
+has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
+Run \`foo\` to unset it."
+  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
+  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has prefix did not exit with 10; got '$EXIT_CODE'"
+
+  # builtin: globalconfig
+  echo 'globalconfig=garbage' > "${BUILTIN_NPMRC}"
+  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  EXPECTED_OUTPUT="Your builtin npmrc file ($(nvm_sanitize_path "${BUILTIN_NPMRC}"))
+has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
+Run \`foo\` to unset it."
+  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
+  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has globalconfig did not exit with 10; got '$EXIT_CODE'"
+
+  rm "${BUILTIN_NPMRC}" || die "${BUILTIN_NPMRC} could not be removed"
+
+  # user: prefix
+  echo 'prefix=garbage' > "${USER_NPMRC}"
+  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  EXPECTED_OUTPUT="Your user’s .npmrc file ($(nvm_sanitize_path "${USER_NPMRC}"))
+has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
+Run \`foo\` to unset it."
+  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
+  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has prefix did not exit with 10; got '$EXIT_CODE'"
+
+  # user: globalconfig
+  echo 'globalconfig=garbage' > "${USER_NPMRC}"
+  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  EXPECTED_OUTPUT="Your user’s .npmrc file ($(nvm_sanitize_path "${USER_NPMRC}"))
+has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
+Run \`foo\` to unset it."
+  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
+  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has globalconfig did not exit with 10; got '$EXIT_CODE'"
+)
 
 cleanup


### PR DESCRIPTION
Fixes #2251. Fixes #1774. Fixes #1694. Fixes #1277. Fixes #1261. Fixes #1242. Fixes #966. Fixes #926. Fixes #860. Fixes #781. Fixes #709. Closes #1826. Closes #730.

This PR removes the call to `npm config get prefix` on `nvm use`, instead partially replicating the algorithm npm itself uses to build up its config. Since we don't have to actually produce a config, merely detect if any option is set that would influence `npm config get prefix` (namely, `prefix` or `globalconfig`), the checks are simpler and can be done relatively quickly. Previously, #1679, 1458de72934a33b279ac3cbb9d648295501ae74d, 8ee6f3035292b46fe4067a089d2b0752f4ce0e98, and a1def710628a2fc71552a9f79f9b53f3d6a3b8db implemented partial forms of this checking. This PR specifically adds the checks for npmrc files, which allows the call to npm to be removed.