### PR TITLE
Remove useless -q option in `ls` command

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1121,13 +1121,13 @@ nvm_ls() {
       fi
     fi
 
-    if ! [ -d "${NVM_DIRS_TO_SEARCH1}" ] || ! (command ls -1qA "${NVM_DIRS_TO_SEARCH1}" | nvm_grep -q .); then
+    if ! [ -d "${NVM_DIRS_TO_SEARCH1}" ] || ! (command ls -1A "${NVM_DIRS_TO_SEARCH1}" | nvm_grep -q .); then
       NVM_DIRS_TO_SEARCH1=''
     fi
-    if ! [ -d "${NVM_DIRS_TO_SEARCH2}" ] || ! (command ls -1qA "${NVM_DIRS_TO_SEARCH2}" | nvm_grep -q .); then
+    if ! [ -d "${NVM_DIRS_TO_SEARCH2}" ] || ! (command ls -1A "${NVM_DIRS_TO_SEARCH2}" | nvm_grep -q .); then
       NVM_DIRS_TO_SEARCH2="${NVM_DIRS_TO_SEARCH1}"
     fi
-    if ! [ -d "${NVM_DIRS_TO_SEARCH3}" ] || ! (command ls -1qA "${NVM_DIRS_TO_SEARCH3}" | nvm_grep -q .); then
+    if ! [ -d "${NVM_DIRS_TO_SEARCH3}" ] || ! (command ls -1A "${NVM_DIRS_TO_SEARCH3}" | nvm_grep -q .); then
       NVM_DIRS_TO_SEARCH3="${NVM_DIRS_TO_SEARCH2}"
     fi
 


### PR DESCRIPTION
This commit prevent the error which says '-q' option isn't supported being shown on minimal distros or unsupported distros such as Alpine Linux (uses busybox). Also, '-q' option in ls command isn't actually required because what '-q' option does is just prints '?' character instead of nongraphic characters. (Prevent error being shown)

## References

- https://linuxcommand.org/lc3_man_pages/ls1.html

       -q, --hide-control-chars
              print ? instead of nongraphic characters

## Related issues

#2059 [alpinelinux] ls: unrecognized option: q

## Comments

For manual fixes, restarting shell is required after hardcoding the nvm.sh file. The file is located in '~/.nvm/nvm.sh'.