### PR TITLE
Fix `nvm_ls_current` fast unit test

### DIFF
--- a/test/fast/Unit tests/nvm_ls_current
+++ b/test/fast/Unit tests/nvm_ls_current
@@ -19,7 +19,8 @@ fi
 
 rm -rf "$TEST_DIR"
 mkdir "$TEST_DIR"
-ln -s "$(command which which)" "$TEST_DIR/which"
+# Ensure that the system version of which is used, not node_modules/.bin/which
+ln -s "$(PATH=$(echo $PATH | tr ":" "\n" | grep -v "node_modules/.bin" | tr "\n" ":") command which which)" "$TEST_DIR/which"
 ln -s "$(command which dirname)" "$TEST_DIR/dirname"
 ln -s "$(command which printf)" "$TEST_DIR/printf"
 
@@ -27,12 +28,12 @@ ln -s "$(command which printf)" "$TEST_DIR/printf"
 [ "@$(PATH="$TEST_DIR" nvm_ls_current 2> /dev/stdout 1> /dev/null)@" = "@@" ] || die 'when node not installed, nvm_ls_current returned error output'
 
 echo "#!/bin/bash" > "$TEST_DIR/node"
-echo "echo 'VERSION FOO!'" > "$TEST_DIR/node"
+echo "echo 'VERSION FOO!'" >> "$TEST_DIR/node"
 chmod a+x "$TEST_DIR/node"
 
-[ "$(alias nvm_tree_contains_path='return_zero' && PATH="$TEST_DIR" nvm_ls_current)" = "VERSION FOO!" ] || die 'when activated, did not return nvm node version'
+[ "$(PATH="$TEST_DIR" nvm_ls_current)" = "VERSION FOO!" ] || die 'when activated, did not return nvm node version'
 
 alias node='node --harmony'
-[ "$(alias nvm_tree_contains_path='return_zero' && PATH="$TEST_DIR" nvm_ls_current)" = "VERSION FOO!" ] || die 'when activated and node aliased, did not return nvm node version'
+[ "$(PATH="$TEST_DIR" nvm_ls_current)" = "VERSION FOO!" ] || die 'when activated and node aliased, did not return nvm node version'
 
 cleanup


### PR DESCRIPTION
Fixes one of the failing tests in #2181

`nvm_ls_current` returns 'system' when `nvm_tree_contains_path` is aliased to return zero, as if nvm is deactivated. This fix instead sets `NVM_DIR` to match `TEST_DIR` so that `nvm_tree_contains_path` passes and the mock executable is actually used. Let me know if this approach is reasonable!

Relevant branches in `nvm_ls_current`:
https://github.com/nvm-sh/nvm/blob/e01060fa2c331d77e306a90288b759010e14758e/nvm.sh#L915-L925