### PR TITLE
Detect correct profile in install.sh based on $SHELL var

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -267,14 +267,16 @@ nvm_detect_profile() {
   local DETECTED_PROFILE
   DETECTED_PROFILE=''
 
-  if [ -n "${BASH_VERSION-}" ]; then
+  if [ "${SHELL#*bash}" != "$SHELL" ]; then
     if [ -f "$HOME/.bashrc" ]; then
       DETECTED_PROFILE="$HOME/.bashrc"
     elif [ -f "$HOME/.bash_profile" ]; then
       DETECTED_PROFILE="$HOME/.bash_profile"
     fi
-  elif [ -n "${ZSH_VERSION-}" ]; then
-    DETECTED_PROFILE="$HOME/.zshrc"
+  elif [ "${SHELL#*zsh}" != "$SHELL" ]; then
+    if [ -f "$HOME/.zshrc" ]; then
+      DETECTED_PROFILE="$HOME/.zshrc"
+    fi
   fi
 
   if [ -z "$DETECTED_PROFILE" ]; then

--- a/test/install_script/nvm_detect_profile
+++ b/test/install_script/nvm_detect_profile
@@ -14,8 +14,7 @@ cleanup () {
   unset HOME
   unset NVM_ENV
   unset NVM_DETECT_PROFILE
-  unset BASH_VERSION
-  unset ZSH_VERSION
+  unset SHELL
   unset -f setup cleanup die
   rm -f ".bashrc" ".bash_profile" ".zshrc" ".profile" "test_profile" > "/dev/null" 2>&1
 }
@@ -35,7 +34,7 @@ if [ -n "$NVM_DETECT_PROFILE" ]; then
 fi
 
 # .bashrc should be detected for bash
-NVM_DETECT_PROFILE="$(BASH_VERSION="1"; unset PROFILE; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL="/bin/bash"; unset PROFILE; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.bashrc" ]; then
   die "nvm_detect_profile didn't pick \$HOME/.bashrc for bash"
 fi
@@ -47,7 +46,7 @@ if [ "$NVM_DETECT_PROFILE" != "test_profile" ]; then
 fi
 
 # .zshrc should be detected for zsh
-NVM_DETECT_PROFILE="$(ZSH_VERSION="1"; unset PROFILE; unset BASH_VERSION; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL="/bin/zsh"; unset PROFILE; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.zshrc" ]; then
   die "nvm_detect_profile didn't pick \$HOME/.zshrc for zsh"
 fi
@@ -64,7 +63,7 @@ fi
 #
 
 # $PROFILE is a valid file
-NVM_DETECT_PROFILE="$(PROFILE="test_profile"; unset ZSH_VERSION; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(PROFILE="test_profile"; unset SHELL; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "test_profile" ]; then
   die "nvm_detect_profile didn't pick \$PROFILE when it was a valid file"
 fi
@@ -83,35 +82,35 @@ fi
 #
 
 # It should favor .profile if file exists
-NVM_DETECT_PROFILE="$(unset BASH_VERSION; unset ZSH_VERSION; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.profile" ]; then
   die "nvm_detect_profile should have selected .profile"
 fi
 
 # Otherwise, it should favor .bashrc if file exists
 rm ".profile"
-NVM_DETECT_PROFILE="$(unset BASH_VERSION; unset ZSH_VERSION; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.bashrc" ]; then
   die "nvm_detect_profile should have selected .bashrc"
 fi
 
 # Otherwise, it should favor .bash_profile if file exists
 rm ".bashrc"
-NVM_DETECT_PROFILE="$(unset BASH_VERSION; unset ZSH_VERSION; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.bash_profile" ]; then
   die "nvm_detect_profile should have selected .bash_profile"
 fi
 
 # Otherwise, it should favor .zshrc if file exists
 rm ".bash_profile"
-NVM_DETECT_PROFILE="$(unset BASH_VERSION; unset ZSH_VERSION; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.zshrc" ]; then
   die "nvm_detect_profile should have selected .zshrc"
 fi
 
 # It should be empty if none is found
 rm ".zshrc"
-NVM_DETECT_PROFILE="$(unset BASH_VERSION; unset ZSH_VERSION; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
 if [ ! -z "$NVM_DETECT_PROFILE" ]; then
   die "nvm_detect_profile should have returned an empty value"
 fi


### PR DESCRIPTION
This attempts to detect the users default shell rather than the shell the install script is running in, which will always be `bash` if following install instructions. Fixes #2555 