### PR TITLE
Balance the if statement in bash example

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ cdnvm() {
             nvm use default;
         fi
 
-        elif [[ -s $nvm_path/.nvmrc && -r $nvm_path/.nvmrc ]]; then
+    elif [[ -s $nvm_path/.nvmrc && -r $nvm_path/.nvmrc ]]; then
         declare nvm_version
         nvm_version=$(<"$nvm_path"/.nvmrc)
 


### PR DESCRIPTION
Nesting the `elif` at the same level as the `if` and `fi` makes it clear which code applies to which branch (no .nvmrc file / found .nvmrc file).

I wasted a while looking at it trying to work out how it did anything if there was a .nvmrc file, because obviously the `if` didn't match and I couldn't see the `elif` branch.