### PR TITLE
[Fix] `nvm_die_on_prefix`: only grep lines starting with env var name

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2224,7 +2224,7 @@ nvm_die_on_prefix() {
   # here, we avoid trying to replicate "which one wins" or testing the value; if any are defined, it errors
   # until none are left.
   local NVM_NPM_CONFIG_PREFIX_ENV
-  NVM_NPM_CONFIG_PREFIX_ENV="$(command env | nvm_grep -i NPM_CONFIG_PREFIX | command tail -1 | command awk -F '=' '{print $1}')"
+  NVM_NPM_CONFIG_PREFIX_ENV="$(command env | nvm_grep -i ^NPM_CONFIG_PREFIX | command tail -1 | command awk -F '=' '{print $1}')"
   if [ -n "${NVM_NPM_CONFIG_PREFIX_ENV-}" ]; then
     local NVM_CONFIG_VALUE
     eval "NVM_CONFIG_VALUE=\"\$${NVM_NPM_CONFIG_PREFIX_ENV}\""

--- a/test/fast/Unit tests/nvm_die_on_prefix
+++ b/test/fast/Unit tests/nvm_die_on_prefix
@@ -84,6 +84,9 @@ EXIT_CODE="$(export npm_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo "$(nvm_versi
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
 [ "_$EXIT_CODE" = "_4" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 4; got '$EXIT_CODE'"
 
+OUTPUT="$(export FOO='NPM_CONFIG_PREFIX' ; nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
+[ -z "$OUTPUT" ] || die "'nvm_die_on_prefix' was not a noop; got '$OUTPUT'"
+
 # npmrc tests
 (
   cd "${TEST_DIR}"


### PR DESCRIPTION
This restricts the lines found when searching for `NPM_CONFIG_PREFIX` env vars.

I had trouble getting nvm to work in AWS CodeBuild, because the env vars contained entries such as:

```
BASH_FUNC_nvm()=() {
  # This contains the complete code of nvm...
}
```

Any line containing `NPM_CONFIG_PREFIX` would get selected and evaluated, resulting in very strange error messages:

```
Running command [ -s $NVM_DIR/nvm.sh ] && . $NVM_DIR/nvm.sh
/usr/local/nvm/nvm.sh: line 2230: $(nvm_sanitize_path "${NPM_CONFIG_PREFIX}");: command not found
```

I have to idea why these env vars exist, but this change ensures that they are ignored.

I've added a test case as well, but I haven't run the full test suite. Someone more familiar with nvm may have to double-check this.