### PR TITLE
[readme] remove duplicate word 'run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Eg: `curl ... | NVM_DIR="path/to/nvm"`. Ensure that the `NVM_DIR` does not conta
 #### Troubleshooting on Linux
 
 On Linux, after running the install script, if you get `nvm: command not found` or see no feedback from your terminal after you type `command -v nvm`, simply close your current terminal, open a new terminal, and try verifying again.
-Alternatively, you can run run the following commands for the different shells on the command line:
+Alternatively, you can run the following commands for the different shells on the command line:
 
 *bash*: `source ~/.bashrc`
 


### PR DESCRIPTION
Fix a typo where the word 'run' was written twice.