### PR TITLE
[actions] add step security runner

### DIFF
--- a/.github/workflows/latest-npm.yml
+++ b/.github/workflows/latest-npm.yml
@@ -8,6 +8,12 @@ jobs:
     outputs:
       latest: ${{ steps.set-matrix.outputs.requireds }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v1
+        with:
+          allowed-endpoints:
+            iojs.org:443
+            nodejs.org:443
       - uses: ljharb/actions/node/matrix@main
         id: set-matrix
         with:
@@ -39,6 +45,14 @@ jobs:
           - node-version: "0.10"
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v1
+        with:
+          allowed-endpoints:
+            github.com:443
+            iojs.org:443
+            nodejs.org:443
+            registry.npmjs.org:443
       - uses: actions/checkout@v2
       - uses: ljharb/actions/node/install@main
         name: 'nvm install-latest-npm'
@@ -55,4 +69,8 @@ jobs:
     needs: [nodes]
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v1
+        with:
+          egress-policy: block
       - run: 'echo tests completed'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,12 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v1
+        with:
+          allowed-endpoints:
+            github.com:443
+            nodejs.org:443
+            registry.npmjs.org:443
       - uses: actions/checkout@v2
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
@@ -20,6 +26,14 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v1
+        with:
+          allowed-endpoints:
+            ghcr.io:443
+            github.com:443
+            pkg-containers.githubusercontent.com:443
+            nodejs.org:443
+            registry.npmjs.org:443
       - uses: actions/checkout@v2
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
@@ -32,6 +46,12 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v1
+        with:
+          allowed-endpoints:
+            github.com:443
+            nodejs.org:443
+            registry.npmjs.org:443
       - uses: actions/checkout@v2
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
@@ -44,6 +64,10 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v1
+        with:
+          allowed-endpoints:
+            github.com:443
       - uses: actions/checkout@v2
       - name: check tests filenames
         run: ./rename_test.sh --check

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v1
+      with:
+        allowed-endpoints:
+          api.github.com:443
+          github.com:443
     - uses: actions/checkout@v2
     - uses: ljharb/rebase@master
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v1
+        with:
+          allowed-endpoints:
+            github.com:443
+            registry.npmjs.org:443
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v1
+      with:
+        allowed-endpoints:
+          api.github.com:443
     - uses: ljharb/require-allow-edits@main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -26,9 +26,18 @@ jobs:
             file: nvm-exec # only runs in bash
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v1
+        with:
+          allowed-endpoints:
+            ghcr.io:443
+            github.com:443
+            pkg-containers.githubusercontent.com:443
       - uses: actions/checkout@v2
       - name: Install shellcheck
         run: brew install shellcheck
+        env:
+          HOMEBREW_NO_ANALYTICS: 1
       - run: "shellcheck --version"
       - name: Run shellcheck on ${{ matrix.file }}
         run: shellcheck -s ${{ matrix.shell }} ${{ matrix.file }}
@@ -39,4 +48,8 @@ jobs:
       needs: [shellcheck_matrix]
       runs-on: ubuntu-latest
       steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@v1
+          with:
+            egress-policy: block
         - run: 'echo tests completed'

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v1
+      with:
+        allowed-endpoints:
+          github.com:443
+          registry.npmjs.org:443
     - uses: actions/checkout@v2
       with:
         # https://github.com/actions/checkout/issues/217#issue-599945005


### PR DESCRIPTION
This PR adds the `step-security/harden-runner` GitHub Action to the lint.yml workflow to restrict outbound calls. This is a new GitHub Action that provides runtime security for GitHub hosted runner. As of now, it can be used to set allowed outbound traffic for workflow runs to prevent credential exfiltration. You can see the results of running this on a fork [here](https://github.com/varunsh-coder/nvm/runs/4288537584?check_suite_focus=true#step:3:4). 

@ljharb would love to pilot `step-security/harden-runner` on this workflow to get feedback and improve the experience. Do let me know if you have any questions. Thanks!