### PR TITLE
[Docs]: Tell mac user to try again with zsh in the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Since OS X 10.9, `/usr/bin/git` has been preset by Xcode command line tools, whi
 
 If you get `nvm: command not found` after running the install script, one of the following might be the reason:
 
-  - Since macOS 10.15, the default shell is `zsh` and nvm will look for `.zshrc` to update, none is installed by default. Create one with `touch ~/.zshrc` and run the install script again.
+  - Since macOS 10.15, the default shell is `zsh` and nvm will look for `.zshrc` to update, none is installed by default. Create one with `touch ~/.zshrc` and run the [install script](#install--update-script) again with `zsh` instead of `bash` in the command.
 
   - If you use bash, the previous default shell, run `touch ~/.bash_profile` to create the necessary profile file if it does not exist.
 


### PR DESCRIPTION
While trying to install `nvm` on MacOS 10.15.7 (Catalina) by using 
`curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash`
I encounter error `nvm: command not found`. The reason that the **nvm source string** is not appended to `.zshrc`, but `.bashrc`. The current README tells me to run the install script again. However, if I attempt to run `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash`, it won't work. But if I run `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | zsh`, the **nvm source string** is added to my `.zsh`.