### PR TITLE
[Dockerfile] Update dated base image from Ubuntu 16.04 to 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Please note that it'll use about 1.2 GB disk space and about 15 minutes to
 # build this image, it depends on your hardware.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 LABEL maintainer="Peter Dave Hello <hsu@peterdavehello.org>"
 LABEL name="nvm-dev-env"
 LABEL version="latest"
@@ -54,7 +54,6 @@ RUN apt update         && \
         curl                  \
         git                   \
         jq                    \
-        realpath              \
         zsh                   \
         ksh                   \
         gcc-4.8               \

--- a/README.md
+++ b/README.md
@@ -788,7 +788,7 @@ export NVM_DIR="$HOME/.nvm"
 
 ## Docker For Development Environment
 
-To make the development and testing work easier, we have a Dockerfile for development usage, which is based on Ubuntu 16.04 base image, prepared with essential and useful tools for `nvm` development, to build the docker image of the environment, run the docker command at the root of `nvm` repository:
+To make the development and testing work easier, we have a Dockerfile for development usage, which is based on Ubuntu 18.04 base image, prepared with essential and useful tools for `nvm` development, to build the docker image of the environment, run the docker command at the root of `nvm` repository:
 
 ```sh
 $ docker build -t nvm-dev .


### PR DESCRIPTION
Ubuntu 16.04 is EOLed.

The `realpath` package is no longer existed in the new versions of Ubuntu and should be removed.