### PR TITLE
[Fix] `nvm_get_download_slug`: better architecture selection for M1 Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ If the above doesn't fix the problem, you may try the following:
 
   - For more information about this issue and possible workarounds, please [refer here](https://github.com/nvm-sh/nvm/issues/576)
 
+**Note** For Macs with the M1 chip, node started providing **arm64** arch darwin packages since v16.0.0. For earlier versions, there were only **darwin_x64** packages available but no **darwin_arm64**. If you are facing issues installing node using `nvm`, you may want to update to v16 or later.
+
 #### Ansible
 
 You can use a task:

--- a/nvm.sh
+++ b/nvm.sh
@@ -2093,6 +2093,14 @@ nvm_get_download_slug() {
     fi
   fi
 
+  # If node version in below 16.0.0 then there is no arm64 packages available in node repositories, so we have to install "x64" arch packages
+  # If running MAC M1 :: arm64 arch and Darwin OS then use "x64" Architecture because node doesn't provide darwin_arm64 package below v16.0.0
+  if nvm_version_greater '16.0.0' "${VERSION}"; then
+    if [ "_${NVM_OS}" = '_darwin' ] && [ "${NVM_ARCH}" = 'arm64' ]; then
+      NVM_ARCH=x64
+    fi
+  fi
+
   if [ "${KIND}" = 'binary' ]; then
     nvm_echo "${FLAVOR}-${VERSION}-${NVM_OS}-${NVM_ARCH}"
   elif [ "${KIND}" = 'source' ]; then

--- a/test/fast/Unit tests/nvm_get_download_slug
+++ b/test/fast/Unit tests/nvm_get_download_slug
@@ -1,0 +1,111 @@
+#!/bin/sh
+
+cleanup() {
+    unset nvm_get_os
+    unset nvm_get_arch
+}
+
+die () { cleanup; echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+[ "$(nvm_get_download_slug 2>/dev/null ; echo $?)" = '1' ] || die 'invalid flavor did not fail with exit code 1'
+[ "$(nvm_get_download_slug 2>&1)" = 'supported flavors: node, iojs' ] || die 'invalid flavor did not fail with expected message'
+
+[ "$(nvm_get_download_slug node 2>/dev/null ; echo $?)" = '2' ] || die 'invalid kind did not fail with exit code 2'
+[ "$(nvm_get_download_slug node 2>&1)" = 'supported kinds: binary, source' ] || die 'invalid kind did not fail with expected message'
+[ "$(nvm_get_download_slug iojs 2>/dev/null ; echo $?)" = '2' ] || die 'invalid kind did not fail with exit code 2'
+[ "$(nvm_get_download_slug iojs 2>&1)" = 'supported kinds: binary, source' ] || die 'invalid kind did not fail with expected message'
+
+nvm_get_os() {
+    echo omgOS
+}
+nvm_get_arch() {
+    echo nemesis
+}
+
+ACTUAL="$(nvm_get_download_slug node binary 1.2.3)"
+EXPECTED='node-1.2.3-omgOS-nemesis'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs binary 1.2.3)"
+EXPECTED='iojs-1.2.3-omgOS-nemesis'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+ACTUAL="$(nvm_get_download_slug node source 1.2.3)"
+EXPECTED="node-1.2.3"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs source 1.2.3)"
+EXPECTED="iojs-1.2.3"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+nvm_get_arch() {
+    echo armv6l
+}
+ACTUAL="$(nvm_get_download_slug node binary 1.2.3)"
+EXPECTED='node-1.2.3-omgOS-arm-pi'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs binary 1.2.3)"
+EXPECTED='iojs-1.2.3-omgOS-arm-pi'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+ACTUAL="$(nvm_get_download_slug node source 1.2.3)"
+EXPECTED="node-1.2.3"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs source 1.2.3)"
+EXPECTED="iojs-1.2.3"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+nvm_get_arch() {
+    echo armv7l
+}
+ACTUAL="$(nvm_get_download_slug node binary 1.2.3)"
+EXPECTED='node-1.2.3-omgOS-arm-pi'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs binary 1.2.3)"
+EXPECTED='iojs-1.2.3-omgOS-arm-pi'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+ACTUAL="$(nvm_get_download_slug node source 1.2.3)"
+EXPECTED="node-1.2.3"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs source 1.2.3)"
+EXPECTED="iojs-1.2.3"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+nvm_get_os() {
+    echo darwin
+}
+nvm_get_arch() {
+    echo nemesis
+}
+ACTUAL="$(nvm_get_download_slug node binary 15.99.99)"
+EXPECTED='node-15.99.99-darwin-nemesis'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs binary 15.99.99)"
+EXPECTED='iojs-15.99.99-darwin-nemesis'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+ACTUAL="$(nvm_get_download_slug node source 15.99.99)"
+EXPECTED="node-15.99.99"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs source 15.99.99)"
+EXPECTED="iojs-15.99.99"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+nvm_get_arch() {
+    echo arm64
+}
+ACTUAL="$(nvm_get_download_slug node binary 15.99.99)"
+EXPECTED='node-15.99.99-darwin-x64'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs binary 15.99.99)"
+EXPECTED='iojs-15.99.99-darwin-x64'
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+ACTUAL="$(nvm_get_download_slug node source 15.99.99)"
+EXPECTED="node-15.99.99"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+ACTUAL="$(nvm_get_download_slug iojs source 15.99.99)"
+EXPECTED="iojs-15.99.99"
+[ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+


### PR DESCRIPTION
Changed configuration in **nvm_get_download_slug()** function, made condition for **darwin** based OS running on **arm64** arch i.e, **MAC M1**. 
If so, then change HOST_ARCH to **x64** so that NVM will fetch **x64 arch** package from node repository which is the only package node currently having for darwin systems but no arm64 based packages

#### Problem
- Macbook M1 ARM64 architecture problem that does not allow us to use default terminal for installing node packages using nvm, please [refer here](https://github.com/nvm-sh/nvm/issues/2350)
- What we did was use a rosetta-2 terminal for installing different node versions using NVM. It was creating problems for automation developers who use scripts to run operations, and it was not always possible to run the script on a single installed version of the node.
- Even by transforming the current shell to a different arch using rosetta2 e.g, **arch -x86_64 zsh** causing problems as it creates a new instance of the terminal that is indirectly equivalent to using a different terminal i.e, rosetta one, which stops execution of next series of commands if it is invoked inside the script

#### Solutions Available
- Use the latest version node as old ones were not built for mac m1 arch.
- Use rosetta2 terminal to install node version as it converts architecture from arm64 to amd64, which then nvm install node packages for amd64
- **Solution Provided by me** for automation engineers who don't want to switch on rosetta2 terminal just for installing node versions, Please [refer this](https://github.com/nvm-sh/nvm/issues/2350#issuecomment-969947270). Complete consequences explained in detail

#### Solution
- Made changes in **nvm.sh** file to update **nvm_get_download_slug()** function that basically gathers architecture information regarding users system. 
- Basically **rosetta** was only being used to change architecture so that **nvm_get_download_slug()** would get **x86_64** instead of **arm64** architecture. Because older versions were never designed for **arm64** architectures.
- This part was the pain and I added conditions for the same, so that if the device is apple-based with silicon chip then it will set "x64" arch. So that packages fetched from the nodejs repository will be installed properly.

#### NVM working on mac m1 after making PR changes in nvm.sh
![Problem solved after refreshing changes](https://user-images.githubusercontent.com/77939876/142740986-9201de78-6d44-405d-b393-a7d7dab6df2b.png)
- First I have run "uname -a" to show my mac m1 architecture
- Then I am trying to install node 12.22.7 **nvm install 12.22.7** on arm64 arch. This throws me an error as the package was not found.
- Then I sourced the RC file so that my changes in **nvm.sh** reflect in the shell. Whoop, this worked