### PR TITLE
Bugfix: bash_completion configuration line is not append if the PROFILE variable is set to /etc/bashrc (which is a valid bashrc file).

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ nvm_profile_is_bash_or_zsh() {
   local TEST_PROFILE
   TEST_PROFILE="${1-}"
   case "${TEST_PROFILE-}" in
-    *"/.bashrc" | *"/.bash_profile" | *"/.zshrc")
+    *"/.bashrc" | *"/.bash_profile" | *"/.zshrc" | "/etc/bashrc")
       return
     ;;
     *)


### PR DESCRIPTION
All is described in the Pull Request title. Linked issue: [https://github.com/nvm-sh/nvm/issues/2568](https://github.com/nvm-sh/nvm/issues/2568 )