### PR TITLE
nvm_get_arch(): fix for arm64 kernel running armv7l userland

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1796,6 +1796,14 @@ nvm_get_arch() {
     aarch64) NVM_ARCH="arm64" ;;
     *) NVM_ARCH="${HOST_ARCH}" ;;
   esac
+
+  # If running a 64bit ARM kernel but a 32bit ARM userland, change ARCH to 32bit ARM (armv7l)
+  L=$(ls -dl /sbin/init) #                                         if /sbin/init is 32bit executable
+  if [ "$(uname)" = "Linux" ] && [ "${NVM_ARCH}" = arm64 ] && [ "$(od -An -t x1 -j 4 -N 1 "${L#*-> }")" = ' 01' ]; then
+    NVM_ARCH=armv7l
+    HOST_ARCH=armv7l
+  fi
+
   nvm_echo "${NVM_ARCH}"
 }
 

--- a/test/fast/Unit tests/nvm_get_arch
+++ b/test/fast/Unit tests/nvm_get_arch
@@ -79,4 +79,6 @@ run_test amd64 smartos x64 no_pkg_info
 run_test x86 osx x86
 run_test amd64 osx x64
 
+run_test arm64 smartos x64
+
 cleanup


### PR DESCRIPTION
Several people in the Raspberry Pi community have had issues with `nvm`. We realized that everyone affected had one thing in common: they were using armhf (armv7l) Raspberry Pi OS, but had enabled the arm64 kernel.

`nvm` mistakenly detected the OS to be 64-bit arm, while in reality it was armhf. This pull request solves the problem.