### PR TITLE
[Issue] Adding nvm_grep in install.sh makes CI to fail

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,10 @@ nvm_has() {
   type "$1" > /dev/null 2>&1
 }
 
+nvm_grep() {
+  GREP_OPTIONS='' command grep "$@"
+}
+
 nvm_default_install_dir() {
   [ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm"
 }
@@ -423,7 +427,7 @@ nvm_reset() {
   unset -f nvm_has nvm_install_dir nvm_latest_version nvm_profile_is_bash_or_zsh \
     nvm_source nvm_node_version nvm_download install_nvm_from_git nvm_install_node \
     install_nvm_as_script nvm_try_profile nvm_detect_profile nvm_check_global_modules \
-    nvm_do_install nvm_reset nvm_default_install_dir
+    nvm_do_install nvm_reset nvm_default_install_dir nvm_grep
 }
 
 [ "_$NVM_ENV" = "_testing" ] || nvm_do_install

--- a/test/install_script/nvm_install_with_node_version
+++ b/test/install_script/nvm_install_with_node_version
@@ -6,5 +6,7 @@ die () { echo "$@" ; exit 1; }
 unset NVM_DIR
 NODE_VERSION=8 \. ../../install.sh
 
+. "${NVM_DIR}/nvm.sh"
+
 # nvm installed node 8
 nvm ls 8 > /dev/null 2>&1 || die "nvm didn't install node 8"


### PR DESCRIPTION
Simply copy/pasting nvm_grep function from nvm.sh to install.sh makes the test `nvm_install_with_node_version` to fail.