### PR TITLE
[readme]: clarify that lts/* points to the active LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ In place of a version pointer like "14.7" or "16.3" or "12.22.1", you can use th
 
 ### Long-term Support
 
-Node has a [schedule](https://github.com/nodejs/Release#release-schedule) for long-term support (LTS) You can reference LTS versions in aliases and `.nvmrc` files with the notation `lts/*` for the latest LTS, and `lts/argon` for LTS releases from the "argon" line, for example. In addition, the following commands support LTS arguments:
+Node has a [schedule](https://github.com/nodejs/Release#release-schedule) for long-term support (LTS) You can reference LTS versions in aliases and `.nvmrc` files with the notation `lts/*` for the latest _Active_ LTS, and `lts/argon` for LTS releases from the "argon" line, for example. In addition, the following commands support LTS arguments:
 
   - `nvm install --lts` / `nvm install --lts=argon` / `nvm install 'lts/*'` / `nvm install lts/argon`
   - `nvm uninstall --lts` / `nvm uninstall --lts=argon` / `nvm uninstall 'lts/*'` / `nvm uninstall lts/argon`


### PR DESCRIPTION
IMO https://nodejs.org/en/about/releases/ could do a better job clarifying that "current" is a non-LTS classification

but regardless.. `lts/*` is basically like a `lts/active` .. but since that other page is kinda weak on distinguishing "current" from "active lts", i think this small addition helps. :)

jordan if you think i should propose some wording changes to /releases i'm happy to followup with that, as well.