### PR TITLE
[Fix] `nvm_alias`: ensure `lts/-1` returns the one before `lts/*`

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -994,6 +994,7 @@ nvm_alias() {
   if [ "$(expr "${ALIAS}" : '^lts/-[1-9][0-9]*$')" -gt 0 ]; then
     local N
     N="$(echo "${ALIAS}" | cut -d '-' -f 2)"
+    N=$((N+1))
     local RESULT
     RESULT="$(command ls "${NVM_ALIAS_DIR}/lts" | command tail -n "${N}" | command head -n 1)"
     if [ "${RESULT}" != '*' ]; then

--- a/test/fast/Unit tests/nvm_alias LTS-N
+++ b/test/fast/Unit tests/nvm_alias LTS-N
@@ -25,10 +25,12 @@ LTS_NAMES_PATH="${MOCKS_DIR}/LTS_names.txt"
 
 N=0
 while IFS= read -r LTS; do
+  if [ $N -gt 0 ]; then
+    EXPECTED="$(nvm_alias "lts/${LTS}")"
+    ACTUAL="$(nvm_alias "lts/-${N}")"
+    [ "${EXPECTED}" = "${ACTUAL}" ] || die "\`nvm_alias lts/-${N}\` was \`${ACTUAL}\`; expected \`${EXPECTED}\`"
+  fi
   N=$(($N+1))
-  EXPECTED="$(nvm_alias "lts/${LTS}")"
-  ACTUAL="$(nvm_alias "lts/-${N}")"
-  [ "${EXPECTED}" = "${ACTUAL}" ] || die "\`nvm_alias lts/-${N}\` was \`${ACTUAL}\`; expected \`${EXPECTED}\`"
 done < "${LTS_NAMES_PATH}"
 
 cleanup


### PR DESCRIPTION
Title says it all.

fixes #2461