### PR TITLE
Fix `nvm install` error if /sbin/init is absent and errtrace is enabled

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2742,6 +2742,15 @@ nvm() {
     EXIT_CODE="$?"
     set -a
     return "$EXIT_CODE"
+  elif [ -n "${BASH-}" ] && [ "${-#*E}" != "$-" ]; then
+    # shellcheck disable=SC3041
+    set +E
+    local EXIT_CODE
+    IFS="${DEFAULT_IFS}" nvm "$@"
+    EXIT_CODE="$?"
+    # shellcheck disable=SC3041
+    set -E
+    return "$EXIT_CODE"
   elif [ "${IFS}" != "${DEFAULT_IFS}" ]; then
     IFS="${DEFAULT_IFS}" nvm "$@"
     return "$?"

--- a/nvm.sh
+++ b/nvm.sh
@@ -1870,10 +1870,12 @@ nvm_get_arch() {
     *) NVM_ARCH="${HOST_ARCH}" ;;
   esac
 
-  # If running a 64bit ARM kernel but a 32bit ARM userland, change ARCH to 32bit ARM (armv7l)
+  # If running a 64bit ARM kernel but a 32bit ARM userland,
+  # change ARCH to 32bit ARM (armv7l) if /sbin/init is 32bit executable
   local L
-  L=$(ls -dl /sbin/init 2>/dev/null) # if /sbin/init is 32bit executable
-  if [ "$(uname)" = "Linux" ] && [ "${NVM_ARCH}" = arm64 ] && [ "$(od -An -t x1 -j 4 -N 1 "${L#*-> }")" = ' 01' ]; then
+  if [ "$(uname)" = "Linux" ] && [ "${NVM_ARCH}" = arm64 ] &&
+    L="$(ls -dl /sbin/init 2>/dev/null)" &&
+    [ "$(od -An -t x1 -j 4 -N 1 "${L#*-> }")" = ' 01' ]; then
     NVM_ARCH=armv7l
     HOST_ARCH=armv7l
   fi

--- a/nvm.sh
+++ b/nvm.sh
@@ -1871,6 +1871,7 @@ nvm_get_arch() {
   esac
 
   # If running a 64bit ARM kernel but a 32bit ARM userland, change ARCH to 32bit ARM (armv7l)
+  local L
   L=$(ls -dl /sbin/init 2>/dev/null) # if /sbin/init is 32bit executable
   if [ "$(uname)" = "Linux" ] && [ "${NVM_ARCH}" = arm64 ] && [ "$(od -An -t x1 -j 4 -N 1 "${L#*-> }")" = ' 01' ]; then
     NVM_ARCH=armv7l

--- a/test/installation_node/install on bash with ERR trap and set -E
+++ b/test/installation_node/install on bash with ERR trap and set -E
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -e
+
+cleanup() {
+  nvm cache clear
+  nvm deactivate
+  rm -rf "${NVM_DIR}"/v*
+  nvm unalias default
+}
+
+die() {
+  echo "$@"
+  cleanup || true
+  exit 1
+}
+
+\. ../../nvm.sh
+
+if [ -z "${BASH-}" ]; then
+  echo "This test only applies to Bash; skipping"
+  exit
+fi
+
+cleanup || true
+trap 'echo "==> EXIT signal received (status: $?)"; cleanup' EXIT
+
+# shellcheck disable=SC3047
+trap 'echo "==> ERR signal received"; exit 1' ERR
+# shellcheck disable=SC3041
+set -E
+
+# shellcheck disable=SC3045,SC3047
+ERR_TRAP_EXPECTED="$(trap -p ERR)"
+
+# Adding ` || die 'install failed'` implicitly disables error handling and
+# prevents ERR trap execution, so for the purposes of this test, `nvm install`
+# can't be part of another command or statement
+nvm install node
+
+case "$-" in
+*E*)
+  # shellcheck disable=SC3045,SC3047
+  [ "$(trap -p ERR)" = "$ERR_TRAP_EXPECTED" ] ||
+    die "ERR trap not restored after \"nvm install $VERSION\""
+  ;;
+*)
+  die "errtrace not restored after \"nvm install $VERSION\""
+  ;;
+esac


### PR DESCRIPTION
(Discussed at length in #2678)

- Move `ls -dl /sbin/init` to the following `if` statement for implicit
  error handling (even if enabled, `errexit` and `errtrace` have no
  effect in this context)
- Disable errtrace (`set -E`) in nvm_get_arch and consolidate existing
  checks for `set -e` and `set -a` into one loop

`nvm install` fails with "Binary download failed, trying source" in Arch
Linux package build scripts. This is the combined result of `makepkg`
running these scripts with ERR trap inheritance enabled, and the lack
of error handling when `nvm_get_arch` calls `ls -dl /sbin/init`. If
`/sbin/init` doesn't exist, the ERR trap set by `makepkg` exits
non-zero and the operation fails.