### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/latest-npm.yml
+++ b/.github/workflows/latest-npm.yml
@@ -4,6 +4,8 @@ on: [pull_request, push]
 
 jobs:
   nodes:
+    permissions:
+      contents: read
     name: 'nvm install-latest-npm'
     runs-on: ubuntu-latest
 
@@ -44,6 +46,8 @@ jobs:
       - run: npm --version
 
   node:
+    permissions:
+      contents: none
     name: 'nvm install-latest-npm'
     needs: [nodes]
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,8 @@ on: [pull_request, push]
 
 jobs:
   eclint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,6 +16,8 @@ jobs:
       - run: npm run eclint
 
   dockerfile_lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -24,6 +28,8 @@ jobs:
       - run: npm run dockerfile_lint
 
   doctoc:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -34,6 +40,8 @@ jobs:
       - run: npm run doctoc:check
 
   test_naming:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -4,6 +4,8 @@ on: [pull_request_target]
 
 jobs:
   _:
+    permissions:
+      contents: write
     name: "Automatic Rebase"
 
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on: [pull_request, push]
 
 jobs:
   release:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -4,6 +4,8 @@ on: [pull_request_target]
 
 jobs:
   _:
+    permissions:
+      pull-requests: read
     name: "Require “Allow Edits”"
 
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,6 +4,8 @@ on: [pull_request, push]
 
 jobs:
   shellcheck_matrix:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,6 +34,8 @@ jobs:
         run: shellcheck -s ${{ matrix.shell }} ${{ matrix.file }}
 
   shellcheck:
+      permissions:
+        contents: none
       needs: [shellcheck_matrix]
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
   _:
+    permissions:
+      contents: write
     name: "update readme TOC"
 
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-npm.yml
+++ b/.github/workflows/windows-npm.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   msys_fail_install:
     # Default installation does not work due to npm_config_prefix set to C:\npm\prefix
+    permissions:
+      contents: none
     name: 'MSYS fail prefix nvm install'
     runs-on: windows-latest
     steps:
@@ -20,6 +22,8 @@ jobs:
           ! nvm install --lts
 
   msys_matrix:
+    permissions:
+      contents: none
     name: 'MSYS nvm install'
     runs-on: windows-latest
     strategy:
@@ -43,6 +47,8 @@ jobs:
           nvm install ${{ matrix.npm-node-version }}
 
   cygwin_matrix:
+    permissions:
+      contents: none
     name: 'Cygwin nvm install'
     runs-on: windows-latest
     steps:
@@ -111,6 +117,8 @@ jobs:
           nvm install ${{ matrix.npm-node-version }}
 
   nvm_windows:
+      permissions:
+        contents: none
       needs: [wsl_matrix, cygwin_matrix, msys_matrix, msys_fail_install]
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
This PR adds specific permissions to the existing workflows under .github/workflows.

### Background

I have implemented a [GitHub App](https://github.com/apps/step-security) to automatically restrict permissions for the GITHUB_TOKEN in workflows. This is a security best practice as per the GitHub Actions [hardening guide](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions). 

I am trying the App out on public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows. The App automatically fixes permissions when a PR is created that creates a new workflow, so feel free to [install it](https://github.com/apps/step-security) for future workflows, or try it out on other repos. 

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. If you have feedback, would love to hear it. Thanks!