### PR TITLE
Avoid infinite loop in cdnvm()

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Put the following at the end of your `$HOME/.bashrc`:
 
 ```bash
 cdnvm() {
-    cd "$@";
+    command cd "$@";
     nvm_path=$(nvm_find_up .nvmrc | tr -d '\n')
 
     # If there are no .nvmrc file, use the default nvm version


### PR DESCRIPTION
Do not use the aliased `cd` inside `cdnvm()`.

This avoids an infinite loop when re-reading `~/.bashrc` - eg. if the user does a `source ~/.profile`.