### PR TITLE
Improve README about Macs with M1 chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ Let's assume that:
 - you already have versions `12.20.1` and `14.15.4` installed using `nvm`
 - the current version in use is `14.15.4`
 - you are using the `zsh` shell
+- you have Rosetta 2 installed (macOS prompts you to install Rosetta 2 the first time you open a Intel-only non-command-line application, or you may install Rosetta 2 from the command line with `softwareupdate --install-rosetta`)
 
 ```sh
 # Check what version you're running:


### PR DESCRIPTION
I was trying to follow the instructions on the README on a fresh macOS installation and tripped over the fact that Rosetta 2 wasn’t installed. I got the following error:

```console
$ arch -x86_64 zsh
arch: posix_spawnp: zsh: Bad CPU type in executable
```

This pull request mentions that you must have Rosetta 2 installed and provides instructions on how to do it. I ended up installing Rosetta 2 by opening OBS, which is Intel-only when installed via Homebrew as of 2021-04-05, and I borrowed the command to install Rosetta 2 on the command line from this thread: https://apple.stackexchange.com/questions/408375/zsh-bad-cpu-type-in-executable