### PR TITLE
handle nonexisting /sbin/init a bit more cleanly

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1871,6 +1871,7 @@ nvm_get_arch() {
   esac
 
   # If running a 64bit ARM kernel but a 32bit ARM userland, change ARCH to 32bit ARM (armv7l)
+  local L
   L=$(ls -dl /sbin/init 2>/dev/null) # if /sbin/init is 32bit executable
   if [ "$(uname)" = "Linux" ] && [ "${NVM_ARCH}" = arm64 ] && [ "$(od -An -t x1 -j 4 -N 1 "${L#*-> }")" = ' 01' ]; then
     NVM_ARCH=armv7l


### PR DESCRIPTION
TL;DR: `nvm install` fails in Arch's `makepkg` environment when `/sbin/init` does not exist. No idea (yet) why exactly this happens, but slightly modifying the line checking for `/sbin/init` here seems to fix things.

A few more details/reasoning:

In some very rare circumstances, a non-existing `/sbin/init` seems to cause an `nvm install` to fail without any 'good' hint as to why it fails. (It seems like the commit 7f2ccd51d4c20cd23d7ba79e4c19f06c40b68470 made it especially hard to pinpoint what's going on here, because even if things silently fail there, it might still cause a script failure in those circumstances.

This could look like this, for example:

```
Downloading and installing node v14.18.1...
Binary download failed, trying source.
```

…and then nothing more.

I am not entirely certain what exactly causes it to fail here – I'd (very broadly) assume that some "globally" set shell option from whatever called nvm might still cause the `ls` error to cause the nvm script to exit. I've originally come across it on Arch in `makechrootpkg`, although the main culprit seems to be in `makepkg` itself – which seems to be enough to reproduce it.

Basically, it happens when running `makepkg` for a `PKGBUILD` where `nvm` is used (as, for example, recommended at https://wiki.archlinux.org/title/Node.js_package_guidelines#Using_nvm), when `/sbin/init` does not exist (on Arch it does not exist by default, but is provided by the `systemd-sysvcompat` package).

I've only come across it by accident by building in a "clean chroot" (https://wiki.archlinux.org/title/DeveloperWiki:Building_in_a_clean_chroot), where a package providing `/sbin/init` is not installed by default. The chroot environment itself does not seem to be relevant though (directly using `nvm` in it is possible) – it seems like it's only the `makepkg` environment that seems to matter.

On top of that, this "had worked a few weeks ago" – but I was not able to find out what had changed on Arch's end that might have caused this.

I understand this is probably not really an `nvm` issue – I had just hoped that, with this being an easy fix (without any obvious downsides – to me at least), which shouldn't do much damage but just handles the non-existing file "a bit more cleanly", it might be easiest to address this here. Unless I can find out where things are _actually_ causing the issue in Arch's tools.
