### PR TITLE
Fix potential unbound var error on nvm install

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -3078,7 +3078,7 @@ nvm() {
           nvm_ensure_default_set "${provided_version}"
         fi
 
-        if [ -n "${ALIAS}" ]; then
+        if [ -n "${ALIAS-}" ]; then
           nvm alias "${ALIAS}" "${provided_version}"
         fi
 


### PR DESCRIPTION
As per #2420, when using `nvm install` with an already installed
version, Bash (and potentially other shells) may emit an unbound
variable error when `set -u` is set. The presence of the error depends
on specific shell versions, but appears to happen in MacOS 11.1 (Big
Sur) using a recent Bash version installed via Homebrew (as of this
writing).

The fix accesses `ALIAS` correctly for the case where it is not set by
an `alias` option to `nvm install`.