### PR TITLE
Remove backslash from sourcing on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Running either of the above commands downloads a script and runs it. The script 
 <a id="profile_snippet"></a>
 ```sh
 export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
 ```
 
 #### Additional Notes
@@ -229,8 +229,8 @@ Now add these lines to your `~/.bashrc`, `~/.profile`, or `~/.zshrc` file to hav
 
 ```sh
 export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 ```
 
 ### Manual Install
@@ -242,7 +242,7 @@ export NVM_DIR="$HOME/.nvm" && (
   git clone https://github.com/nvm-sh/nvm.git "$NVM_DIR"
   cd "$NVM_DIR"
   git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1)`
-) && \. "$NVM_DIR/nvm.sh"
+) && . "$NVM_DIR/nvm.sh"
 ```
 
 Now add these lines to your `~/.bashrc`, `~/.profile`, or `~/.zshrc` file to have it automatically sourced upon login:
@@ -250,8 +250,8 @@ Now add these lines to your `~/.bashrc`, `~/.profile`, or `~/.zshrc` file to hav
 
 ```sh
 export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 ```
 
 ### Manual Upgrade
@@ -268,7 +268,7 @@ For manual upgrade with `git` (requires git v1.7.10+):
   cd "$NVM_DIR"
   git fetch --tags origin
   git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1)`
-) && \. "$NVM_DIR/nvm.sh"
+) && . "$NVM_DIR/nvm.sh"
 ```
 
 ## Usage
@@ -708,7 +708,7 @@ Additionally, nvm modifies `PATH`, and, if present, `MANPATH` and `NODE_PATH` wh
 To activate, you need to source `bash_completion`:
 
 ```sh
-[[ -r $NVM_DIR/bash_completion ]] && \. $NVM_DIR/bash_completion
+[[ -r $NVM_DIR/bash_completion ]] && . $NVM_DIR/bash_completion
 ```
 
 Put the above sourcing line just below the sourcing line for nvm in your profile (`.bashrc`, `.bash_profile`).
@@ -809,8 +809,8 @@ Edit `~/.bashrc` (or other shell resource config) and remove the lines below:
 
 ```sh
 export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-[[ -r $NVM_DIR/bash_completion ]] && \. $NVM_DIR/bash_completion
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+[[ -r $NVM_DIR/bash_completion ]] && . $NVM_DIR/bash_completion
 ```
 
 ## Docker For Development Environment


### PR DESCRIPTION
`alias .=something` won't happen and we must consider `alias export=something` if we assume this happens.
`\.` is also confusing because it is different from the ordinary way.