### PR TITLE
Update tar syntax to support OpenBSD.

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2270,7 +2270,15 @@ nvm_extract_tarball() {
     tar='gtar'
   fi
 
-  command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" --strip-components 1 || return 1
+  if [ "${NVM_OS}" = 'openbsd' ]; then
+    if [ "${tar_compression_flag}" = 'J' ]; then
+      command xzcat "${TARBALL}" | "${tar}" -xf - -C "${TMPDIR}" -s '/[^\/]*\///' || return 1
+    else
+      command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" -s '/[^\/]*\///' || return 1
+    fi
+  else
+    command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" --strip-components 1 || return 1
+  fi
 }
 
 nvm_get_make_jobs() {

--- a/test/fast/Unit tests/nvm_extract_tarball
+++ b/test/fast/Unit tests/nvm_extract_tarball
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+[ "$(nvm_extract_tarball 2>&1)" = "nvm_extract_tarball requires exactly 4 arguments" ] || die 'incorrect error message with no args'
+[ "$(nvm_extract_tarball > /dev/null 2>&1 ; echo $?)" = "5" ] || die 'incorrect error code with no args'
+[ "$(nvm_extract_tarball one two three 2>&1)" = "nvm_extract_tarball requires exactly 4 arguments" ] || die 'incorrect error message with three args'
+[ "$(nvm_extract_tarball one two three > /dev/null 2>&1 ; echo $?)" = "5" ] || die 'incorrect error code with three args'
+[ "$(nvm_extract_tarball one two three four five 2>&1)" = "nvm_extract_tarball requires exactly 4 arguments" ] || die 'incorrect error message with five args'
+[ "$(nvm_extract_tarball one two three four five > /dev/null 2>&1 ; echo $?)" = "5" ] || die 'incorrect error code with five args'


### PR DESCRIPTION
This PR special-cases the archive extraction code when executed on OpenBSD. This is to workaround the use of the `-J` and `--strip-components` options, which OpenBSD's `tar` does not support. If the `xz` format archive was downloaded, it correctly calls `xzcat` and pipes the output to `tar`. If not, it correctly calls the `tar` with the normal compression flag. In either case, it does not append the `--strip-components=1` option, but rather uses the `-s` option to perform `ed(1)`-style basic regex replacement on the path.

This is tested to execute correctly on OpenBSD 7.0 (current release as of this PR). It does not address compilation issues of the downloaded `node` source code, as mentioned in #2134, which will likely require upstreaming of some subset of the OpenBSD-specific source patches that were developed for the OpenBSD ports build of `node` (see the OpenBSD patches for node-12.22.7 [here](https://github.com/openbsd/ports/tree/master/lang/node) or the implementation of binary builds for OpenBSD, but it does allow you to reach that step without error. This should, however, fully address #2660.

Fixes #2660.