### PR TITLE
[readme] update `cdnvm` implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,17 +503,9 @@ If you prefer a lighter-weight solution, the recipes below have been contributed
 Put the following at the end of your `$HOME/.bashrc`:
 
 ```bash
-find-up() {
-    path=$(pwd)
-    while [[ "$path" != "" && ! -e "$path/$1" ]]; do
-        path=${path%/*}
-    done
-    echo "$path"
-}
-
 cdnvm() {
     cd "$@";
-    nvm_path=$(find-up .nvmrc | tr -d '\n')
+    nvm_path=$(nvm_find_up .nvmrc | tr -d '\n')
 
     # If there are no .nvmrc file, use the default nvm version
     if [[ ! $nvm_path = *[^[:space:]]* ]]; then


### PR DESCRIPTION
当函数名为find-up时，定时运行会报以下错误：
```
`find-up': not a valid identifier
```
修改为find_up即可修复该问题