### PR TITLE
[Fix] `install`: Ignore npm command under $NVM_DIR when checking for global modules

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -262,7 +262,9 @@ nvm_detect_profile() {
 # Node, and warn them if so.
 #
 nvm_check_global_modules() {
-  command -v npm >/dev/null 2>&1 || return 0
+  local NPM_COMMAND
+  NPM_COMMAND="$(command -v npm 2>/dev/null)" || return 0
+  [ -n "${NVM_DIR}" ] && [ -z "${NPM_COMMAND%%$NVM_DIR/*}" ] && return 0
 
   local NPM_VERSION
   NPM_VERSION="$(npm --version)"

--- a/test/install_script/nvm_check_global_modules
+++ b/test/install_script/nvm_check_global_modules
@@ -6,9 +6,10 @@ cleanup () {
 
   rm -f npm
   PATH="$ORIGINAL_PATH"
+  NVM_DIR="$ORIGINAL_NVM_DIR"
 
   unset -f setup cleanup die
-  unset message ORIGINAL_PATH
+  unset message ORIGINAL_PATH ORIGINAL_NVM_DIR
 }
 die () { echo "$@" ; cleanup ; exit 1; }
 
@@ -16,6 +17,10 @@ NVM_ENV=testing \. ../../install.sh
 
 setup () {
   ORIGINAL_PATH="$PATH"
+  ORIGINAL_NVM_DIR="$NVM_DIR"
+
+  # Pretend we're not using NVM
+  unset NVM_DIR
 
   npm_config_prefix="$(pwd)"
   export npm_config_prefix
@@ -28,6 +33,10 @@ setup
 npm install -g nop >/dev/null || die 'nvm_check_global_modules cannot be tested because `npm` cannot install the `nop` package'
 message=$(nvm_check_global_modules)
 [ ! -z "$message" ] || die "nvm_check_global_modules should have printed a notice when npm had global modules installed"
+
+# Admit we're using NVM, just for this one test
+message=$(NVM_DIR=$ORIGINAL_NVM_DIR nvm_check_global_modules)
+[ -z "$message" ] || die "nvm_check_global_modules should not have printed a notice when npm is managed by nvm"
 
 npm uninstall -g nop >/dev/null
 message=$(nvm_check_global_modules)


### PR DESCRIPTION
It's an especially clever check — just a substring match — but should cover a typical situation.

Fixes #2339.