### PR TITLE
[New] `install`: add `-b` flag to skip building from source

### DIFF
--- a/test/fast/Unit tests/nvm_install_binary_nosource
+++ b/test/fast/Unit tests/nvm_install_binary_nosource
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+cleanup () {
+  nvm cache clear
+  nvm deactivate
+  rm -rf ${NVM_DIR}/v*
+  nvm unalias default
+}
+
+die () { echo "$@" ; cleanup; exit 1;}
+
+\. ../../../nvm.sh
+
+nvm_binary_available() {
+    return 1
+}
+
+# Unit test to check if the function errors out when the flag is set
+OUTPUT="$(nvm_install_binary node std 8.0.0 1 2>&1)"
+EXPECTED_OUTPUT='Binary download failed. Download from source aborted.'
+if [ "${OUTPUT#*$EXPECTED_OUTPUT}" = "${OUTPUT}" ]; then
+  die "No source binary flag is active and should have returned >${EXPECTED_OUTPUT}<. Instead it returned >${OUTPUT}<"
+fi
+
+# Unit test to check if the function errors out when the flag is set
+OUTPUT="$(nvm_install_binary node std 8.0.0 0 2>&1)"
+EXPECTED_OUTPUT='Binary download failed. Download from source aborted.'
+if [ "${OUTPUT#*$EXPECTED_OUTPUT}" != "${OUTPUT}" ]; then
+  die "No source binary flag is not active and should have downloaded from source. Instead it returned >${OUTPUT}<"
+fi

--- a/test/installation_node/install from binary with binary flag set
+++ b/test/installation_node/install from binary with binary flag set
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../nvm.sh
+
+nvm unalias default || die 'unable to unalias default'
+
+NVM_TEST_VERSION=v0.10.7
+
+# Remove the stuff we're clobbering.
+[ -e ../../$NVM_TEST_VERSION ] && rm -R ../../$NVM_TEST_VERSION
+
+# Install from binary
+nvm install -b $NVM_TEST_VERSION || die "install $NVM_TEST_VERSION failed"
+
+# Check
+[ -d ../../$NVM_TEST_VERSION ]
+nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION || die "'nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION' failed"
+
+# ensure default is set
+NVM_CURRENT_DEFAULT="$(nvm_alias default)"
+[ "$NVM_CURRENT_DEFAULT" = "$NVM_TEST_VERSION" ] || die "wrong default alias: $(nvm alias)"
+
+# Falls back to source but if -b is set fails binary download.
+OUTPUT="$(nvm install -b 9.0.0 2>&1)"
+EXPECTED_OUTPUT='Binary download failed. Download from source aborted.'
+if [ "${OUTPUT#*$EXPECTED_OUTPUT}" = "${OUTPUT}" ]; then
+  die "No source binary flag is active and should have returned >${EXPECTED_OUTPUT}<. Instead it returned >${OUTPUT}<"
+fi
+
+# Falls back to source but if -b is not set.
+OUTPUT="$(nvm install 9.0.0 2>&1)"
+EXPECTED_OUTPUT='Binary download failed. Download from source aborted.'
+if [ "${OUTPUT#*$EXPECTED_OUTPUT}" != "${OUTPUT}" ]; then
+  die "No source binary flag is active and should have returned >${EXPECTED_OUTPUT}<. Instead it returned >${OUTPUT}<"
+fi


### PR DESCRIPTION
This PR aims to add the `--b` flag that skips source download and  install from binary only.'
Closes : https://github.com/nvm-sh/nvm/issues/2114