### PR TITLE
[actions] Add shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,31 @@
+name: "Tests: shellcheck"
+
+on: [pull_request, push]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shell:
+          - bash
+          - sh
+          - dash
+          - ksh
+        file:
+          - nvm.sh
+        include:
+          - shell: bash
+            file: install.sh # only supported on bash
+          - shell: bash
+            file: bash_completion # only needed in bash/zsh
+          - shell: bash
+            file: nvm-exec # only runs in bash
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install shellcheck
+        run: brew install shellcheck
+      - run: "shellcheck --version"
+      - name: Run shellcheck on ${{ matrix.file }}
+        run: shellcheck -s ${{ matrix.shell }} ${{ matrix.file }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
   - $SHELL --version 2> /dev/null || dpkg -s $SHELL 2> /dev/null || which $SHELL
   - curl --version
   - wget --version
-  - shellcheck --version
 install:
   - if [ -z "${SHELLCHECK-}" ]; then nvm install node && npm install && npm prune && npm ls urchin doctoc eclint dockerfile_lint; fi
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
@@ -27,8 +26,6 @@ script:
   - if [ -n "${DOCTOCCHECK-}" ]; then cp README.md README.md.orig && npm run doctoc && diff -q README.md README.md.orig ; fi
   - if [ -n "${ECLINT-}" ]; then npm run eclint ; fi
   - if [ -n "${DOCKERFILE_LINT-}" ]; then npm run dockerfile_lint ; fi
-  - if [ -n "${SHELLCHECK-}" ]; then shellcheck -s bash nvm.sh && shellcheck -s sh nvm.sh && shellcheck -s dash nvm.sh && shellcheck -s ksh nvm.sh ; fi
-  - if [ -n "${SHELLCHECK-}" ]; then shellcheck -s bash install.sh bash_completion nvm-exec ; fi
   - if [ -n "${SHELL-}" ] && [ -n "${TEST_SUITE}" ]; then if [ "${TEST_SUITE}" = 'installation_iojs' ]; then travis_retry make TEST_SUITE=$TEST_SUITE URCHIN="$(npm bin)/urchin" test-$SHELL ; else make TEST_SUITE=$TEST_SUITE URCHIN="$(npm bin)/urchin" test-$SHELL; fi; fi
 before_cache:
   - if [ -n "$WITHOUT_CURL" ]; then sudo apt-get install curl -y ; fi
@@ -43,7 +40,6 @@ env:
   matrix:
     - MAKE_RELEASE=true
     - DOCTOCCHECK=true
-    - SHELLCHECK=true
     - ECLINT=true
     - DOCKERFILE_LINT=true
     - SHELL=bash TEST_SUITE=install_script


### PR DESCRIPTION
This adds a github workflow that runs shellcheck on `nvm.sh` and `install.sh`. `nvm.sh` is tested with each shell in `[bash, sh, dash, ksh]` and `install.sh` is tested with just `bash`. I think submitting this PR should run the workflow, but just in case, [here](https://github.com/reasonablytall/nvm/actions/runs/370757305) is an example of this change running on my fork.

Unfortunately shellcheck [does not support zsh](https://github.com/koalaman/shellcheck/issues/809), which is why it's omitted from the matrix.

I ignored [SC1001](https://github.com/koalaman/shellcheck/wiki/SC1001) in nvm.sh because there are three instances where `\command ...` is used (i'm guessing) to suppress aliases. More recent versions of shellcheck automatically ignore these instances, but not the older version available on the ubuntu-based github runners. Alternatively, I could ignore the specific lines in nvm.sh rather than globally ignoring SC1001, or I could figure out a way to manually install a more recent version of shellcheck. Let me know!

