### PR TITLE
Clarify the M1 shell instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,4 +928,10 @@ $ node -p process.arch
 x64
 # It is now safe to return to the arm64 zsh process:
 $ exit
+# We're back to a native shell:
+$ arch
+arm64
+# And the new version is now available to use:
+$ nvm use v14.15.4
+Now using node v14.15.4 (npm v6.14.10)
 ```

--- a/README.md
+++ b/README.md
@@ -919,13 +919,13 @@ arm64
 $ nvm install v12.20.1
 # Now uninstall the version we want to replace:
 $ nvm uninstall v14.15.4
-# Set the architecture for our shell to 64-bit X86:
+# Launch a new zsh process under the 64-bit X86 architecture:
 $ arch -x86_64 zsh
 # Install node using nvm. This should download the precompiled x64 binary:
 $ nvm install v14.15.4
 # Now check that the architecture is correct:
 $ node -p process.arch
 x64
-# It is now safe to revert zsh back to the native architecture:
-$ arch -arm64 zsh
+# It is now safe to return to the arm64 zsh process:
+$ exit
 ```


### PR DESCRIPTION
The instructions seemed to encourage the misconception that `arch -x86_64 zsh` somehow modifies the default architecture for `zsh`, an operation which would need to be "reverted".
In fact, `arch -x86_64 …` merely spawns a new process under the selected architecture.