### PR TITLE
[Fix] `exec`: `--` should stop argument parsing

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2612,6 +2612,7 @@ nvm() {
   for i in "$@"
   do
     case $i in
+      --) break ;;
       '-h'|'help'|'--help')
         NVM_NO_COLORS=""
         for j in "$@"; do

--- a/test/slow/nvm exec/Running 'nvm exec' with help should not parse
+++ b/test/slow/nvm exec/Running 'nvm exec' with help should not parse
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+nvm use 0.10
+
+nvm exec stable -- node --help | grep 'Usage: node [options]' || die "Help menu should have been displayed for node and not nvm"


### PR DESCRIPTION
Running `nvm exec stable -- node --help` shows nvm's help, not node's. This change stops help parsing when encountering a `--`.