### PR TITLE
Use local variable when looping over args

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2554,6 +2554,7 @@ nvm() {
     return $?
   fi
 
+  local i
   for i in "$@"
   do
     case $i in


### PR DESCRIPTION
When the `nvm` function is called by a script which itself uses a variable
named `i`, `nvm` clobbers the caller's variable. This happens even if the
caller has declared its variable as local.

See note 1 on https://tldp.org/LDP/abs/html/localvar.html#FTN.AEN18568