### PR TITLE
[Tests] Run fast test suite in clean environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make test-$shell",
-    "test/fast": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=fast test-$shell",
+    "test/fast": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); env -i TERM=\"$TERM\" bash -lc \"make TEST_SUITE=fast test-$shell\"",
     "test/slow": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=slow test-$shell",
     "test/install_script": "shell=$(basename -- $(ps -o comm= $(ps -o ppid= -p $PPID)) | sed 's/^-//'); make TEST_SUITE=install_script test-$shell",
     "test/installation": "npm run --silent test/installation/node && npm run --silent test/installation/iojs",

--- a/test/fast/Running "nvm use iojs" uses latest io.js version
+++ b/test/fast/Running "nvm use iojs" uses latest io.js version
@@ -27,7 +27,9 @@ EXPECTED_OUTPUT="$(nvm_add_iojs_prefix ${VERSION})"
 
 nvm use --delete-prefix iojs || die '`nvm use iojs` failed'
 
-CURRENT="$(nvm current)"
+# Remove node_modules/.bin from the path so that the system version `which` is
+# used in nvm_ls_current
+PATH=$(echo "$PATH" | tr ":" "\n" | grep -v "node_modules/.bin" | tr "\n" ":") CURRENT="$(nvm current)"
 echo "current: ${CURRENT}"
 
 [ "${CURRENT}" = "${IOJS_VERSION}" ] || die "expected >${IOJS_VERSION}<; got >${CURRENT}<"


### PR DESCRIPTION
Fixes #2181

This makes `npm run test/fast` start the test suite from within a fresh login shell, effectively removing the `NPM_CONFIG_...` variables that caused most tests to fail in #2181. I've run this in both zsh and bash, and all fast tests pass.

`$TERM` is included in the fresh environment to prevent tests that rely on the color output of `nvm_print_formatted_alias` from failing. 

`node_modules/.bin` is still added to the path by the makefile, so I temporarily remove it in `test/fast/Running "nvm use iojs" uses latest io.js version` for the same reason as #2322.

This change could probably work for the other suites too! I just haven't dug into that yet... let me know what you think! :)
