### PR TITLE
[Docs] Update README - Corrects "Troubleshooting on Linux Section"

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Eg: `curl ... | NVM_DIR="path/to/nvm"`. Ensure that the `NVM_DIR` does not conta
 
 #### Troubleshooting on Linux
 
-On Linux, after running the install script, if you get `nvm: command not found` or see no feedback from your terminal after you type `command -v nvm`, simply close your current terminal, open a new terminal, and try verifying again.
+On Linux, after running the install script, if you get `nvm: command not found` or see no feedback from your terminal after you type `command nvm -v`, simply close your current terminal, open a new terminal, and try verifying again.
 
 #### Troubleshooting on macOS
 


### PR DESCRIPTION
The command "nvm -v" was inverted "-v nvm"