### PR TITLE
updated automatic call script for bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ cdnvm() {
     fi
 }
 alias cd='cdnvm'
-cd $PWD
+cd "$PWD"
 ```
 
 This alias would search 'up' from your current directory in order to detect a `.nvmrc` file. If it finds it, it will switch to that version; if not, it will use the default version.


### PR DESCRIPTION
Bash terminal was throwing error: `bash: cd: too many arguments` when directory had some spaces in the name.
The quotes around `$PWD` fixes this issue