### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You can use a task:
 ```yaml
 - name: nvm
   shell: >
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | zsh
   args:
     creates: "{{ ansible_env.HOME }}/.nvm/nvm.sh"
 ```


### PR DESCRIPTION
zsh is the default shell for mac now, so we should write the nvm config to that.