### PR TITLE
[Fix] `bash_completion`: be robust when `cd` is overridden

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -58,7 +58,7 @@ __nvm_aliases() {
   declare aliases
   aliases=""
   if [ -d "${NVM_DIR}/alias" ]; then
-    aliases="$(cd "${NVM_DIR}/alias" && command find "${PWD}" -type f | command sed "s:${PWD}/::")"
+    aliases="$(command cd "${NVM_DIR}/alias" && command find "${PWD}" -type f | command sed "s:${PWD}/::")"
   fi
   echo "${aliases} node stable unstable iojs"
 }


### PR DESCRIPTION
### Bug:
If `cd` is patched (overridden) and prints something to stdout/stderr, completing `nvm use` with tab-tab erroneously displays this output alongside the completion options.

### Steps to reproduce:
```bash
# Patch cd to print arbitrary text:
function cd(){ echo EXTRA INFORMATION IN MY FACE; command cd "$@"; }
nvm use <TAB> <TAB>
```
Completion words should be e.g 
`default      EXTRA        FACE         IN           INFORMATION  iojs         MY           node         stable       unstable     v14.17.6`

### Fix:
This is fixed if function `__nvm_aliases` in `bash_completion` uses `command cd` instead of bare `cd`.