### PR TITLE
[actions] Add release test workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: "Tests: release process"
+
+on: [pull_request, push]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: "14"
+      - run: npm install
+      - name: Configure git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git fetch --unshallow --tags || git fetch --tags
+      - name: Attempt `make release` process
+        run: echo proceed | make TAG=99.99.99 release
+        env:
+          GIT_EDITOR: "sed -i '1 s/^/99.99.99 make release test/'"
+      - name: Ensure tag is created
+        run: git tag | grep v99.99.99

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
   - if [ -z "${SHELLCHECK-}" ]; then nvm install node && npm install && npm prune && npm ls urchin doctoc eclint dockerfile_lint; fi
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
-  - if [ -n "${MAKE_RELEASE-}" ]; then export GIT_EDITOR="sed -i '1 s/^/99.99.99 make release test/'" && git fetch --unshallow --tags && echo proceed | make TAG=99.99.99 release ; fi
   - if [ -n "${DOCTOCCHECK-}" ]; then cp README.md README.md.orig && npm run doctoc && diff -q README.md README.md.orig ; fi
   - if [ -n "${ECLINT-}" ]; then npm run eclint ; fi
   - if [ -n "${DOCKERFILE_LINT-}" ]; then npm run dockerfile_lint ; fi
@@ -38,7 +37,6 @@ env:
     - PATH="/usr/lib/ccache/:$PATH"
     - NVM_DIR="${TRAVIS_BUILD_DIR}"
   matrix:
-    - MAKE_RELEASE=true
     - DOCTOCCHECK=true
     - ECLINT=true
     - DOCKERFILE_LINT=true
@@ -47,17 +45,17 @@ env:
     - SHELL=dash TEST_SUITE=fast
     - SHELL=bash TEST_SUITE=fast
     - SHELL=zsh TEST_SUITE=fast
-  #  - SHELL=ksh TEST_SUITE=fast
+    #  - SHELL=ksh TEST_SUITE=fast
     - SHELL=sh TEST_SUITE=sourcing
     - SHELL=dash TEST_SUITE=sourcing
     - SHELL=bash TEST_SUITE=sourcing
     - SHELL=zsh TEST_SUITE=sourcing
-  #  - SHELL=ksh TEST_SUITE=sourcing
+    #  - SHELL=ksh TEST_SUITE=sourcing
     - SHELL=sh TEST_SUITE=slow
     - SHELL=dash TEST_SUITE=slow
     - SHELL=bash TEST_SUITE=slow
     - SHELL=zsh TEST_SUITE=slow
-  #  - SHELL=ksh TEST_SUITE=slow
+    #  - SHELL=ksh TEST_SUITE=slow
     - SHELL=sh TEST_SUITE=installation_node
     - SHELL=sh TEST_SUITE=installation_node WITHOUT_CURL=1
     - SHELL=dash TEST_SUITE=installation_node
@@ -66,8 +64,8 @@ env:
     - SHELL=bash TEST_SUITE=installation_node WITHOUT_CURL=1
     - SHELL=zsh TEST_SUITE=installation_node
     - SHELL=zsh TEST_SUITE=installation_node WITHOUT_CURL=1
-  #  - SHELL=ksh TEST_SUITE=installation_node
-  #  - SHELL=ksh TEST_SUITE=installation_node WITHOUT_CURL=1
+    #  - SHELL=ksh TEST_SUITE=installation_node
+    #  - SHELL=ksh TEST_SUITE=installation_node WITHOUT_CURL=1
     - SHELL=sh TEST_SUITE=installation_iojs
     - SHELL=sh TEST_SUITE=installation_iojs WITHOUT_CURL=1
     - SHELL=dash TEST_SUITE=installation_iojs
@@ -76,8 +74,8 @@ env:
     - SHELL=bash TEST_SUITE=installation_iojs WITHOUT_CURL=1
     - SHELL=zsh TEST_SUITE=installation_iojs
     - SHELL=zsh TEST_SUITE=installation_iojs WITHOUT_CURL=1
-  #  - SHELL=ksh TEST_SUITE=installation_iojs
-  #  - SHELL=ksh TEST_SUITE=installation_iojs WITHOUT_CURL=1
+    #  - SHELL=ksh TEST_SUITE=installation_iojs
+    #  - SHELL=ksh TEST_SUITE=installation_iojs WITHOUT_CURL=1
     - NODE=10 TEST="nvm install-latest-npm"
     - NODE=9 TEST="nvm install-latest-npm"
     - NODE=8 TEST="nvm install-latest-npm"


### PR DESCRIPTION
Adds a workflow that tests the `make release ...` process by running it with a placeholder version (`99.99.99`) and ensuring that a new tag is created. 

This replaces the previous travis process and adds the tag check as a bonus.
