### PR TITLE
prefix all variable with LOCAL_NVM_

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -59,31 +59,31 @@ nvm_is_alias() {
 }
 
 nvm_command_info() {
-  local COMMAND
-  local INFO
-  COMMAND="${1}"
-  if type "${COMMAND}" | nvm_grep -q hashed; then
-    INFO="$(type "${COMMAND}" | command sed -E 's/\(|\)//g' | command awk '{print $4}')"
-  elif type "${COMMAND}" | nvm_grep -q aliased; then
+  local LOCAL_NVM_COMMAND
+  local LOCAL_NVM_INFO
+  LOCAL_NVM_COMMAND="${1}"
+  if type "${LOCAL_NVM_COMMAND}" | nvm_grep -q hashed; then
+    LOCAL_NVM_INFO="$(type "${LOCAL_NVM_COMMAND}" | command sed -E 's/\(|\)//g' | command awk '{print $4}')"
+  elif type "${LOCAL_NVM_COMMAND}" | nvm_grep -q aliased; then
     # shellcheck disable=SC2230
-    INFO="$(which "${COMMAND}") ($(type "${COMMAND}" | command awk '{ $1=$2=$3=$4="" ;print }' | command sed -e 's/^\ *//g' -Ee "s/\`|'//g"))"
-  elif type "${COMMAND}" | nvm_grep -q "^${COMMAND} is an alias for"; then
+    LOCAL_NVM_INFO="$(which "${LOCAL_NVM_COMMAND}") ($(type "${LOCAL_NVM_COMMAND}" | command awk '{ $1=$2=$3=$4="" ;print }' | command sed -e 's/^\ *//g' -Ee "s/\`|'//g"))"
+  elif type "${LOCAL_NVM_COMMAND}" | nvm_grep -q "^${LOCAL_NVM_COMMAND} is an alias for"; then
     # shellcheck disable=SC2230
-    INFO="$(which "${COMMAND}") ($(type "${COMMAND}" | command awk '{ $1=$2=$3=$4=$5="" ;print }' | command sed 's/^\ *//g'))"
-  elif type "${COMMAND}" | nvm_grep -q "^${COMMAND} is \\/"; then
-    INFO="$(type "${COMMAND}" | command awk '{print $3}')"
+    LOCAL_NVM_INFO="$(which "${LOCAL_NVM_COMMAND}") ($(type "${LOCAL_NVM_COMMAND}" | command awk '{ $1=$2=$3=$4=$5="" ;print }' | command sed 's/^\ *//g'))"
+  elif type "${LOCAL_NVM_COMMAND}" | nvm_grep -q "^${LOCAL_NVM_COMMAND} is \\/"; then
+    LOCAL_NVM_INFO="$(type "${LOCAL_NVM_COMMAND}" | command awk '{print $3}')"
   else
-    INFO="$(type "${COMMAND}")"
+    LOCAL_NVM_INFO="$(type "${LOCAL_NVM_COMMAND}")"
   fi
-  nvm_echo "${INFO}"
+  nvm_echo "${LOCAL_NVM_INFO}"
 }
 
 nvm_has_colors() {
-  local NVM_NUM_COLORS
+  local LOCAL_NVM_NUM_COLORS
   if nvm_has tput; then
-    NVM_NUM_COLORS="$(tput -T "${TERM:-vt100}" colors)"
+    LOCAL_NVM_NUM_COLORS="$(tput -T "${TERM:-vt100}" colors)"
   fi
-  [ "${NVM_NUM_COLORS:--1}" -ge 8 ]
+  [ "${LOCAL_NVM_NUM_COLORS:--1}" -ge 8 ]
 }
 
 nvm_curl_libz_support() {
@@ -95,33 +95,33 @@ nvm_curl_use_compression() {
 }
 
 nvm_get_latest() {
-  local NVM_LATEST_URL
-  local CURL_COMPRESSED_FLAG
+  local LOCAL_NVM_LATEST_URL
+  local LOCAL_NVM_CURL_COMPRESSED_FLAG
   if nvm_has "curl"; then
     if nvm_curl_use_compression; then
-      CURL_COMPRESSED_FLAG="--compressed"
+      LOCAL_NVM_CURL_COMPRESSED_FLAG="--compressed"
     fi
-    NVM_LATEST_URL="$(curl ${CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S https://latest.nvm.sh -o /dev/null)"
+    LOCAL_NVM_LATEST_URL="$(curl ${LOCAL_NVM_CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S https://latest.nvm.sh -o /dev/null)"
   elif nvm_has "wget"; then
-    NVM_LATEST_URL="$(wget -q https://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
+    LOCAL_NVM_LATEST_URL="$(wget -q https://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
   else
     nvm_err 'nvm needs curl or wget to proceed.'
     return 1
   fi
-  if [ -z "${NVM_LATEST_URL}" ]; then
+  if [ -z "${LOCAL_NVM_LATEST_URL}" ]; then
     nvm_err "https://latest.nvm.sh did not redirect to the latest release on GitHub"
     return 2
   fi
-  nvm_echo "${NVM_LATEST_URL##*/}"
+  nvm_echo "${LOCAL_NVM_LATEST_URL##*/}"
 }
 
 nvm_download() {
-  local CURL_COMPRESSED_FLAG
+  local LOCAL_NVM_CURL_COMPRESSED_FLAG
   if nvm_has "curl"; then
     if nvm_curl_use_compression; then
-      CURL_COMPRESSED_FLAG="--compressed"
+      LOCAL_NVM_CURL_COMPRESSED_FLAG="--compressed"
     fi
-    curl --fail ${CURL_COMPRESSED_FLAG:-} -q "$@"
+    curl --fail ${LOCAL_NVM_CURL_COMPRESSED_FLAG:-} -q "$@"
   elif nvm_has "wget"; then
     # Emulate curl with wget
     ARGS=$(nvm_echo "$@" | command sed -e 's/--progress-bar /--progress=bar /' \
@@ -134,7 +134,7 @@ nvm_download() {
                             -e 's/-o /-O /' \
                             -e 's/-C - /-c /')
     # shellcheck disable=SC2086
-    eval wget $ARGS
+    eval wget ${ARGS}
   fi
 }
 
@@ -150,12 +150,12 @@ nvm_is_version_installed() {
   if [ -z "${1-}" ]; then
     return 1
   fi
-  local NVM_NODE_BINARY
-  NVM_NODE_BINARY='node'
+  local LOCAL_NVM_NODE_BINARY
+  LOCAL_NVM_NODE_BINARY='node'
   if [ "_$(nvm_get_os)" = '_win' ]; then
-    NVM_NODE_BINARY='node.exe'
+    LOCAL_NVM_NODE_BINARY='node.exe'
   fi
-  if [ -x "$(nvm_version_path "$1" 2>/dev/null)/bin/${NVM_NODE_BINARY}" ]; then
+  if [ -x "$(nvm_version_path "$1" 2>/dev/null)/bin/${LOCAL_NVM_NODE_BINARY}" ]; then
     return 0
   fi
   return 1
@@ -169,161 +169,161 @@ nvm_print_npm_version() {
 
 nvm_install_latest_npm() {
   nvm_echo 'Attempting to upgrade to the latest working version of npm...'
-  local NODE_VERSION
-  NODE_VERSION="$(nvm_strip_iojs_prefix "$(nvm_ls_current)")"
-  if [ "${NODE_VERSION}" = 'system' ]; then
-    NODE_VERSION="$(node --version)"
-  elif [ "${NODE_VERSION}" = 'none' ]; then
-    nvm_echo "Detected node version ${NODE_VERSION}, npm version v${NPM_VERSION}"
-    NODE_VERSION=''
+  local LOCAL_NVM_NODE_VERSION
+  LOCAL_NVM_NODE_VERSION="$(nvm_strip_iojs_prefix "$(nvm_ls_current)")"
+  if [ "${LOCAL_NVM_NODE_VERSION}" = 'system' ]; then
+    LOCAL_NVM_NODE_VERSION="$(node --version)"
+  elif [ "${LOCAL_NVM_NODE_VERSION}" = 'none' ]; then
+    nvm_echo "Detected node version ${LOCAL_NVM_NODE_VERSION}, npm version v${LOCAL_NPM_VERSION}"
+    LOCAL_NVM_NODE_VERSION=''
   fi
-  if [ -z "${NODE_VERSION}" ]; then
+  if [ -z "${LOCAL_NVM_NODE_VERSION}" ]; then
     nvm_err 'Unable to obtain node version.'
     return 1
   fi
-  local NPM_VERSION
-  NPM_VERSION="$(npm --version 2>/dev/null)"
-  if [ -z "${NPM_VERSION}" ]; then
+  local LOCAL_NPM_VERSION
+  LOCAL_NPM_VERSION="$(npm --version 2>/dev/null)"
+  if [ -z "${LOCAL_NPM_VERSION}" ]; then
     nvm_err 'Unable to obtain npm version.'
     return 2
   fi
 
-  local NVM_NPM_CMD
-  NVM_NPM_CMD='npm'
+  local LOCAL_NVM_TOOL_NPM
+  LOCAL_NVM_TOOL_NPM='npm'
   if [ "${NVM_DEBUG-}" = 1 ]; then
-    nvm_echo "Detected node version ${NODE_VERSION}, npm version v${NPM_VERSION}"
-    NVM_NPM_CMD='nvm_echo npm'
+    nvm_echo "Detected node version ${LOCAL_NVM_NODE_VERSION}, npm version v${LOCAL_NPM_VERSION}"
+    LOCAL_NVM_TOOL_NPM='nvm_echo npm'
   fi
 
-  local NVM_IS_0_6
-  NVM_IS_0_6=0
-  if nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 0.6.0 && nvm_version_greater 0.7.0 "${NODE_VERSION}"; then
-    NVM_IS_0_6=1
+  local LOCAL_NVM_IS_0_6
+  LOCAL_NVM_IS_0_6=0
+  if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 0.6.0 && nvm_version_greater 0.7.0 "${LOCAL_NVM_NODE_VERSION}"; then
+    LOCAL_NVM_IS_0_6=1
   fi
-  local NVM_IS_0_9
-  NVM_IS_0_9=0
-  if nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 0.9.0 && nvm_version_greater 0.10.0 "${NODE_VERSION}"; then
-    NVM_IS_0_9=1
+  local LOCAL_NVM_IS_0_9
+  LOCAL_NVM_IS_0_9=0
+  if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 0.9.0 && nvm_version_greater 0.10.0 "${LOCAL_NVM_NODE_VERSION}"; then
+    LOCAL_NVM_IS_0_9=1
   fi
 
-  if [ $NVM_IS_0_6 -eq 1 ]; then
+  if [ ${LOCAL_NVM_IS_0_6} -eq 1 ]; then
     nvm_echo '* `node` v0.6.x can only upgrade to `npm` v1.3.x'
-    $NVM_NPM_CMD install -g npm@1.3
-  elif [ $NVM_IS_0_9 -eq 0 ]; then
+    ${LOCAL_NVM_TOOL_NPM} install -g npm@1.3
+  elif [ ${LOCAL_NVM_IS_0_9} -eq 0 ]; then
     # node 0.9 breaks here, for some reason
-    if nvm_version_greater_than_or_equal_to "${NPM_VERSION}" 1.0.0 && nvm_version_greater 2.0.0 "${NPM_VERSION}"; then
+    if nvm_version_greater_than_or_equal_to "${LOCAL_NPM_VERSION}" 1.0.0 && nvm_version_greater 2.0.0 "${LOCAL_NPM_VERSION}"; then
       nvm_echo '* `npm` v1.x needs to first jump to `npm` v1.4.28 to be able to upgrade further'
-      $NVM_NPM_CMD install -g npm@1.4.28
-    elif nvm_version_greater_than_or_equal_to "${NPM_VERSION}" 2.0.0 && nvm_version_greater 3.0.0 "${NPM_VERSION}"; then
+      ${LOCAL_NVM_TOOL_NPM} install -g npm@1.4.28
+    elif nvm_version_greater_than_or_equal_to "${LOCAL_NPM_VERSION}" 2.0.0 && nvm_version_greater 3.0.0 "${LOCAL_NPM_VERSION}"; then
       nvm_echo '* `npm` v2.x needs to first jump to the latest v2 to be able to upgrade further'
-      $NVM_NPM_CMD install -g npm@2
+      ${LOCAL_NVM_TOOL_NPM} install -g npm@2
     fi
   fi
 
-  if [ $NVM_IS_0_9 -eq 1 ] || [ $NVM_IS_0_6 -eq 1 ]; then
+  if [ ${LOCAL_NVM_IS_0_9} -eq 1 ] || [ ${LOCAL_NVM_IS_0_6} -eq 1 ]; then
     nvm_echo '* node v0.6 and v0.9 are unable to upgrade further'
-  elif nvm_version_greater 1.1.0 "${NODE_VERSION}"; then
+  elif nvm_version_greater 1.1.0 "${LOCAL_NVM_NODE_VERSION}"; then
     nvm_echo '* `npm` v4.5.x is the last version that works on `node` versions < v1.1.0'
-    $NVM_NPM_CMD install -g npm@4.5
-  elif nvm_version_greater 4.0.0 "${NODE_VERSION}"; then
+    ${LOCAL_NVM_TOOL_NPM} install -g npm@4.5
+  elif nvm_version_greater 4.0.0 "${LOCAL_NVM_NODE_VERSION}"; then
     nvm_echo '* `npm` v5 and higher do not work on `node` versions below v4.0.0'
-    $NVM_NPM_CMD install -g npm@4
-  elif [ $NVM_IS_0_9 -eq 0 ] && [ $NVM_IS_0_6 -eq 0 ]; then
-    local NVM_IS_4_4_OR_BELOW
-    NVM_IS_4_4_OR_BELOW=0
-    if nvm_version_greater 4.5.0 "${NODE_VERSION}"; then
-      NVM_IS_4_4_OR_BELOW=1
+    ${LOCAL_NVM_TOOL_NPM} install -g npm@4
+  elif [ ${LOCAL_NVM_IS_0_9} -eq 0 ] && [ ${LOCAL_NVM_IS_0_6} -eq 0 ]; then
+    local LOCAL_NVM_IS_4_4_OR_BELOW
+    LOCAL_NVM_IS_4_4_OR_BELOW=0
+    if nvm_version_greater 4.5.0 "${LOCAL_NVM_NODE_VERSION}"; then
+      LOCAL_NVM_IS_4_4_OR_BELOW=1
     fi
 
-    local NVM_IS_5_OR_ABOVE
-    NVM_IS_5_OR_ABOVE=0
-    if [ $NVM_IS_4_4_OR_BELOW -eq 0 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 5.0.0; then
-      NVM_IS_5_OR_ABOVE=1
+    local LOCAL_NVM_IS_5_OR_ABOVE
+    LOCAL_NVM_IS_5_OR_ABOVE=0
+    if [ ${LOCAL_NVM_IS_4_4_OR_BELOW} -eq 0 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 5.0.0; then
+      LOCAL_NVM_IS_5_OR_ABOVE=1
     fi
 
-    local NVM_IS_6_OR_ABOVE
-    NVM_IS_6_OR_ABOVE=0
-    local NVM_IS_6_2_OR_ABOVE
-    NVM_IS_6_2_OR_ABOVE=0
-    if [ $NVM_IS_5_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 6.0.0; then
-      NVM_IS_6_OR_ABOVE=1
-      if nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 6.2.0; then
-        NVM_IS_6_2_OR_ABOVE=1
+    local LOCAL_NVM_IS_6_OR_ABOVE
+    LOCAL_NVM_IS_6_OR_ABOVE=0
+    local LOCAL_NVM_IS_6_2_OR_ABOVE
+    LOCAL_NVM_IS_6_2_OR_ABOVE=0
+    if [ ${LOCAL_NVM_IS_5_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 6.0.0; then
+      LOCAL_NVM_IS_6_OR_ABOVE=1
+      if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 6.2.0; then
+        LOCAL_NVM_IS_6_2_OR_ABOVE=1
       fi
     fi
 
-    local NVM_IS_9_OR_ABOVE
-    NVM_IS_9_OR_ABOVE=0
-    local NVM_IS_9_3_OR_ABOVE
-    NVM_IS_9_3_OR_ABOVE=0
-    if [ $NVM_IS_6_2_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 9.0.0; then
-      NVM_IS_9_OR_ABOVE=1
-      if nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 9.3.0; then
-        NVM_IS_9_3_OR_ABOVE=1
+    local LOCAL_NVM_IS_9_OR_ABOVE
+    LOCAL_NVM_IS_9_OR_ABOVE=0
+    local LOCAL_NVM_IS_9_3_OR_ABOVE
+    LOCAL_NVM_IS_9_3_OR_ABOVE=0
+    if [ ${LOCAL_NVM_IS_6_2_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 9.0.0; then
+      LOCAL_NVM_IS_9_OR_ABOVE=1
+      if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 9.3.0; then
+        LOCAL_NVM_IS_9_3_OR_ABOVE=1
       fi
     fi
 
-    local NVM_IS_10_OR_ABOVE
-    NVM_IS_10_OR_ABOVE=0
-    if [ $NVM_IS_9_3_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 10.0.0; then
-      NVM_IS_10_OR_ABOVE=1
+    local LOCAL_NVM_IS_10_OR_ABOVE
+    LOCAL_NVM_IS_10_OR_ABOVE=0
+    if [ ${LOCAL_NVM_IS_9_3_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 10.0.0; then
+      LOCAL_NVM_IS_10_OR_ABOVE=1
     fi
-    local NVM_IS_12_LTS_OR_ABOVE
-    NVM_IS_12_LTS_OR_ABOVE=0
-    if [ $NVM_IS_10_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 12.13.0; then
-      NVM_IS_12_LTS_OR_ABOVE=1
+    local LOCAL_NVM_IS_12_LTS_OR_ABOVE
+    LOCAL_NVM_IS_12_LTS_OR_ABOVE=0
+    if [ ${LOCAL_NVM_IS_10_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 12.13.0; then
+      LOCAL_NVM_IS_12_LTS_OR_ABOVE=1
     fi
-    local NVM_IS_13_OR_ABOVE
-    NVM_IS_13_OR_ABOVE=0
-    if [ $NVM_IS_12_LTS_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 13.0.0; then
-      NVM_IS_13_OR_ABOVE=1
+    local LOCAL_NVM_IS_13_OR_ABOVE
+    LOCAL_NVM_IS_13_OR_ABOVE=0
+    if [ ${LOCAL_NVM_IS_12_LTS_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 13.0.0; then
+      LOCAL_NVM_IS_13_OR_ABOVE=1
     fi
-    local NVM_IS_14_LTS_OR_ABOVE
-    NVM_IS_14_LTS_OR_ABOVE=0
-    if [ $NVM_IS_13_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 14.15.0; then
-      NVM_IS_14_LTS_OR_ABOVE=1
+    local LOCAL_NVM_IS_14_LTS_OR_ABOVE
+    LOCAL_NVM_IS_14_LTS_OR_ABOVE=0
+    if [ ${LOCAL_NVM_IS_13_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 14.15.0; then
+      LOCAL_NVM_IS_14_LTS_OR_ABOVE=1
     fi
-    local NVM_IS_15_OR_ABOVE
-    NVM_IS_15_OR_ABOVE=0
-    if [ $NVM_IS_14_LTS_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 15.0.0; then
-      NVM_IS_15_OR_ABOVE=1
+    local LOCAL_NVM_IS_15_OR_ABOVE
+    LOCAL_NVM_IS_15_OR_ABOVE=0
+    if [ ${LOCAL_NVM_IS_14_LTS_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 15.0.0; then
+      LOCAL_NVM_IS_15_OR_ABOVE=1
     fi
-    local NVM_IS_16_OR_ABOVE
-    NVM_IS_16_OR_ABOVE=0
-    if [ $NVM_IS_15_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 16.0.0; then
-      NVM_IS_16_OR_ABOVE=1
+    local LOCAL_NVM_IS_16_OR_ABOVE
+    LOCAL_NVM_IS_16_OR_ABOVE=0
+    if [ ${LOCAL_NVM_IS_15_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 16.0.0; then
+      LOCAL_NVM_IS_16_OR_ABOVE=1
     fi
 
-    if [ $NVM_IS_4_4_OR_BELOW -eq 1 ] || {
-      [ $NVM_IS_5_OR_ABOVE -eq 1 ] && nvm_version_greater 5.10.0 "${NODE_VERSION}"; \
+    if [ ${LOCAL_NVM_IS_4_4_OR_BELOW} -eq 1 ] || {
+      [ ${LOCAL_NVM_IS_5_OR_ABOVE} -eq 1 ] && nvm_version_greater 5.10.0 "${LOCAL_NVM_NODE_VERSION}"; \
     }; then
       nvm_echo '* `npm` `v5.3.x` is the last version that works on `node` 4.x versions below v4.4, or 5.x versions below v5.10, due to `Buffer.alloc`'
-      $NVM_NPM_CMD install -g npm@5.3
-    elif [ $NVM_IS_4_4_OR_BELOW -eq 0 ] && nvm_version_greater 4.7.0 "${NODE_VERSION}"; then
+      ${LOCAL_NVM_TOOL_NPM} install -g npm@5.3
+    elif [ ${LOCAL_NVM_IS_4_4_OR_BELOW} -eq 0 ] && nvm_version_greater 4.7.0 "${LOCAL_NVM_NODE_VERSION}"; then
       nvm_echo '* `npm` `v5.4.1` is the last version that works on `node` `v4.5` and `v4.6`'
-      $NVM_NPM_CMD install -g npm@5.4.1
-    elif [ $NVM_IS_6_OR_ABOVE -eq 0 ]; then
+      ${LOCAL_NVM_TOOL_NPM} install -g npm@5.4.1
+    elif [ ${LOCAL_NVM_IS_6_OR_ABOVE} -eq 0 ]; then
       nvm_echo '* `npm` `v5.x` is the last version that works on `node` below `v6.0.0`'
-      $NVM_NPM_CMD install -g npm@5
+      ${LOCAL_NVM_TOOL_NPM} install -g npm@5
     elif \
-      { [ $NVM_IS_6_OR_ABOVE -eq 1 ] && [ $NVM_IS_6_2_OR_ABOVE -eq 0 ]; } \
-      || { [ $NVM_IS_9_OR_ABOVE -eq 1 ] && [ $NVM_IS_9_3_OR_ABOVE -eq 0 ]; } \
+      { [ ${LOCAL_NVM_IS_6_OR_ABOVE} -eq 1 ] && [ ${LOCAL_NVM_IS_6_2_OR_ABOVE} -eq 0 ]; } \
+      || { [ ${LOCAL_NVM_IS_9_OR_ABOVE} -eq 1 ] && [ ${LOCAL_NVM_IS_9_3_OR_ABOVE} -eq 0 ]; } \
     ; then
       nvm_echo '* `npm` `v6.9` is the last version that works on `node` `v6.0.x`, `v6.1.x`, `v9.0.x`, `v9.1.x`, or `v9.2.x`'
-      $NVM_NPM_CMD install -g npm@6.9
-    elif [ $NVM_IS_10_OR_ABOVE -eq 0 ]; then
+      ${LOCAL_NVM_TOOL_NPM} install -g npm@6.9
+    elif [ ${LOCAL_NVM_IS_10_OR_ABOVE} -eq 0 ]; then
       nvm_echo '* `npm` `v6.x` is the last version that works on `node` below `v10.0.0`'
-      $NVM_NPM_CMD install -g npm@6
+      ${LOCAL_NVM_TOOL_NPM} install -g npm@6
     elif \
-      [ $NVM_IS_12_LTS_OR_ABOVE -eq 0 ] \
-      || { [ $NVM_IS_13_OR_ABOVE -eq 1 ] && [ $NVM_IS_14_LTS_OR_ABOVE -eq 0 ]; } \
-      || { [ $NVM_IS_15_OR_ABOVE -eq 1 ] && [ $NVM_IS_16_OR_ABOVE -eq 0 ]; } \
+      [ ${LOCAL_NVM_IS_12_LTS_OR_ABOVE} -eq 0 ] \
+      || { [ ${LOCAL_NVM_IS_13_OR_ABOVE} -eq 1 ] && [ ${LOCAL_NVM_IS_14_LTS_OR_ABOVE} -eq 0 ]; } \
+      || { [ ${LOCAL_NVM_IS_15_OR_ABOVE} -eq 1 ] && [ ${LOCAL_NVM_IS_16_OR_ABOVE} -eq 0 ]; } \
     ; then
       nvm_echo '* `npm` `v7.x` is the last version that works on `node` `v13`, `v15`, below `v12.13`, or `v14.0` - `v14.15`'
-      $NVM_NPM_CMD install -g npm@7
+      ${LOCAL_NVM_TOOL_NPM} install -g npm@7
     else
       nvm_echo '* Installing latest `npm`; if this does not work on your node version, please report a bug!'
-      $NVM_NPM_CMD install -g npm
+      ${LOCAL_NVM_TOOL_NPM} install -g npm
     fi
   fi
   nvm_echo "* npm upgraded to: v$(npm --version 2>/dev/null)"
@@ -349,86 +349,86 @@ if [ -z "${NVM_DIR-}" ]; then
   export NVM_DIR
 else
   # https://unix.stackexchange.com/a/198289
-  case $NVM_DIR in
+  case ${NVM_DIR} in
     *[!/]*/)
       NVM_DIR="${NVM_DIR%"${NVM_DIR##*[!/]}"}"
       export NVM_DIR
-      nvm_err "Warning: \$NVM_DIR should not have trailing slashes"
+      nvm_err "Warning: \${NVM_DIR} should not have trailing slashes"
     ;;
   esac
 fi
 unset NVM_SCRIPT_SOURCE 2>/dev/null
 
 nvm_tree_contains_path() {
-  local tree
-  tree="${1-}"
-  local node_path
-  node_path="${2-}"
+  local LOCAL_NVM_TREE
+  LOCAL_NVM_TREE="${1-}"
+  local LOCAL_NVM_NODE_PATH
+  LOCAL_NVM_NODE_PATH="${2-}"
 
-  if [ "@${tree}@" = "@@" ] || [ "@${node_path}@" = "@@" ]; then
+  if [ "@${LOCAL_NVM_TREE}@" = "@@" ] || [ "@${LOCAL_NVM_NODE_PATH}@" = "@@" ]; then
     nvm_err "both the tree and the node path are required"
     return 2
   fi
 
-  local previous_pathdir
-  previous_pathdir="${node_path}"
-  local pathdir
-  pathdir=$(dirname "${previous_pathdir}")
-  while [ "${pathdir}" != '' ] && [ "${pathdir}" != '.' ] && [ "${pathdir}" != '/' ] &&
-      [ "${pathdir}" != "${tree}" ] && [ "${pathdir}" != "${previous_pathdir}" ]; do
-    previous_pathdir="${pathdir}"
-    pathdir=$(dirname "${previous_pathdir}")
+  local LOCAL_NVM_PREVIOUS_PATHDIR
+  LOCAL_NVM_PREVIOUS_PATHDIR="${LOCAL_NVM_NODE_PATH}"
+  local LOCAL_NVM_PATHDIR
+  LOCAL_NVM_PATHDIR=$(dirname "${LOCAL_NVM_PREVIOUS_PATHDIR}")
+  while [ "${LOCAL_NVM_PATHDIR}" != '' ] && [ "${LOCAL_NVM_PATHDIR}" != '.' ] && [ "${LOCAL_NVM_PATHDIR}" != '/' ] &&
+      [ "${LOCAL_NVM_PATHDIR}" != "${LOCAL_NVM_TREE}" ] && [ "${LOCAL_NVM_PATHDIR}" != "${LOCAL_NVM_PREVIOUS_PATHDIR}" ]; do
+    LOCAL_NVM_PREVIOUS_PATHDIR="${LOCAL_NVM_PATHDIR}"
+    LOCAL_NVM_PATHDIR=$(dirname "${LOCAL_NVM_PREVIOUS_PATHDIR}")
   done
-  [ "${pathdir}" = "${tree}" ]
+  [ "${LOCAL_NVM_PATHDIR}" = "${LOCAL_NVM_TREE}" ]
 }
 
 nvm_find_project_dir() {
-  local path_
-  path_="${PWD}"
-  while [ "${path_}" != "" ] && [ ! -f "${path_}/package.json" ] && [ ! -d "${path_}/node_modules" ]; do
-    path_=${path_%/*}
+  local LOCAL_NVM_PATH
+  LOCAL_NVM_PATH="${PWD}"
+  while [ "${LOCAL_NVM_PATH}" != "" ] && [ ! -f "${LOCAL_NVM_PATH}/package.json" ] && [ ! -d "${LOCAL_NVM_PATH}/node_modules" ]; do
+    LOCAL_NVM_PATH=${LOCAL_NVM_PATH%/*}
   done
-  nvm_echo "${path_}"
+  nvm_echo "${LOCAL_NVM_PATH}"
 }
 
 # Traverse up in directory tree to find containing folder
 nvm_find_up() {
-  local path_
-  path_="${PWD}"
-  while [ "${path_}" != "" ] && [ ! -f "${path_}/${1-}" ]; do
-    path_=${path_%/*}
+  local LOCAL_NVM_PATH
+  LOCAL_NVM_PATH="${PWD}"
+  while [ "${LOCAL_NVM_PATH}" != "" ] && [ ! -f "${LOCAL_NVM_PATH}/${1-}" ]; do
+    LOCAL_NVM_PATH=${LOCAL_NVM_PATH%/*}
   done
-  nvm_echo "${path_}"
+  nvm_echo "${LOCAL_NVM_PATH}"
 }
 
 nvm_find_nvmrc() {
-  local dir
-  dir="$(nvm_find_up '.nvmrc')"
-  if [ -e "${dir}/.nvmrc" ]; then
-    nvm_echo "${dir}/.nvmrc"
+  local LOCAL_NVM_DIR
+  LOCAL_NVM_DIR="$(nvm_find_up '.nvmrc')"
+  if [ -e "${LOCAL_NVM_DIR}/.nvmrc" ]; then
+    nvm_echo "${LOCAL_NVM_DIR}/.nvmrc"
   fi
 }
 
 # Obtain nvm version from rc file
 nvm_rc_version() {
   export NVM_RC_VERSION=''
-  local NVMRC_PATH
-  NVMRC_PATH="$(nvm_find_nvmrc)"
-  if [ ! -e "${NVMRC_PATH}" ]; then
-    if [ "${NVM_SILENT:-0}" -ne 1 ]; then
+  local LOCAL_NVM_RC_PATH
+  LOCAL_NVM_RC_PATH="$(nvm_find_nvmrc)"
+  if [ ! -e "${LOCAL_NVM_RC_PATH}" ]; then
+    if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
       nvm_err "No .nvmrc file found"
     fi
     return 1
   fi
-  NVM_RC_VERSION="$(command head -n 1 "${NVMRC_PATH}" | command tr -d '\r')" || command printf ''
+  NVM_RC_VERSION="$(command head -n 1 "${LOCAL_NVM_RC_PATH}" | command tr -d '\r')" || command printf ''
   if [ -z "${NVM_RC_VERSION}" ]; then
-    if [ "${NVM_SILENT:-0}" -ne 1 ]; then
-      nvm_err "Warning: empty .nvmrc file found at \"${NVMRC_PATH}\""
+    if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+      nvm_err "Warning: empty .nvmrc file found at \"${LOCAL_NVM_RC_PATH}\""
     fi
     return 2
   fi
-  if [ "${NVM_SILENT:-0}" -ne 1 ]; then
-    nvm_echo "Found '${NVMRC_PATH}' with version <${NVM_RC_VERSION}>"
+  if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+    nvm_echo "Found '${LOCAL_NVM_RC_PATH}' with version <${NVM_RC_VERSION}>"
   fi
 }
 
@@ -470,13 +470,13 @@ nvm_version_greater_than_or_equal_to() {
 }
 
 nvm_version_dir() {
-  local NVM_WHICH_DIR
-  NVM_WHICH_DIR="${1-}"
-  if [ -z "${NVM_WHICH_DIR}" ] || [ "${NVM_WHICH_DIR}" = "new" ]; then
+  local LOCAL_NVM_WHICH_DIR
+  LOCAL_NVM_WHICH_DIR="${1-}"
+  if [ -z "${LOCAL_NVM_WHICH_DIR}" ] || [ "${LOCAL_NVM_WHICH_DIR}" = "new" ]; then
     nvm_echo "${NVM_DIR}/versions/node"
-  elif [ "_${NVM_WHICH_DIR}" = "_iojs" ]; then
+  elif [ "_${LOCAL_NVM_WHICH_DIR}" = "_iojs" ]; then
     nvm_echo "${NVM_DIR}/versions/io.js"
-  elif [ "_${NVM_WHICH_DIR}" = "_old" ]; then
+  elif [ "_${LOCAL_NVM_WHICH_DIR}" = "_old" ]; then
     nvm_echo "${NVM_DIR}"
   else
     nvm_err 'unknown version dir'
@@ -489,177 +489,177 @@ nvm_alias_path() {
 }
 
 nvm_version_path() {
-  local VERSION
-  VERSION="${1-}"
-  if [ -z "${VERSION}" ]; then
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="${1-}"
+  if [ -z "${LOCAL_NVM_VERSION}" ]; then
     nvm_err 'version is required'
     return 3
-  elif nvm_is_iojs_version "${VERSION}"; then
-    nvm_echo "$(nvm_version_dir iojs)/$(nvm_strip_iojs_prefix "${VERSION}")"
-  elif nvm_version_greater 0.12.0 "${VERSION}"; then
-    nvm_echo "$(nvm_version_dir old)/${VERSION}"
+  elif nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
+    nvm_echo "$(nvm_version_dir iojs)/$(nvm_strip_iojs_prefix "${LOCAL_NVM_VERSION}")"
+  elif nvm_version_greater 0.12.0 "${LOCAL_NVM_VERSION}"; then
+    nvm_echo "$(nvm_version_dir old)/${LOCAL_NVM_VERSION}"
   else
-    nvm_echo "$(nvm_version_dir new)/${VERSION}"
+    nvm_echo "$(nvm_version_dir new)/${LOCAL_NVM_VERSION}"
   fi
 }
 
 nvm_ensure_version_installed() {
-  local PROVIDED_VERSION
-  PROVIDED_VERSION="${1-}"
-  if [ "${PROVIDED_VERSION}" = 'system' ]; then
+  local LOCAL_NVM_PROVIDED_VERSION
+  LOCAL_NVM_PROVIDED_VERSION="${1-}"
+  if [ "${LOCAL_NVM_PROVIDED_VERSION}" = 'system' ]; then
     if nvm_has_system_iojs || nvm_has_system_node; then
       return 0
     fi
     nvm_err "N/A: no system version of node/io.js is installed."
     return 1
   fi
-  local LOCAL_VERSION
-  local EXIT_CODE
-  LOCAL_VERSION="$(nvm_version "${PROVIDED_VERSION}")"
-  EXIT_CODE="$?"
-  local NVM_VERSION_DIR
-  if [ "${EXIT_CODE}" != "0" ] || ! nvm_is_version_installed "${LOCAL_VERSION}"; then
-    if VERSION="$(nvm_resolve_alias "${PROVIDED_VERSION}")"; then
-      nvm_err "N/A: version \"${PROVIDED_VERSION} -> ${VERSION}\" is not yet installed."
+  local LOCAL_NVM_VERSION
+  local LOCAL_NVM_EXIT_CODE
+  LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")"
+  LOCAL_NVM_EXIT_CODE="$?"
+  if [ "${LOCAL_NVM_EXIT_CODE}" != "0" ] || ! nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
+    if LOCAL_NVM_ALIAS_VERSION="$(nvm_resolve_alias "${LOCAL_NVM_PROVIDED_VERSION}")"; then
+      nvm_err "N/A: version \"${LOCAL_NVM_PROVIDED_VERSION} -> ${LOCAL_NVM_ALIAS_VERSION}\" is not yet installed."
     else
-      local PREFIXED_VERSION
-      PREFIXED_VERSION="$(nvm_ensure_version_prefix "${PROVIDED_VERSION}")"
-      nvm_err "N/A: version \"${PREFIXED_VERSION:-$PROVIDED_VERSION}\" is not yet installed."
+      local LOCAL_NVM_PREFIXED_VERSION
+      LOCAL_NVM_PREFIXED_VERSION="$(nvm_ensure_version_prefix "${LOCAL_NVM_PROVIDED_VERSION}")"
+      nvm_err "N/A: version \"${LOCAL_NVM_PREFIXED_VERSION:-${LOCAL_NVM_PROVIDED_VERSION}}\" is not yet installed."
     fi
     nvm_err ""
-    nvm_err "You need to run \"nvm install ${PROVIDED_VERSION}\" to install it before using it."
+    nvm_err "You need to run \"nvm install ${LOCAL_NVM_PROVIDED_VERSION}\" to install it before using it."
     return 1
   fi
 }
 
 # Expand a version using the version cache
 nvm_version() {
-  local PATTERN
-  PATTERN="${1-}"
-  local VERSION
+  local LOCAL_NVM_PATTERN
+  LOCAL_NVM_PATTERN="${1-}"
+  local LOCAL_NVM_VERSION
   # The default version is the current one
-  if [ -z "${PATTERN}" ]; then
-    PATTERN='current'
+  if [ -z "${LOCAL_NVM_PATTERN}" ]; then
+    LOCAL_NVM_PATTERN='current'
   fi
 
-  if [ "${PATTERN}" = "current" ]; then
+  if [ "${LOCAL_NVM_PATTERN}" = "current" ]; then
     nvm_ls_current
     return $?
   fi
 
-  local NVM_NODE_PREFIX
-  NVM_NODE_PREFIX="$(nvm_node_prefix)"
-  case "_${PATTERN}" in
-    "_${NVM_NODE_PREFIX}" | "_${NVM_NODE_PREFIX}-")
-      PATTERN="stable"
+  local LOCAL_NVM_NODE_PREFIX
+  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
+  case "_${LOCAL_NVM_PATTERN}" in
+    "_${LOCAL_NVM_NODE_PREFIX}" | "_${LOCAL_NVM_NODE_PREFIX}-")
+      LOCAL_NVM_PATTERN="stable"
     ;;
   esac
-  VERSION="$(nvm_ls "${PATTERN}" | command tail -1)"
-  if [ -z "${VERSION}" ] || [ "_${VERSION}" = "_N/A" ]; then
+  LOCAL_NVM_VERSION="$(nvm_ls "${LOCAL_NVM_PATTERN}" | command tail -1)"
+  if [ -z "${LOCAL_NVM_VERSION}" ] || [ "_${LOCAL_NVM_VERSION}" = "_N/A" ]; then
     nvm_echo "N/A"
     return 3
   fi
-  nvm_echo "${VERSION}"
+  nvm_echo "${LOCAL_NVM_VERSION}"
 }
 
 nvm_remote_version() {
-  local PATTERN
-  PATTERN="${1-}"
-  local VERSION
-  if nvm_validate_implicit_alias "${PATTERN}" 2>/dev/null; then
-    case "${PATTERN}" in
+  local LOCAL_NVM_PATTERN
+  LOCAL_NVM_PATTERN="${1-}"
+  local LOCAL_NVM_VERSION
+  if nvm_validate_implicit_alias "${LOCAL_NVM_PATTERN}" 2>/dev/null; then
+    case "${LOCAL_NVM_PATTERN}" in
       "$(nvm_iojs_prefix)")
-        VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote_iojs | command tail -1)" &&:
+        LOCAL_NVM_VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote_iojs | command tail -1)" &&:
       ;;
       *)
-        VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${PATTERN}")" &&:
+        LOCAL_NVM_VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${LOCAL_NVM_PATTERN}")" &&:
       ;;
     esac
   else
-    VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_remote_versions "${PATTERN}" | command tail -1)"
+    LOCAL_NVM_VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_remote_versions "${LOCAL_NVM_PATTERN}" | command tail -1)"
   fi
   if [ -n "${NVM_VERSION_ONLY-}" ]; then
     command awk 'BEGIN {
       n = split(ARGV[1], a);
       print a[1]
-    }' "${VERSION}"
+    }' "${LOCAL_NVM_VERSION}"
   else
-    nvm_echo "${VERSION}"
+    nvm_echo "${LOCAL_NVM_VERSION}"
   fi
-  if [ "${VERSION}" = 'N/A' ]; then
+  if [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
     return 3
   fi
 }
 
 nvm_remote_versions() {
-  local NVM_IOJS_PREFIX
-  NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local NVM_NODE_PREFIX
-  NVM_NODE_PREFIX="$(nvm_node_prefix)"
+  local LOCAL_NVM_IOJS_PREFIX
+  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local LOCAL_NVM_NODE_PREFIX
+  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
 
-  local PATTERN
-  PATTERN="${1-}"
+  local LOCAL_NVM_PATTERN
+  LOCAL_NVM_PATTERN="${1-}"
 
-  local NVM_FLAVOR
+  local LOCAL_NVM_FLAVOR
   if [ -n "${NVM_LTS-}" ]; then
-    NVM_FLAVOR="${NVM_NODE_PREFIX}"
+    LOCAL_NVM_FLAVOR="${LOCAL_NVM_NODE_PREFIX}"
   fi
 
-  case "${PATTERN}" in
-    "${NVM_IOJS_PREFIX}" | "io.js")
-      NVM_FLAVOR="${NVM_IOJS_PREFIX}"
-      unset PATTERN
+  case "${LOCAL_NVM_PATTERN}" in
+    "${LOCAL_NVM_IOJS_PREFIX}" | "io.js")
+      LOCAL_NVM_FLAVOR="${LOCAL_NVM_IOJS_PREFIX}"
+      unset LOCAL_NVM_PATTERN
     ;;
-    "${NVM_NODE_PREFIX}")
-      NVM_FLAVOR="${NVM_NODE_PREFIX}"
-      unset PATTERN
+    "${LOCAL_NVM_NODE_PREFIX}")
+      LOCAL_NVM_FLAVOR="${LOCAL_NVM_NODE_PREFIX}"
+      unset LOCAL_NVM_PATTERN
     ;;
   esac
 
-  if nvm_validate_implicit_alias "${PATTERN-}" 2>/dev/null; then
+  if nvm_validate_implicit_alias "${LOCAL_NVM_PATTERN-}" 2>/dev/null; then
     nvm_err 'Implicit aliases are not supported in nvm_remote_versions.'
     return 1
   fi
 
-  local NVM_LS_REMOTE_EXIT_CODE
-  NVM_LS_REMOTE_EXIT_CODE=0
-  local NVM_LS_REMOTE_PRE_MERGED_OUTPUT
-  NVM_LS_REMOTE_PRE_MERGED_OUTPUT=''
-  local NVM_LS_REMOTE_POST_MERGED_OUTPUT
-  NVM_LS_REMOTE_POST_MERGED_OUTPUT=''
-  if [ -z "${NVM_FLAVOR-}" ] || [ "${NVM_FLAVOR-}" = "${NVM_NODE_PREFIX}" ]; then
-    local NVM_LS_REMOTE_OUTPUT
+  local LOCAL_NVM_LS_REMOTE_EXIT_CODE
+  LOCAL_NVM_LS_REMOTE_EXIT_CODE=0
+  local LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT
+  LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT=''
+  local LOCAL_NVM_LS_REMOTE_POST_MERGED_OUTPUT
+  LOCAL_NVM_LS_REMOTE_POST_MERGED_OUTPUT=''
+  if [ -z "${LOCAL_NVM_FLAVOR-}" ] || [ "${LOCAL_NVM_FLAVOR-}" = "${LOCAL_NVM_NODE_PREFIX}" ]; then
+    local LOCAL_NVM_LS_REMOTE_OUTPUT
     # extra space is needed here to avoid weird behavior when `nvm_ls_remote` ends in a `*`
-    NVM_LS_REMOTE_OUTPUT="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${PATTERN-}") " &&:
-    NVM_LS_REMOTE_EXIT_CODE=$?
+    LOCAL_NVM_LS_REMOTE_OUTPUT="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${LOCAL_NVM_PATTERN-}") " &&:
+    LOCAL_NVM_LS_REMOTE_EXIT_CODE=$?
     # split output into two
-    NVM_LS_REMOTE_PRE_MERGED_OUTPUT="${NVM_LS_REMOTE_OUTPUT%%v4\.0\.0*}"
-    NVM_LS_REMOTE_POST_MERGED_OUTPUT="${NVM_LS_REMOTE_OUTPUT#"$NVM_LS_REMOTE_PRE_MERGED_OUTPUT"}"
+    LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT="${LOCAL_NVM_LS_REMOTE_OUTPUT%%v4\.0\.0*}"
+    LOCAL_NVM_LS_REMOTE_POST_MERGED_OUTPUT="${LOCAL_NVM_LS_REMOTE_OUTPUT#"${LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT}"}"
   fi
 
-  local NVM_LS_REMOTE_IOJS_EXIT_CODE
-  NVM_LS_REMOTE_IOJS_EXIT_CODE=0
-  local NVM_LS_REMOTE_IOJS_OUTPUT
-  NVM_LS_REMOTE_IOJS_OUTPUT=''
+  local LOCAL_NVM_LS_REMOTE_IOJS_EXIT_CODE
+  LOCAL_NVM_LS_REMOTE_IOJS_EXIT_CODE=0
+  local LOCAL_NVM_LS_REMOTE_IOJS_OUTPUT
+  LOCAL_NVM_LS_REMOTE_IOJS_OUTPUT=''
   if [ -z "${NVM_LTS-}" ] && {
-    [ -z "${NVM_FLAVOR-}" ] || [ "${NVM_FLAVOR-}" = "${NVM_IOJS_PREFIX}" ];
+    [ -z "${LOCAL_NVM_FLAVOR-}" ] || [ "${LOCAL_NVM_FLAVOR-}" = "${LOCAL_NVM_IOJS_PREFIX}" ];
   }; then
-    NVM_LS_REMOTE_IOJS_OUTPUT=$(nvm_ls_remote_iojs "${PATTERN-}") &&:
-    NVM_LS_REMOTE_IOJS_EXIT_CODE=$?
+    LOCAL_NVM_LS_REMOTE_IOJS_OUTPUT=$(nvm_ls_remote_iojs "${LOCAL_NVM_PATTERN-}") &&:
+    LOCAL_NVM_LS_REMOTE_IOJS_EXIT_CODE=$?
   fi
 
   # the `sed` removes both blank lines, and only-whitespace lines (see "weird behavior" ~19 lines up)
-  VERSIONS="$(nvm_echo "${NVM_LS_REMOTE_PRE_MERGED_OUTPUT}
-${NVM_LS_REMOTE_IOJS_OUTPUT}
-${NVM_LS_REMOTE_POST_MERGED_OUTPUT}" | nvm_grep -v "N/A" | command sed '/^ *$/d')"
+  local LOCAL_NVM_VERSIONS
+  LOCAL_NVM_VERSIONS="$(nvm_echo "${LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT}
+${LOCAL_NVM_LS_REMOTE_IOJS_OUTPUT}
+${LOCAL_NVM_LS_REMOTE_POST_MERGED_OUTPUT}" | nvm_grep -v "N/A" | command sed '/^ *$/d')"
 
-  if [ -z "${VERSIONS}" ]; then
+  if [ -z "${LOCAL_NVM_VERSIONS}" ]; then
     nvm_echo 'N/A'
     return 3
   fi
   # the `sed` is to remove trailing whitespaces (see "weird behavior" ~25 lines up)
-  nvm_echo "${VERSIONS}" | command sed 's/ *$//g'
-  return $NVM_LS_REMOTE_EXIT_CODE || $NVM_LS_REMOTE_IOJS_EXIT_CODE
+  nvm_echo "${LOCAL_NVM_VERSIONS}" | command sed 's/ *$//g'
+  return ${LOCAL_NVM_LS_REMOTE_EXIT_CODE} || ${LOCAL_NVM_LS_REMOTE_IOJS_EXIT_CODE}
 }
 
 nvm_is_valid_version() {
@@ -672,9 +672,9 @@ nvm_is_valid_version() {
       return 0
     ;;
     *)
-      local VERSION
-      VERSION="$(nvm_strip_iojs_prefix "${1-}")"
-      nvm_version_greater_than_or_equal_to "${VERSION}" 0
+      local LOCAL_NVM_VERSION
+      LOCAL_NVM_VERSION="$(nvm_strip_iojs_prefix "${1-}")"
+      nvm_version_greater_than_or_equal_to "${LOCAL_NVM_VERSION}" 0
     ;;
   esac
 }
@@ -688,64 +688,64 @@ nvm_normalize_version() {
 }
 
 nvm_normalize_lts() {
-  local LTS
-  LTS="${1-}"
+  local LOCAL_NVM_LTS
+  LOCAL_NVM_LTS="${1-}"
 
-  if [ "$(expr "${LTS}" : '^lts/-[1-9][0-9]*$')" -gt 0 ]; then
-    local N
-    N="$(echo "${LTS}" | cut -d '-' -f 2)"
-    N=$((N+1))
-    local NVM_ALIAS_DIR
-    NVM_ALIAS_DIR="$(nvm_alias_path)"
-    local RESULT
-    RESULT="$(command ls "${NVM_ALIAS_DIR}/lts" | command tail -n "${N}" | command head -n 1)"
-    if [ "${RESULT}" != '*' ]; then
-      nvm_echo "lts/${RESULT}"
+  if [ "$(expr "${LOCAL_NVM_LTS}" : '^lts/-[1-9][0-9]*$')" -gt 0 ]; then
+    local LOCAL_NVM_N
+    LOCAL_NVM_N="$(echo "${LOCAL_NVM_LTS}" | cut -d '-' -f 2)"
+    LOCAL_NVM_N=$((LOCAL_NVM_N+1))
+    local LOCAL_NVM_ALIAS_DIR
+    LOCAL_NVM_ALIAS_DIR="$(nvm_alias_path)"
+    local LOCAL_NVM_RESULT
+    LOCAL_NVM_RESULT="$(command ls "${LOCAL_NVM_ALIAS_DIR}/lts" | command tail -n "${LOCAL_NVM_N}" | command head -n 1)"
+    if [ "${LOCAL_NVM_RESULT}" != '*' ]; then
+      nvm_echo "lts/${LOCAL_NVM_RESULT}"
     else
       nvm_err 'That many LTS releases do not exist yet.'
       return 2
     fi
   else
-    nvm_echo "${LTS}"
+    nvm_echo "${LOCAL_NVM_LTS}"
   fi
 }
 
 nvm_ensure_version_prefix() {
-  local NVM_VERSION
-  NVM_VERSION="$(nvm_strip_iojs_prefix "${1-}" | command sed -e 's/^\([0-9]\)/v\1/g')"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="$(nvm_strip_iojs_prefix "${1-}" | command sed -e 's/^\([0-9]\)/v\1/g')"
   if nvm_is_iojs_version "${1-}"; then
-    nvm_add_iojs_prefix "${NVM_VERSION}"
+    nvm_add_iojs_prefix "${LOCAL_NVM_VERSION}"
   else
-    nvm_echo "${NVM_VERSION}"
+    nvm_echo "${LOCAL_NVM_VERSION}"
   fi
 }
 
 nvm_format_version() {
-  local VERSION
-  VERSION="$(nvm_ensure_version_prefix "${1-}")"
-  local NUM_GROUPS
-  NUM_GROUPS="$(nvm_num_version_groups "${VERSION}")"
-  if [ "${NUM_GROUPS}" -lt 3 ]; then
-    nvm_format_version "${VERSION%.}.0"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="$(nvm_ensure_version_prefix "${1-}")"
+  local LOCAL_NVM_NUM_GROUPS
+  LOCAL_NVM_NUM_GROUPS="$(nvm_num_version_groups "${LOCAL_NVM_VERSION}")"
+  if [ "${LOCAL_NVM_NUM_GROUPS}" -lt 3 ]; then
+    nvm_format_version "${LOCAL_NVM_VERSION%.}.0"
   else
-    nvm_echo "${VERSION}" | command cut -f1-3 -d.
+    nvm_echo "${LOCAL_NVM_VERSION}" | command cut -f1-3 -d.
   fi
 }
 
 nvm_num_version_groups() {
-  local VERSION
-  VERSION="${1-}"
-  VERSION="${VERSION#v}"
-  VERSION="${VERSION%.}"
-  if [ -z "${VERSION}" ]; then
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="${1-}"
+  LOCAL_NVM_VERSION="${LOCAL_NVM_VERSION#v}"
+  LOCAL_NVM_VERSION="${LOCAL_NVM_VERSION%.}"
+  if [ -z "${LOCAL_NVM_VERSION}" ]; then
     nvm_echo "0"
     return
   fi
-  local NVM_NUM_DOTS
-  NVM_NUM_DOTS=$(nvm_echo "${VERSION}" | command sed -e 's/[^\.]//g')
-  local NVM_NUM_GROUPS
-  NVM_NUM_GROUPS=".${NVM_NUM_DOTS}" # add extra dot, since it's (n - 1) dots at this point
-  nvm_echo "${#NVM_NUM_GROUPS}"
+  local LOCAL_NVM_NUM_DOTS
+  LOCAL_NVM_NUM_DOTS=$(nvm_echo "${LOCAL_NVM_VERSION}" | command sed -e 's/[^\.]//g')
+  local LOCAL_NVM_NUM_GROUPS
+  LOCAL_NVM_NUM_GROUPS=".${LOCAL_NVM_NUM_DOTS}" # add extra dot, since it's (n - 1) dots at this point
+  nvm_echo "${#LOCAL_NVM_NUM_GROUPS}"
 }
 
 nvm_strip_path() {
@@ -793,22 +793,22 @@ nvm_binary_available() {
 
 nvm_set_colors() {
   if [ "${#1}" -eq 5 ] && nvm_echo "$1" | nvm_grep -E "^[rRgGbBcCyYmMkKeW]{1,}$" 1>/dev/null; then
-    local INSTALLED_COLOR
-    local LTS_AND_SYSTEM_COLOR
-    local CURRENT_COLOR
-    local NOT_INSTALLED_COLOR
-    local DEFAULT_COLOR
+    local LOCAL_NVM_INSTALLED_COLOR
+    local LOCAL_NVM_LTS_AND_SYSTEM_COLOR
+    local LOCAL_NVM_CURRENT_COLOR
+    local LOCAL_NVM_NOT_INSTALLED_COLOR
+    local LOCAL_NVM_DEFAULT_COLOR
 
-    INSTALLED_COLOR="$(echo "$1" | awk '{ print substr($0, 1, 1); }')"
-    LTS_AND_SYSTEM_COLOR="$(echo "$1" | awk '{ print substr($0, 2, 1); }')"
-    CURRENT_COLOR="$(echo "$1" | awk '{ print substr($0, 3, 1); }')"
-    NOT_INSTALLED_COLOR="$(echo "$1" | awk '{ print substr($0, 4, 1); }')"
-    DEFAULT_COLOR="$(echo "$1" | awk '{ print substr($0, 5, 1); }')"
+    LOCAL_NVM_INSTALLED_COLOR="$(echo "$1" | awk '{ print substr($0, 1, 1); }')"
+    LOCAL_NVM_LTS_AND_SYSTEM_COLOR="$(echo "$1" | awk '{ print substr($0, 2, 1); }')"
+    LOCAL_NVM_CURRENT_COLOR="$(echo "$1" | awk '{ print substr($0, 3, 1); }')"
+    LOCAL_NVM_NOT_INSTALLED_COLOR="$(echo "$1" | awk '{ print substr($0, 4, 1); }')"
+    LOCAL_NVM_DEFAULT_COLOR="$(echo "$1" | awk '{ print substr($0, 5, 1); }')"
     if ! nvm_has_colors; then
-      nvm_echo "Setting colors to: ${INSTALLED_COLOR} ${LTS_AND_SYSTEM_COLOR} ${CURRENT_COLOR} ${NOT_INSTALLED_COLOR} ${DEFAULT_COLOR}"
+      nvm_echo "Setting colors to: ${LOCAL_NVM_INSTALLED_COLOR} ${LOCAL_NVM_LTS_AND_SYSTEM_COLOR} ${LOCAL_NVM_CURRENT_COLOR} ${LOCAL_NVM_NOT_INSTALLED_COLOR} ${LOCAL_NVM_DEFAULT_COLOR}"
       nvm_echo "WARNING: Colors may not display because they are not supported in this shell."
     else
-      nvm_echo_with_colors "Setting colors to: \033[$(nvm_print_color_code "${INSTALLED_COLOR}") ${INSTALLED_COLOR}\033[$(nvm_print_color_code "${LTS_AND_SYSTEM_COLOR}") ${LTS_AND_SYSTEM_COLOR}\033[$(nvm_print_color_code "${CURRENT_COLOR}") ${CURRENT_COLOR}\033[$(nvm_print_color_code "${NOT_INSTALLED_COLOR}") ${NOT_INSTALLED_COLOR}\033[$(nvm_print_color_code "${DEFAULT_COLOR}") ${DEFAULT_COLOR}\033[0m"
+      nvm_echo_with_colors "Setting colors to: \033[$(nvm_print_color_code "${LOCAL_NVM_INSTALLED_COLOR}") ${LOCAL_NVM_INSTALLED_COLOR}\033[$(nvm_print_color_code "${LOCAL_NVM_LTS_AND_SYSTEM_COLOR}") ${LOCAL_NVM_LTS_AND_SYSTEM_COLOR}\033[$(nvm_print_color_code "${LOCAL_NVM_CURRENT_COLOR}") ${LOCAL_NVM_CURRENT_COLOR}\033[$(nvm_print_color_code "${LOCAL_NVM_NOT_INSTALLED_COLOR}") ${LOCAL_NVM_NOT_INSTALLED_COLOR}\033[$(nvm_print_color_code "${LOCAL_NVM_DEFAULT_COLOR}") ${LOCAL_NVM_DEFAULT_COLOR}\033[0m"
     fi
     export NVM_COLORS="$1"
   else
@@ -817,18 +817,18 @@ nvm_set_colors() {
 }
 
 nvm_get_colors() {
-  local COLOR
-  local SYS_COLOR
+  local LOCAL_NVM_COLOR
+  local LOCAL_NVM_SYS_COLOR
   if [ -n "${NVM_COLORS-}" ]; then
     case $1 in
-      1) COLOR=$(nvm_print_color_code "$(echo "$NVM_COLORS" | awk '{ print substr($0, 1, 1); }')");;
-      2) COLOR=$(nvm_print_color_code "$(echo "$NVM_COLORS" | awk '{ print substr($0, 2, 1); }')");;
-      3) COLOR=$(nvm_print_color_code "$(echo "$NVM_COLORS" | awk '{ print substr($0, 3, 1); }')");;
-      4) COLOR=$(nvm_print_color_code "$(echo "$NVM_COLORS" | awk '{ print substr($0, 4, 1); }')");;
-      5) COLOR=$(nvm_print_color_code "$(echo "$NVM_COLORS" | awk '{ print substr($0, 5, 1); }')");;
+      1) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 1, 1); }')");;
+      2) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 2, 1); }')");;
+      3) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 3, 1); }')");;
+      4) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 4, 1); }')");;
+      5) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 5, 1); }')");;
       6)
-        SYS_COLOR=$(nvm_print_color_code "$(echo "$NVM_COLORS" | awk '{ print substr($0, 2, 1); }')")
-        COLOR=$(nvm_echo "$SYS_COLOR" | command tr '0;' '1;')
+        LOCAL_NVM_SYS_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 2, 1); }')")
+        LOCAL_NVM_COLOR=$(nvm_echo "${LOCAL_NVM_SYS_COLOR}" | command tr '0;' '1;')
         ;;
       *)
         nvm_err "Invalid color index, ${1-}"
@@ -837,12 +837,12 @@ nvm_get_colors() {
     esac
   else
     case $1 in
-      1) COLOR='0;34m';;
-      2) COLOR='0;33m';;
-      3) COLOR='0;32m';;
-      4) COLOR='0;31m';;
-      5) COLOR='0;37m';;
-      6) COLOR='1;33m';;
+      1) LOCAL_NVM_COLOR='0;34m';;
+      2) LOCAL_NVM_COLOR='0;33m';;
+      3) LOCAL_NVM_COLOR='0;32m';;
+      4) LOCAL_NVM_COLOR='0;31m';;
+      5) LOCAL_NVM_COLOR='0;37m';;
+      6) LOCAL_NVM_COLOR='1;33m';;
       *)
         nvm_err "Invalid color index, ${1-}"
         return 1
@@ -850,7 +850,7 @@ nvm_get_colors() {
     esac
   fi
 
-  echo "$COLOR"
+  echo "${LOCAL_NVM_COLOR}"
 }
 
 nvm_print_color_code() {
@@ -878,179 +878,181 @@ nvm_print_color_code() {
 }
 
 nvm_print_formatted_alias() {
-  local ALIAS
-  ALIAS="${1-}"
-  local DEST
-  DEST="${2-}"
-  local VERSION
-  VERSION="${3-}"
-  if [ -z "${VERSION}" ]; then
-    VERSION="$(nvm_version "${DEST}")" ||:
+  local LOCAL_NVM_ALIAS
+  LOCAL_NVM_ALIAS="${1-}"
+  local LOCAL_NVM_DEST
+  LOCAL_NVM_DEST="${2-}"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="${3-}"
+  if [ -z "${LOCAL_NVM_VERSION}" ]; then
+    LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_DEST}")" ||:
   fi
-  local VERSION_FORMAT
-  local ALIAS_FORMAT
-  local DEST_FORMAT
 
-  local INSTALLED_COLOR
-  local SYSTEM_COLOR
-  local CURRENT_COLOR
-  local NOT_INSTALLED_COLOR
-  local DEFAULT_COLOR
-  local LTS_COLOR
+  local LOCAL_NVM_INSTALLED_COLOR
+  local LOCAL_NVM_SYSTEM_COLOR
+  local LOCAL_NVM_CURRENT_COLOR
+  local LOCAL_NVM_NOT_INSTALLED_COLOR
+  local LOCAL_NVM_DEFAULT_COLOR
+  local LOCAL_NVM_LTS_COLOR
+  LOCAL_NVM_INSTALLED_COLOR=$(nvm_get_colors 1)
+  LOCAL_NVM_SYSTEM_COLOR=$(nvm_get_colors 2)
+  LOCAL_NVM_CURRENT_COLOR=$(nvm_get_colors 3)
+  LOCAL_NVM_NOT_INSTALLED_COLOR=$(nvm_get_colors 4)
+  LOCAL_NVM_DEFAULT_COLOR=$(nvm_get_colors 5)
+  LOCAL_NVM_LTS_COLOR=$(nvm_get_colors 6)
 
-  INSTALLED_COLOR=$(nvm_get_colors 1)
-  SYSTEM_COLOR=$(nvm_get_colors 2)
-  CURRENT_COLOR=$(nvm_get_colors 3)
-  NOT_INSTALLED_COLOR=$(nvm_get_colors 4)
-  DEFAULT_COLOR=$(nvm_get_colors 5)
-  LTS_COLOR=$(nvm_get_colors 6)
+  local LOCAL_NVM_DEST_FORMAT
+  local LOCAL_NVM_ALIAS_FORMAT
+  local LOCAL_NVM_VERSION_FORMAT
+  LOCAL_NVM_DEST_FORMAT='%s'
+  LOCAL_NVM_ALIAS_FORMAT='%s'
+  LOCAL_NVM_VERSION_FORMAT='%s'
 
-  ALIAS_FORMAT='%s'
-  DEST_FORMAT='%s'
-  VERSION_FORMAT='%s'
-  local NEWLINE
-  NEWLINE='\n'
-  if [ "_${DEFAULT}" = '_true' ]; then
-    NEWLINE=' (default)\n'
+  local LOCAL_NVM_NEWLINE
+  LOCAL_NVM_NEWLINE='\n'
+  if [ "_${NVM_DEFAULT}" = '_true' ]; then
+    LOCAL_NVM_NEWLINE=' (default)\n'
   fi
-  local ARROW
-  ARROW='->'
+
+  local LOCAL_NVM_ARROW
+  LOCAL_NVM_ARROW='->'
   if [ -z "${NVM_NO_COLORS}" ] && nvm_has_colors; then
-    ARROW='\033[0;90m->\033[0m'
-    if [ "_${DEFAULT}" = '_true' ]; then
-      NEWLINE=" \033[${DEFAULT_COLOR}(default)\033[0m\n"
+    LOCAL_NVM_ARROW='\033[0;90m->\033[0m'
+    if [ "_${NVM_DEFAULT}" = '_true' ]; then
+      LOCAL_NVM_NEWLINE=" \033[${LOCAL_NVM_DEFAULT_COLOR}(default)\033[0m\n"
     fi
-    if [ "_${VERSION}" = "_${NVM_CURRENT-}" ]; then
-      ALIAS_FORMAT="\033[${CURRENT_COLOR}%s\033[0m"
-      DEST_FORMAT="\033[${CURRENT_COLOR}%s\033[0m"
-      VERSION_FORMAT="\033[${CURRENT_COLOR}%s\033[0m"
-    elif nvm_is_version_installed "${VERSION}"; then
-      ALIAS_FORMAT="\033[${INSTALLED_COLOR}%s\033[0m"
-      DEST_FORMAT="\033[${INSTALLED_COLOR}%s\033[0m"
-      VERSION_FORMAT="\033[${INSTALLED_COLOR}%s\033[0m"
-    elif [ "${VERSION}" = '∞' ] || [ "${VERSION}" = 'N/A' ]; then
-      ALIAS_FORMAT="\033[${NOT_INSTALLED_COLOR}%s\033[0m"
-      DEST_FORMAT="\033[${NOT_INSTALLED_COLOR}%s\033[0m"
-      VERSION_FORMAT="\033[${NOT_INSTALLED_COLOR}%s\033[0m"
+    if [ "_${LOCAL_NVM_VERSION}" = "_${LOCAL_NVM_CURRENT-}" ]; then
+      LOCAL_NVM_ALIAS_FORMAT="\033[${LOCAL_NVM_CURRENT_COLOR}%s\033[0m"
+      LOCAL_NVM_DEST_FORMAT="\033[${LOCAL_NVM_CURRENT_COLOR}%s\033[0m"
+      LOCAL_NVM_VERSION_FORMAT="\033[${LOCAL_NVM_CURRENT_COLOR}%s\033[0m"
+    elif nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
+      LOCAL_NVM_ALIAS_FORMAT="\033[${LOCAL_NVM_INSTALLED_COLOR}%s\033[0m"
+      LOCAL_NVM_DEST_FORMAT="\033[${LOCAL_NVM_INSTALLED_COLOR}%s\033[0m"
+      LOCAL_NVM_VERSION_FORMAT="\033[${LOCAL_NVM_INSTALLED_COLOR}%s\033[0m"
+    elif [ "${LOCAL_NVM_VERSION}" = '∞' ] || [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
+      LOCAL_NVM_ALIAS_FORMAT="\033[${LOCAL_NVM_NOT_INSTALLED_COLOR}%s\033[0m"
+      LOCAL_NVM_DEST_FORMAT="\033[${LOCAL_NVM_NOT_INSTALLED_COLOR}%s\033[0m"
+      LOCAL_NVM_VERSION_FORMAT="\033[${LOCAL_NVM_NOT_INSTALLED_COLOR}%s\033[0m"
     fi
     if [ "_${NVM_LTS-}" = '_true' ]; then
-      ALIAS_FORMAT="\033[${LTS_COLOR}%s\033[0m"
+      LOCAL_NVM_ALIAS_FORMAT="\033[${LOCAL_NVM_LTS_COLOR}%s\033[0m"
     fi
-    if [ "_${DEST%/*}" = "_lts" ]; then
-      DEST_FORMAT="\033[${LTS_COLOR}%s\033[0m"
+    if [ "_${LOCAL_NVM_DEST%/*}" = "_lts" ]; then
+      LOCAL_NVM_DEST_FORMAT="\033[${LOCAL_NVM_LTS_COLOR}%s\033[0m"
     fi
-  elif [ "_${VERSION}" != '_∞' ] && [ "_${VERSION}" != '_N/A' ]; then
-    VERSION_FORMAT='%s *'
+  elif [ "_${LOCAL_NVM_VERSION}" != '_∞' ] && [ "_${LOCAL_NVM_VERSION}" != '_N/A' ]; then
+    LOCAL_NVM_VERSION_FORMAT='%s *'
   fi
-  if [ "${DEST}" = "${VERSION}" ]; then
-    command printf -- "${ALIAS_FORMAT} ${ARROW} ${VERSION_FORMAT}${NEWLINE}" "${ALIAS}" "${DEST}"
+  if [ "${LOCAL_NVM_DEST}" = "${LOCAL_NVM_VERSION}" ]; then
+    command printf -- "${LOCAL_NVM_ALIAS_FORMAT} ${LOCAL_NVM_ARROW} ${LOCAL_NVM_VERSION_FORMAT}${LOCAL_NVM_NEWLINE}" "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_DEST}"
   else
-    command printf -- "${ALIAS_FORMAT} ${ARROW} ${DEST_FORMAT} (${ARROW} ${VERSION_FORMAT})${NEWLINE}" "${ALIAS}" "${DEST}" "${VERSION}"
+    command printf -- "${LOCAL_NVM_ALIAS_FORMAT} ${LOCAL_NVM_ARROW} ${LOCAL_NVM_DEST_FORMAT} (${LOCAL_NVM_ARROW} ${LOCAL_NVM_VERSION_FORMAT})${LOCAL_NVM_NEWLINE}" "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_DEST}" "${LOCAL_NVM_VERSION}"
   fi
 }
 
 nvm_print_alias_path() {
-  local NVM_ALIAS_DIR
-  NVM_ALIAS_DIR="${1-}"
-  if [ -z "${NVM_ALIAS_DIR}" ]; then
+  local LOCAL_NVM_ALIAS_DIR
+  LOCAL_NVM_ALIAS_DIR="${1-}"
+  if [ -z "${LOCAL_NVM_ALIAS_DIR}" ]; then
     nvm_err 'An alias dir is required.'
     return 1
   fi
-  local ALIAS_PATH
-  ALIAS_PATH="${2-}"
-  if [ -z "${ALIAS_PATH}" ]; then
+  local LOCAL_NVM_ALIAS_PATH
+  LOCAL_NVM_ALIAS_PATH="${2-}"
+  if [ -z "${LOCAL_NVM_ALIAS_PATH}" ]; then
     nvm_err 'An alias path is required.'
     return 2
   fi
-  local ALIAS
-  ALIAS="${ALIAS_PATH##"${NVM_ALIAS_DIR}"\/}"
-  local DEST
-  DEST="$(nvm_alias "${ALIAS}" 2>/dev/null)" ||:
-  if [ -n "${DEST}" ]; then
-    NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LTS="${NVM_LTS-}" DEFAULT=false nvm_print_formatted_alias "${ALIAS}" "${DEST}"
+  local LOCAL_NVM_ALIAS
+  LOCAL_NVM_ALIAS="${LOCAL_NVM_ALIAS_PATH##"${LOCAL_NVM_ALIAS_DIR}"\/}"
+  local LOCAL_NVM_DEST
+  LOCAL_NVM_DEST="$(nvm_alias "${LOCAL_NVM_ALIAS}" 2>/dev/null)" ||:
+  if [ -n "${LOCAL_NVM_DEST}" ]; then
+    NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LTS="${NVM_LTS-}" NVM_DEFAULT=false nvm_print_formatted_alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_DEST}"
   fi
 }
 
 nvm_print_default_alias() {
-  local ALIAS
-  ALIAS="${1-}"
-  if [ -z "${ALIAS}" ]; then
+  local LOCAL_NVM_ALIAS
+  LOCAL_NVM_ALIAS="${1-}"
+  if [ -z "${LOCAL_NVM_ALIAS}" ]; then
     nvm_err 'A default alias is required.'
     return 1
   fi
-  local DEST
-  DEST="$(nvm_print_implicit_alias local "${ALIAS}")"
-  if [ -n "${DEST}" ]; then
-    NVM_NO_COLORS="${NVM_NO_COLORS-}" DEFAULT=true nvm_print_formatted_alias "${ALIAS}" "${DEST}"
+  local LOCAL_NVM_DEST
+  LOCAL_NVM_DEST="$(nvm_print_implicit_alias local "${LOCAL_NVM_ALIAS}")"
+  if [ -n "${LOCAL_NVM_DEST}" ]; then
+    NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_DEFAULT=true nvm_print_formatted_alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_DEST}"
   fi
 }
 
 nvm_make_alias() {
-  local ALIAS
-  ALIAS="${1-}"
-  if [ -z "${ALIAS}" ]; then
+  local LOCAL_NVM_ALIAS
+  LOCAL_NVM_ALIAS="${1-}"
+  if [ -z "${LOCAL_NVM_ALIAS}" ]; then
     nvm_err "an alias name is required"
     return 1
   fi
-  local VERSION
-  VERSION="${2-}"
-  if [ -z "${VERSION}" ]; then
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="${2-}"
+  if [ -z "${LOCAL_NVM_VERSION}" ]; then
     nvm_err "an alias target version is required"
     return 2
   fi
-  nvm_echo "${VERSION}" | tee "$(nvm_alias_path)/${ALIAS}" >/dev/null
+  nvm_echo "${LOCAL_NVM_VERSION}" | tee "$(nvm_alias_path)/${LOCAL_NVM_ALIAS}" >/dev/null
 }
 
 nvm_list_aliases() {
-  local ALIAS
-  ALIAS="${1-}"
+  local LOCAL_NVM_ALIAS
+  LOCAL_NVM_ALIAS="${1-}"
 
-  local NVM_CURRENT
-  NVM_CURRENT="$(nvm_ls_current)"
-  local NVM_ALIAS_DIR
-  NVM_ALIAS_DIR="$(nvm_alias_path)"
-  command mkdir -p "${NVM_ALIAS_DIR}/lts"
+  local LOCAL_NVM_CURRENT
+  LOCAL_NVM_CURRENT="$(nvm_ls_current)"
+  local LOCAL_NVM_ALIAS_DIR
+  LOCAL_NVM_ALIAS_DIR="$(nvm_alias_path)"
+  command mkdir -p "${LOCAL_NVM_ALIAS_DIR}/lts"
 
-  if [ "${ALIAS}" != "${ALIAS#lts/}" ]; then
-    nvm_alias "${ALIAS}"
+  if [ "${LOCAL_NVM_ALIAS}" != "${LOCAL_NVM_ALIAS#lts/}" ]; then
+    nvm_alias "${LOCAL_NVM_ALIAS}"
     return $?
   fi
 
   nvm_is_zsh && unsetopt local_options nomatch
   (
-    local ALIAS_PATH
-    for ALIAS_PATH in "${NVM_ALIAS_DIR}/${ALIAS}"*; do
-      NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_CURRENT="${NVM_CURRENT}" nvm_print_alias_path "${NVM_ALIAS_DIR}" "${ALIAS_PATH}" &
+    local LOCAL_NVM_ALIAS_PATH
+    for LOCAL_NVM_ALIAS_PATH in "${LOCAL_NVM_ALIAS_DIR}/${LOCAL_NVM_ALIAS}"*; do
+      NVM_NO_COLORS="${NVM_NO_COLORS-}" LOCAL_NVM_CURRENT="${LOCAL_NVM_CURRENT}" nvm_print_alias_path "${LOCAL_NVM_ALIAS_DIR}" "${LOCAL_NVM_ALIAS_PATH}" &
     done
     wait
   ) | sort
 
   (
-    local ALIAS_NAME
-    for ALIAS_NAME in "$(nvm_node_prefix)" "stable" "unstable"; do
+    local LOCAL_NVM_ALIAS_NAME
+    for LOCAL_NVM_ALIAS_NAME in "$(nvm_node_prefix)" "stable" "unstable"; do
       {
         # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
-        if [ ! -f "${NVM_ALIAS_DIR}/${ALIAS_NAME}" ] && { [ -z "${ALIAS}" ] || [ "${ALIAS_NAME}" = "${ALIAS}" ]; }; then
-          NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_CURRENT="${NVM_CURRENT}" nvm_print_default_alias "${ALIAS_NAME}"
+        if [ ! -f "${LOCAL_NVM_ALIAS_DIR}/${LOCAL_NVM_ALIAS_NAME}" ] && { [ -z "${LOCAL_NVM_ALIAS}" ] || [ "${LOCAL_NVM_ALIAS_NAME}" = "${LOCAL_NVM_ALIAS}" ]; }; then
+          NVM_NO_COLORS="${NVM_NO_COLORS-}" LOCAL_NVM_CURRENT="${LOCAL_NVM_CURRENT}" nvm_print_default_alias "${LOCAL_NVM_ALIAS_NAME}"
         fi
       } &
     done
     wait
-    ALIAS_NAME="$(nvm_iojs_prefix)"
+    LOCAL_NVM_ALIAS_NAME="$(nvm_iojs_prefix)"
     # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
-    if [ ! -f "${NVM_ALIAS_DIR}/${ALIAS_NAME}" ] && { [ -z "${ALIAS}" ] || [ "${ALIAS_NAME}" = "${ALIAS}" ]; }; then
-      NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_CURRENT="${NVM_CURRENT}" nvm_print_default_alias "${ALIAS_NAME}"
+    if [ ! -f "${LOCAL_NVM_ALIAS_DIR}/${LOCAL_NVM_ALIAS_NAME}" ] && { [ -z "${LOCAL_NVM_ALIAS}" ] || [ "${LOCAL_NVM_ALIAS_NAME}" = "${LOCAL_NVM_ALIAS}" ]; }; then
+      NVM_NO_COLORS="${NVM_NO_COLORS-}" LOCAL_NVM_CURRENT="${LOCAL_NVM_CURRENT}" nvm_print_default_alias "${LOCAL_NVM_ALIAS_NAME}"
     fi
   ) | sort
 
   (
-    local LTS_ALIAS
+    local LOCAL_NVM_LTS_ALIAS
+    local LOCAL_NVM_ALIAS_PATH
     # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
-    for ALIAS_PATH in "${NVM_ALIAS_DIR}/lts/${ALIAS}"*; do
+    for LOCAL_NVM_ALIAS_PATH in "${LOCAL_NVM_ALIAS_DIR}/lts/${LOCAL_NVM_ALIAS}"*; do
       {
-        LTS_ALIAS="$(NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LTS=true nvm_print_alias_path "${NVM_ALIAS_DIR}" "${ALIAS_PATH}")"
-        if [ -n "${LTS_ALIAS}" ]; then
-          nvm_echo "${LTS_ALIAS}"
+        LOCAL_NVM_LTS_ALIAS="$(NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LTS=true nvm_print_alias_path "${LOCAL_NVM_ALIAS_DIR}" "${LOCAL_NVM_ALIAS_PATH}")"
+        if [ -n "${LOCAL_NVM_LTS_ALIAS}" ]; then
+          nvm_echo "${LOCAL_NVM_LTS_ALIAS}"
         fi
       } &
     done
@@ -1060,41 +1062,41 @@ nvm_list_aliases() {
 }
 
 nvm_alias() {
-  local ALIAS
-  ALIAS="${1-}"
-  if [ -z "${ALIAS}" ]; then
+  local LOCAL_NVM_ALIAS
+  LOCAL_NVM_ALIAS="${1-}"
+  if [ -z "${LOCAL_NVM_ALIAS}" ]; then
     nvm_err 'An alias is required.'
     return 1
   fi
-  ALIAS="$(nvm_normalize_lts "${ALIAS}")"
+  LOCAL_NVM_ALIAS="$(nvm_normalize_lts "${LOCAL_NVM_ALIAS}")"
 
-  if [ -z "${ALIAS}" ]; then
+  if [ -z "${LOCAL_NVM_ALIAS}" ]; then
     return 2
   fi
 
-  local NVM_ALIAS_PATH
-  NVM_ALIAS_PATH="$(nvm_alias_path)/${ALIAS}"
-  if [ ! -f "${NVM_ALIAS_PATH}" ]; then
+  local LOCAL_NVM_ALIAS_PATH
+  LOCAL_NVM_ALIAS_PATH="$(nvm_alias_path)/${LOCAL_NVM_ALIAS}"
+  if [ ! -f "${LOCAL_NVM_ALIAS_PATH}" ]; then
     nvm_err 'Alias does not exist.'
     return 2
   fi
 
-  command cat "${NVM_ALIAS_PATH}"
+  command cat "${LOCAL_NVM_ALIAS_PATH}"
 }
 
 nvm_ls_current() {
-  local NVM_LS_CURRENT_NODE_PATH
-  if ! NVM_LS_CURRENT_NODE_PATH="$(command which node 2>/dev/null)"; then
+  local LOCAL_NVM_LS_CURRENT_NODE_PATH
+  if ! LOCAL_NVM_LS_CURRENT_NODE_PATH="$(command which node 2>/dev/null)"; then
     nvm_echo 'none'
-  elif nvm_tree_contains_path "$(nvm_version_dir iojs)" "${NVM_LS_CURRENT_NODE_PATH}"; then
+  elif nvm_tree_contains_path "$(nvm_version_dir iojs)" "${LOCAL_NVM_LS_CURRENT_NODE_PATH}"; then
     nvm_add_iojs_prefix "$(iojs --version 2>/dev/null)"
-  elif nvm_tree_contains_path "${NVM_DIR}" "${NVM_LS_CURRENT_NODE_PATH}"; then
-    local VERSION
-    VERSION="$(node --version 2>/dev/null)"
-    if [ "${VERSION}" = "v0.6.21-pre" ]; then
+  elif nvm_tree_contains_path "${NVM_DIR}" "${LOCAL_NVM_LS_CURRENT_NODE_PATH}"; then
+    local LOCAL_NVM_VERSION
+    LOCAL_NVM_VERSION="$(node --version 2>/dev/null)"
+    if [ "${LOCAL_NVM_VERSION}" = "v0.6.21-pre" ]; then
       nvm_echo 'v0.6.21'
     else
-      nvm_echo "${VERSION}"
+      nvm_echo "${LOCAL_NVM_VERSION}"
     fi
   else
     nvm_echo 'system'
@@ -1106,54 +1108,54 @@ nvm_resolve_alias() {
     return 1
   fi
 
-  local PATTERN
-  PATTERN="${1-}"
+  local LOCAL_NVM_PATTERN
+  LOCAL_NVM_PATTERN="${1-}"
 
-  local ALIAS
-  ALIAS="${PATTERN}"
-  local ALIAS_TEMP
+  local LOCAL_NVM_ALIAS
+  LOCAL_NVM_ALIAS="${LOCAL_NVM_PATTERN}"
+  local LOCAL_NVM_ALIAS_TEMP
 
-  local SEEN_ALIASES
-  SEEN_ALIASES="${ALIAS}"
+  local LOCAL_NVM_SEEN_ALIASES
+  LOCAL_NVM_SEEN_ALIASES="${LOCAL_NVM_ALIAS}"
   while true; do
-    ALIAS_TEMP="$(nvm_alias "${ALIAS}" 2>/dev/null || nvm_echo)"
+    LOCAL_NVM_ALIAS_TEMP="$(nvm_alias "${LOCAL_NVM_ALIAS}" 2>/dev/null || nvm_echo)"
 
-    if [ -z "${ALIAS_TEMP}" ]; then
+    if [ -z "${LOCAL_NVM_ALIAS_TEMP}" ]; then
       break
     fi
 
-    if command printf "${SEEN_ALIASES}" | nvm_grep -q -e "^${ALIAS_TEMP}$"; then
-      ALIAS="∞"
+    if command printf "${LOCAL_NVM_SEEN_ALIASES}" | nvm_grep -q -e "^${LOCAL_NVM_ALIAS_TEMP}$"; then
+      LOCAL_NVM_ALIAS="∞"
       break
     fi
 
-    SEEN_ALIASES="${SEEN_ALIASES}\\n${ALIAS_TEMP}"
-    ALIAS="${ALIAS_TEMP}"
+    LOCAL_NVM_SEEN_ALIASES="${LOCAL_NVM_SEEN_ALIASES}\\n${LOCAL_NVM_ALIAS_TEMP}"
+    LOCAL_NVM_ALIAS="${LOCAL_NVM_ALIAS_TEMP}"
   done
 
-  if [ -n "${ALIAS}" ] && [ "_${ALIAS}" != "_${PATTERN}" ]; then
-    local NVM_IOJS_PREFIX
-    NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-    local NVM_NODE_PREFIX
-    NVM_NODE_PREFIX="$(nvm_node_prefix)"
-    case "${ALIAS}" in
+  if [ -n "${LOCAL_NVM_ALIAS}" ] && [ "_${LOCAL_NVM_ALIAS}" != "_${LOCAL_NVM_PATTERN}" ]; then
+    local LOCAL_NVM_IOJS_PREFIX
+    LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+    local LOCAL_NVM_NODE_PREFIX
+    LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
+    case "${LOCAL_NVM_ALIAS}" in
       '∞' | \
-      "${NVM_IOJS_PREFIX}" | "${NVM_IOJS_PREFIX}-" | \
-      "${NVM_NODE_PREFIX}")
-        nvm_echo "${ALIAS}"
+      "${LOCAL_NVM_IOJS_PREFIX}" | "${LOCAL_NVM_IOJS_PREFIX}-" | \
+      "${LOCAL_NVM_NODE_PREFIX}")
+        nvm_echo "${LOCAL_NVM_ALIAS}"
       ;;
       *)
-        nvm_ensure_version_prefix "${ALIAS}"
+        nvm_ensure_version_prefix "${LOCAL_NVM_ALIAS}"
       ;;
     esac
     return 0
   fi
 
-  if nvm_validate_implicit_alias "${PATTERN}" 2>/dev/null; then
-    local IMPLICIT
-    IMPLICIT="$(nvm_print_implicit_alias local "${PATTERN}" 2>/dev/null)"
-    if [ -n "${IMPLICIT}" ]; then
-      nvm_ensure_version_prefix "${IMPLICIT}"
+  if nvm_validate_implicit_alias "${LOCAL_NVM_PATTERN}" 2>/dev/null; then
+    local LOCAL_NVM_IMPLICIT
+    LOCAL_NVM_IMPLICIT="$(nvm_print_implicit_alias local "${LOCAL_NVM_PATTERN}" 2>/dev/null)"
+    if [ -n "${LOCAL_NVM_IMPLICIT}" ]; then
+      nvm_ensure_version_prefix "${LOCAL_NVM_IMPLICIT}"
     fi
   fi
 
@@ -1165,17 +1167,17 @@ nvm_resolve_local_alias() {
     return 1
   fi
 
-  local VERSION
-  local EXIT_CODE
-  VERSION="$(nvm_resolve_alias "${1-}")"
-  EXIT_CODE=$?
-  if [ -z "${VERSION}" ]; then
-    return $EXIT_CODE
+  local LOCAL_NVM_VERSION
+  local LOCAL_NVM_EXIT_CODE
+  LOCAL_NVM_VERSION="$(nvm_resolve_alias "${1-}")"
+  LOCAL_NVM_EXIT_CODE=$?
+  if [ -z "${LOCAL_NVM_VERSION}" ]; then
+    return ${LOCAL_NVM_EXIT_CODE}
   fi
-  if [ "_${VERSION}" != '_∞' ]; then
-    nvm_version "${VERSION}"
+  if [ "_${LOCAL_NVM_VERSION}" != '_∞' ]; then
+    nvm_version "${LOCAL_NVM_VERSION}"
   else
-    nvm_echo "${VERSION}"
+    nvm_echo "${LOCAL_NVM_VERSION}"
   fi
 }
 
@@ -1196,70 +1198,70 @@ nvm_add_iojs_prefix() {
 }
 
 nvm_strip_iojs_prefix() {
-  local NVM_IOJS_PREFIX
-  NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  if [ "${1-}" = "${NVM_IOJS_PREFIX}" ]; then
+  local LOCAL_NVM_IOJS_PREFIX
+  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  if [ "${1-}" = "${LOCAL_NVM_IOJS_PREFIX}" ]; then
     nvm_echo
   else
-    nvm_echo "${1#"${NVM_IOJS_PREFIX}"-}"
+    nvm_echo "${1#"${LOCAL_NVM_IOJS_PREFIX}"-}"
   fi
 }
 
 nvm_ls() {
-  local PATTERN
-  PATTERN="${1-}"
-  local VERSIONS
-  VERSIONS=''
-  if [ "${PATTERN}" = 'current' ]; then
+  local LOCAL_NVM_PATTERN
+  LOCAL_NVM_PATTERN="${1-}"
+  local LOCAL_NVM_VERSIONS
+  LOCAL_NVM_VERSIONS=''
+  if [ "${LOCAL_NVM_PATTERN}" = 'current' ]; then
     nvm_ls_current
     return
   fi
 
-  local NVM_IOJS_PREFIX
-  NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local NVM_NODE_PREFIX
-  NVM_NODE_PREFIX="$(nvm_node_prefix)"
-  local NVM_VERSION_DIR_IOJS
-  NVM_VERSION_DIR_IOJS="$(nvm_version_dir "${NVM_IOJS_PREFIX}")"
-  local NVM_VERSION_DIR_NEW
-  NVM_VERSION_DIR_NEW="$(nvm_version_dir new)"
-  local NVM_VERSION_DIR_OLD
-  NVM_VERSION_DIR_OLD="$(nvm_version_dir old)"
+  local LOCAL_NVM_IOJS_PREFIX
+  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local LOCAL_NVM_NODE_PREFIX
+  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
+  local LOCAL_NVM_VERSION_DIR_IOJS
+  LOCAL_NVM_VERSION_DIR_IOJS="$(nvm_version_dir "${LOCAL_NVM_IOJS_PREFIX}")"
+  local LOCAL_NVM_VERSION_DIR_NEW
+  LOCAL_NVM_VERSION_DIR_NEW="$(nvm_version_dir new)"
+  local LOCAL_NVM_VERSION_DIR_OLD
+  LOCAL_NVM_VERSION_DIR_OLD="$(nvm_version_dir old)"
 
-  case "${PATTERN}" in
-    "${NVM_IOJS_PREFIX}" | "${NVM_NODE_PREFIX}")
-      PATTERN="${PATTERN}-"
+  case "${LOCAL_NVM_PATTERN}" in
+    "${LOCAL_NVM_IOJS_PREFIX}" | "${LOCAL_NVM_NODE_PREFIX}")
+      LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN}-"
     ;;
     *)
-      if nvm_resolve_local_alias "${PATTERN}"; then
+      if nvm_resolve_local_alias "${LOCAL_NVM_PATTERN}"; then
         return
       fi
-      PATTERN="$(nvm_ensure_version_prefix "${PATTERN}")"
+      LOCAL_NVM_PATTERN="$(nvm_ensure_version_prefix "${LOCAL_NVM_PATTERN}")"
     ;;
   esac
-  if [ "${PATTERN}" = 'N/A' ]; then
+  if [ "${LOCAL_NVM_PATTERN}" = 'N/A' ]; then
     return
   fi
   # If it looks like an explicit version, don't do anything funny
-  local NVM_PATTERN_STARTS_WITH_V
-  case $PATTERN in
-    v*) NVM_PATTERN_STARTS_WITH_V=true ;;
-    *) NVM_PATTERN_STARTS_WITH_V=false ;;
+  local LOCAL_NVM_PATTERN_STARTS_WITH_V
+  case ${LOCAL_NVM_PATTERN} in
+    v*) LOCAL_NVM_PATTERN_STARTS_WITH_V=true ;;
+    *) LOCAL_NVM_PATTERN_STARTS_WITH_V=false ;;
   esac
-  if [ $NVM_PATTERN_STARTS_WITH_V = true ] && [ "_$(nvm_num_version_groups "${PATTERN}")" = "_3" ]; then
-    if nvm_is_version_installed "${PATTERN}"; then
-      VERSIONS="${PATTERN}"
-    elif nvm_is_version_installed "$(nvm_add_iojs_prefix "${PATTERN}")"; then
-      VERSIONS="$(nvm_add_iojs_prefix "${PATTERN}")"
+  if [ ${LOCAL_NVM_PATTERN_STARTS_WITH_V} = true ] && [ "_$(nvm_num_version_groups "${LOCAL_NVM_PATTERN}")" = "_3" ]; then
+    if nvm_is_version_installed "${LOCAL_NVM_PATTERN}"; then
+      LOCAL_NVM_VERSIONS="${LOCAL_NVM_PATTERN}"
+    elif nvm_is_version_installed "$(nvm_add_iojs_prefix "${LOCAL_NVM_PATTERN}")"; then
+      LOCAL_NVM_VERSIONS="$(nvm_add_iojs_prefix "${LOCAL_NVM_PATTERN}")"
     fi
   else
-    case "${PATTERN}" in
-      "${NVM_IOJS_PREFIX}-" | "${NVM_NODE_PREFIX}-" | "system") ;;
+    case "${LOCAL_NVM_PATTERN}" in
+      "${LOCAL_NVM_IOJS_PREFIX}-" | "${LOCAL_NVM_NODE_PREFIX}-" | "system") ;;
       *)
-        local NUM_VERSION_GROUPS
-        NUM_VERSION_GROUPS="$(nvm_num_version_groups "${PATTERN}")"
-        if [ "${NUM_VERSION_GROUPS}" = "2" ] || [ "${NUM_VERSION_GROUPS}" = "1" ]; then
-          PATTERN="${PATTERN%.}."
+        local LOCAL_NVM_NUM_VERSION_GROUPS
+        LOCAL_NVM_NUM_VERSION_GROUPS="$(nvm_num_version_groups "${LOCAL_NVM_PATTERN}")"
+        if [ "${LOCAL_NVM_NUM_VERSION_GROUPS}" = "2" ] || [ "${LOCAL_NVM_NUM_VERSION_GROUPS}" = "1" ]; then
+          LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN%.}."
         fi
       ;;
     esac
@@ -1267,105 +1269,105 @@ nvm_ls() {
     nvm_is_zsh && setopt local_options shwordsplit
     nvm_is_zsh && unsetopt local_options markdirs
 
-    local NVM_DIRS_TO_SEARCH1
-    NVM_DIRS_TO_SEARCH1=''
-    local NVM_DIRS_TO_SEARCH2
-    NVM_DIRS_TO_SEARCH2=''
-    local NVM_DIRS_TO_SEARCH3
-    NVM_DIRS_TO_SEARCH3=''
-    local NVM_ADD_SYSTEM
-    NVM_ADD_SYSTEM=false
-    if nvm_is_iojs_version "${PATTERN}"; then
-      NVM_DIRS_TO_SEARCH1="${NVM_VERSION_DIR_IOJS}"
-      PATTERN="$(nvm_strip_iojs_prefix "${PATTERN}")"
+    local LOCAL_NVM_DIRS_TO_SEARCH1
+    LOCAL_NVM_DIRS_TO_SEARCH1=''
+    local LOCAL_NVM_DIRS_TO_SEARCH2
+    LOCAL_NVM_DIRS_TO_SEARCH2=''
+    local LOCAL_NVM_DIRS_TO_SEARCH3
+    LOCAL_NVM_DIRS_TO_SEARCH3=''
+    local LOCAL_NVM_ADD_SYSTEM
+    LOCAL_NVM_ADD_SYSTEM=false
+    if nvm_is_iojs_version "${LOCAL_NVM_PATTERN}"; then
+      LOCAL_NVM_DIRS_TO_SEARCH1="${LOCAL_NVM_VERSION_DIR_IOJS}"
+      LOCAL_NVM_PATTERN="$(nvm_strip_iojs_prefix "${LOCAL_NVM_PATTERN}")"
       if nvm_has_system_iojs; then
-        NVM_ADD_SYSTEM=true
+        LOCAL_NVM_ADD_SYSTEM=true
       fi
-    elif [ "${PATTERN}" = "${NVM_NODE_PREFIX}-" ]; then
-      NVM_DIRS_TO_SEARCH1="${NVM_VERSION_DIR_OLD}"
-      NVM_DIRS_TO_SEARCH2="${NVM_VERSION_DIR_NEW}"
-      PATTERN=''
+    elif [ "${LOCAL_NVM_PATTERN}" = "${LOCAL_NVM_NODE_PREFIX}-" ]; then
+      LOCAL_NVM_DIRS_TO_SEARCH1="${LOCAL_NVM_VERSION_DIR_OLD}"
+      LOCAL_NVM_DIRS_TO_SEARCH2="${LOCAL_NVM_VERSION_DIR_NEW}"
+      LOCAL_NVM_PATTERN=''
       if nvm_has_system_node; then
-        NVM_ADD_SYSTEM=true
+        LOCAL_NVM_ADD_SYSTEM=true
       fi
     else
-      NVM_DIRS_TO_SEARCH1="${NVM_VERSION_DIR_OLD}"
-      NVM_DIRS_TO_SEARCH2="${NVM_VERSION_DIR_NEW}"
-      NVM_DIRS_TO_SEARCH3="${NVM_VERSION_DIR_IOJS}"
+      LOCAL_NVM_DIRS_TO_SEARCH1="${LOCAL_NVM_VERSION_DIR_OLD}"
+      LOCAL_NVM_DIRS_TO_SEARCH2="${LOCAL_NVM_VERSION_DIR_NEW}"
+      LOCAL_NVM_DIRS_TO_SEARCH3="${LOCAL_NVM_VERSION_DIR_IOJS}"
       if nvm_has_system_iojs || nvm_has_system_node; then
-        NVM_ADD_SYSTEM=true
+        LOCAL_NVM_ADD_SYSTEM=true
       fi
     fi
 
-    if ! [ -d "${NVM_DIRS_TO_SEARCH1}" ] || ! (command ls -1qA "${NVM_DIRS_TO_SEARCH1}" | nvm_grep -q .); then
-      NVM_DIRS_TO_SEARCH1=''
+    if ! [ -d "${LOCAL_NVM_DIRS_TO_SEARCH1}" ] || ! (command ls -1qA "${LOCAL_NVM_DIRS_TO_SEARCH1}" | nvm_grep -q .); then
+      LOCAL_NVM_DIRS_TO_SEARCH1=''
     fi
-    if ! [ -d "${NVM_DIRS_TO_SEARCH2}" ] || ! (command ls -1qA "${NVM_DIRS_TO_SEARCH2}" | nvm_grep -q .); then
-      NVM_DIRS_TO_SEARCH2="${NVM_DIRS_TO_SEARCH1}"
+    if ! [ -d "${LOCAL_NVM_DIRS_TO_SEARCH2}" ] || ! (command ls -1qA "${LOCAL_NVM_DIRS_TO_SEARCH2}" | nvm_grep -q .); then
+      LOCAL_NVM_DIRS_TO_SEARCH2="${LOCAL_NVM_DIRS_TO_SEARCH1}"
     fi
-    if ! [ -d "${NVM_DIRS_TO_SEARCH3}" ] || ! (command ls -1qA "${NVM_DIRS_TO_SEARCH3}" | nvm_grep -q .); then
-      NVM_DIRS_TO_SEARCH3="${NVM_DIRS_TO_SEARCH2}"
+    if ! [ -d "${LOCAL_NVM_DIRS_TO_SEARCH3}" ] || ! (command ls -1qA "${LOCAL_NVM_DIRS_TO_SEARCH3}" | nvm_grep -q .); then
+      LOCAL_NVM_DIRS_TO_SEARCH3="${LOCAL_NVM_DIRS_TO_SEARCH2}"
     fi
 
-    local SEARCH_PATTERN
-    if [ -z "${PATTERN}" ]; then
-      PATTERN='v'
-      SEARCH_PATTERN='.*'
+    local LOCAL_NVM_SEARCH_PATTERN
+    if [ -z "${LOCAL_NVM_PATTERN}" ]; then
+      LOCAL_NVM_PATTERN='v'
+      LOCAL_NVM_SEARCH_PATTERN='.*'
     else
-      SEARCH_PATTERN="$(nvm_echo "${PATTERN}" | command sed 's#\.#\\\.#g;')"
+      LOCAL_NVM_SEARCH_PATTERN="$(nvm_echo "${LOCAL_NVM_PATTERN}" | command sed 's#\.#\\\.#g;')"
     fi
-    if [ -n "${NVM_DIRS_TO_SEARCH1}${NVM_DIRS_TO_SEARCH2}${NVM_DIRS_TO_SEARCH3}" ]; then
-      VERSIONS="$(command find "${NVM_DIRS_TO_SEARCH1}"/* "${NVM_DIRS_TO_SEARCH2}"/* "${NVM_DIRS_TO_SEARCH3}"/* -name . -o -type d -prune -o -path "${PATTERN}*" \
+    if [ -n "${LOCAL_NVM_DIRS_TO_SEARCH1}${LOCAL_NVM_DIRS_TO_SEARCH2}${LOCAL_NVM_DIRS_TO_SEARCH3}" ]; then
+      LOCAL_NVM_VERSIONS="$(command find "${LOCAL_NVM_DIRS_TO_SEARCH1}"/* "${LOCAL_NVM_DIRS_TO_SEARCH2}"/* "${LOCAL_NVM_DIRS_TO_SEARCH3}"/* -name . -o -type d -prune -o -path "${LOCAL_NVM_PATTERN}*" \
         | command sed -e "
-            s#${NVM_VERSION_DIR_IOJS}/#versions/${NVM_IOJS_PREFIX}/#;
+            s#${LOCAL_NVM_VERSION_DIR_IOJS}/#versions/${LOCAL_NVM_IOJS_PREFIX}/#;
             s#^${NVM_DIR}/##;
             \\#^[^v]# d;
             \\#^versions\$# d;
             s#^versions/##;
-            s#^v#${NVM_NODE_PREFIX}/v#;
-            \\#${SEARCH_PATTERN}# !d;
+            s#^v#${LOCAL_NVM_NODE_PREFIX}/v#;
+            \\#${LOCAL_NVM_SEARCH_PATTERN}# !d;
           " \
           -e 's#^\([^/]\{1,\}\)/\(.*\)$#\2.\1#;' \
         | command sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n \
         | command sed -e 's#\(.*\)\.\([^\.]\{1,\}\)$#\2-\1#;' \
-                      -e "s#^${NVM_NODE_PREFIX}-##;" \
+                      -e "s#^${LOCAL_NVM_NODE_PREFIX}-##;" \
       )"
     fi
   fi
 
-  if [ "${NVM_ADD_SYSTEM-}" = true ]; then
-    if [ -z "${PATTERN}" ] || [ "${PATTERN}" = 'v' ]; then
-      VERSIONS="${VERSIONS}$(command printf '\n%s' 'system')"
-    elif [ "${PATTERN}" = 'system' ]; then
-      VERSIONS="$(command printf '%s' 'system')"
+  if [ "${LOCAL_NVM_ADD_SYSTEM-}" = true ]; then
+    if [ -z "${LOCAL_NVM_PATTERN}" ] || [ "${LOCAL_NVM_PATTERN}" = 'v' ]; then
+      LOCAL_NVM_VERSIONS="${LOCAL_NVM_VERSIONS}$(command printf '\n%s' 'system')"
+    elif [ "${LOCAL_NVM_PATTERN}" = 'system' ]; then
+      LOCAL_NVM_VERSIONS="$(command printf '%s' 'system')"
     fi
   fi
 
-  if [ -z "${VERSIONS}" ]; then
+  if [ -z "${LOCAL_NVM_VERSIONS}" ]; then
     nvm_echo 'N/A'
     return 3
   fi
 
-  nvm_echo "${VERSIONS}"
+  nvm_echo "${LOCAL_NVM_VERSIONS}"
 }
 
 nvm_ls_remote() {
-  local PATTERN
-  PATTERN="${1-}"
-  if nvm_validate_implicit_alias "${PATTERN}" 2>/dev/null ; then
-    local IMPLICIT
-    IMPLICIT="$(nvm_print_implicit_alias remote "${PATTERN}")"
-    if [ -z "${IMPLICIT-}" ] || [ "${IMPLICIT}" = 'N/A' ]; then
+  local LOCAL_NVM_PATTERN
+  LOCAL_NVM_PATTERN="${1-}"
+  if nvm_validate_implicit_alias "${LOCAL_NVM_PATTERN}" 2>/dev/null ; then
+    local LOCAL_NVM_IMPLICIT
+    LOCAL_NVM_IMPLICIT="$(nvm_print_implicit_alias remote "${LOCAL_NVM_PATTERN}")"
+    if [ -z "${LOCAL_NVM_IMPLICIT-}" ] || [ "${LOCAL_NVM_IMPLICIT}" = 'N/A' ]; then
       nvm_echo "N/A"
       return 3
     fi
-    PATTERN="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${IMPLICIT}" | command tail -1 | command awk '{ print $1 }')"
-  elif [ -n "${PATTERN}" ]; then
-    PATTERN="$(nvm_ensure_version_prefix "${PATTERN}")"
+    LOCAL_NVM_PATTERN="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${LOCAL_NVM_IMPLICIT}" | command tail -1 | command awk '{ print $1 }')"
+  elif [ -n "${LOCAL_NVM_PATTERN}" ]; then
+    LOCAL_NVM_PATTERN="$(nvm_ensure_version_prefix "${LOCAL_NVM_PATTERN}")"
   else
-    PATTERN=".*"
+    LOCAL_NVM_PATTERN=".*"
   fi
-  NVM_LTS="${NVM_LTS-}" nvm_ls_remote_index_tab node std "${PATTERN}"
+  NVM_LTS="${NVM_LTS-}" nvm_ls_remote_index_tab node std "${LOCAL_NVM_PATTERN}"
 }
 
 nvm_ls_remote_iojs() {
@@ -1374,30 +1376,30 @@ nvm_ls_remote_iojs() {
 
 # args flavor, type, version
 nvm_ls_remote_index_tab() {
-  local LTS
-  LTS="${NVM_LTS-}"
+  local LOCAL_NVM_LTS
+  LOCAL_NVM_LTS="${NVM_LTS-}"
   if [ "$#" -lt 3 ]; then
     nvm_err 'not enough arguments'
     return 5
   fi
 
-  local FLAVOR
-  FLAVOR="${1-}"
+  local LOCAL_NVM_FLAVOR
+  LOCAL_NVM_FLAVOR="${1-}"
 
-  local TYPE
-  TYPE="${2-}"
+  local LOCAL_NVM_TYPE
+  LOCAL_NVM_TYPE="${2-}"
 
-  local MIRROR
-  MIRROR="$(nvm_get_mirror "${FLAVOR}" "${TYPE}")"
-  if [ -z "${MIRROR}" ]; then
+  local LOCAL_NVM_MIRROR
+  LOCAL_NVM_MIRROR="$(nvm_get_mirror "${LOCAL_NVM_FLAVOR}" "${LOCAL_NVM_TYPE}")"
+  if [ -z "${LOCAL_NVM_MIRROR}" ]; then
     return 3
   fi
 
-  local PREFIX
-  PREFIX=''
-  case "${FLAVOR}-${TYPE}" in
-    iojs-std) PREFIX="$(nvm_iojs_prefix)-" ;;
-    node-std) PREFIX='' ;;
+  local LOCAL_NVM_PREFIX
+  LOCAL_NVM_PREFIX=''
+  case "${LOCAL_NVM_FLAVOR}-${LOCAL_NVM_TYPE}" in
+    iojs-std) LOCAL_NVM_PREFIX="$(nvm_iojs_prefix)-" ;;
+    node-std) LOCAL_NVM_PREFIX='' ;;
     iojs-*)
       nvm_err 'unknown type of io.js release'
       return 4
@@ -1407,40 +1409,40 @@ nvm_ls_remote_index_tab() {
       return 4
     ;;
   esac
-  local SORT_COMMAND
-  SORT_COMMAND='command sort'
-  case "${FLAVOR}" in
-    node) SORT_COMMAND='command sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n' ;;
+  local LOCAL_NVM_SORT_COMMAND
+  LOCAL_NVM_SORT_COMMAND='command sort'
+  case "${LOCAL_NVM_FLAVOR}" in
+    node) LOCAL_NVM_SORT_COMMAND='command sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n' ;;
   esac
 
-  local PATTERN
-  PATTERN="${3-}"
+  local LOCAL_NVM_PATTERN
+  LOCAL_NVM_PATTERN="${3-}"
 
-  if [ "${PATTERN#"${PATTERN%?}"}" = '.' ]; then
-    PATTERN="${PATTERN%.}"
+  if [ "${LOCAL_NVM_PATTERN#"${LOCAL_NVM_PATTERN%?}"}" = '.' ]; then
+    LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN%.}"
   fi
 
-  local VERSIONS
-  if [ -n "${PATTERN}" ] && [ "${PATTERN}" != '*' ]; then
-    if [ "${FLAVOR}" = 'iojs' ]; then
-      PATTERN="$(nvm_ensure_version_prefix "$(nvm_strip_iojs_prefix "${PATTERN}")")"
+  local LOCAL_NVM_VERSIONS
+  if [ -n "${LOCAL_NVM_PATTERN}" ] && [ "${LOCAL_NVM_PATTERN}" != '*' ]; then
+    if [ "${LOCAL_NVM_FLAVOR}" = 'iojs' ]; then
+      LOCAL_NVM_PATTERN="$(nvm_ensure_version_prefix "$(nvm_strip_iojs_prefix "${LOCAL_NVM_PATTERN}")")"
     else
-      PATTERN="$(nvm_ensure_version_prefix "${PATTERN}")"
+      LOCAL_NVM_PATTERN="$(nvm_ensure_version_prefix "${LOCAL_NVM_PATTERN}")"
     fi
   else
-    unset PATTERN
+    unset LOCAL_NVM_PATTERN
   fi
 
   nvm_is_zsh && setopt local_options shwordsplit
-  local VERSION_LIST
-  VERSION_LIST="$(nvm_download -L -s "${MIRROR}/index.tab" -o - \
+  local LOCAL_NVM_VERSION_LIST
+  LOCAL_NVM_VERSION_LIST="$(nvm_download -L -s "${LOCAL_NVM_MIRROR}/index.tab" -o - \
     | command sed "
         1d;
-        s/^/${PREFIX}/;
+        s/^/${LOCAL_NVM_PREFIX}/;
       " \
   )"
-  local LTS_ALIAS
-  local LTS_VERSION
+  local LOCAL_NVM_LTS_ALIAS
+  local LOCAL_NVM_LTS_VERSION
   command mkdir -p "$(nvm_alias_path)/lts"
   { command awk '{
         if ($10 ~ /^\-?$/) { next }
@@ -1457,20 +1459,20 @@ nvm_ls_remote_index_tab() {
           print alias, version
         }
       }' \
-    | while read -r LTS_ALIAS_LINE; do
-      LTS_ALIAS="${LTS_ALIAS_LINE%% *}"
-      LTS_VERSION="${LTS_ALIAS_LINE#* }"
-      nvm_make_alias "${LTS_ALIAS}" "${LTS_VERSION}" >/dev/null 2>&1
+    | while read -r LOCAL_NVM_LTS_ALIAS_LINE; do
+      LOCAL_NVM_LTS_ALIAS="${LOCAL_NVM_LTS_ALIAS_LINE%% *}"
+      LOCAL_NVM_LTS_VERSION="${LOCAL_NVM_LTS_ALIAS_LINE#* }"
+      nvm_make_alias "${LOCAL_NVM_LTS_ALIAS}" "${LOCAL_NVM_LTS_VERSION}" >/dev/null 2>&1
     done; } << EOF
-$VERSION_LIST
+${LOCAL_NVM_VERSION_LIST}
 EOF
 
-  if [ -n "${LTS-}" ]; then
-    LTS="$(nvm_normalize_lts "lts/${LTS}")"
-    LTS="${LTS#lts/}"
+  if [ -n "${LOCAL_NVM_LTS-}" ]; then
+    LOCAL_NVM_LTS="$(nvm_normalize_lts "lts/${LOCAL_NVM_LTS}")"
+    LOCAL_NVM_LTS="${LOCAL_NVM_LTS#lts/}"
   fi
 
-  VERSIONS="$({ command awk -v lts="${LTS-}" '{
+  LOCAL_NVM_VERSIONS="$({ command awk -v lts="${LOCAL_NVM_LTS-}" '{
         if (!$1) { next }
         if (lts && $10 ~ /^\-?$/) { next }
         if (lts && lts != "*" && tolower($10) !~ tolower(lts)) { next }
@@ -1485,16 +1487,16 @@ EOF
         }
         prev=$10;
       }' \
-    | nvm_grep -w "${PATTERN:-.*}" \
-    | $SORT_COMMAND; } << EOF
-$VERSION_LIST
+    | nvm_grep -w "${LOCAL_NVM_PATTERN:-.*}" \
+    | ${LOCAL_NVM_SORT_COMMAND}; } << EOF
+${LOCAL_NVM_VERSION_LIST}
 EOF
 )"
-  if [ -z "${VERSIONS}" ]; then
+  if [ -z "${LOCAL_NVM_VERSIONS}" ]; then
     nvm_echo 'N/A'
     return 3
   fi
-  nvm_echo "${VERSIONS}"
+  nvm_echo "${LOCAL_NVM_VERSIONS}"
 }
 
 nvm_get_checksum_binary() {
@@ -1522,9 +1524,9 @@ nvm_get_checksum_binary() {
 }
 
 nvm_get_checksum_alg() {
-  local NVM_CHECKSUM_BIN
-  NVM_CHECKSUM_BIN="$(nvm_get_checksum_binary 2>/dev/null)"
-  case "${NVM_CHECKSUM_BIN-}" in
+  local LOCAL_NVM_CHECKSUM_BIN
+  LOCAL_NVM_CHECKSUM_BIN="$(nvm_get_checksum_binary 2>/dev/null)"
+  case "${LOCAL_NVM_CHECKSUM_BIN-}" in
     sha256sum | shasum | sha256 | gsha256sum | openssl | bssl)
       nvm_echo 'sha-256'
     ;;
@@ -1539,70 +1541,70 @@ nvm_get_checksum_alg() {
 }
 
 nvm_compute_checksum() {
-  local FILE
-  FILE="${1-}"
-  if [ -z "${FILE}" ]; then
+  local LOCAL_NVM_FILE
+  LOCAL_NVM_FILE="${1-}"
+  if [ -z "${LOCAL_NVM_FILE}" ]; then
     nvm_err 'Provided file to checksum is empty.'
     return 2
-  elif ! [ -f "${FILE}" ]; then
+  elif ! [ -f "${LOCAL_NVM_FILE}" ]; then
     nvm_err 'Provided file to checksum does not exist.'
     return 1
   fi
 
   if nvm_has_non_aliased "sha256sum"; then
     nvm_err 'Computing checksum with sha256sum'
-    command sha256sum "${FILE}" | command awk '{print $1}'
+    command sha256sum "${LOCAL_NVM_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "shasum"; then
     nvm_err 'Computing checksum with shasum -a 256'
-    command shasum -a 256 "${FILE}" | command awk '{print $1}'
+    command shasum -a 256 "${LOCAL_NVM_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "sha256"; then
     nvm_err 'Computing checksum with sha256 -q'
-    command sha256 -q "${FILE}" | command awk '{print $1}'
+    command sha256 -q "${LOCAL_NVM_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "gsha256sum"; then
     nvm_err 'Computing checksum with gsha256sum'
-    command gsha256sum "${FILE}" | command awk '{print $1}'
+    command gsha256sum "${LOCAL_NVM_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "openssl"; then
     nvm_err 'Computing checksum with openssl dgst -sha256'
-    command openssl dgst -sha256 "${FILE}" | command awk '{print $NF}'
+    command openssl dgst -sha256 "${LOCAL_NVM_FILE}" | command awk '{print $NF}'
   elif nvm_has_non_aliased "bssl"; then
     nvm_err 'Computing checksum with bssl sha256sum'
-    command bssl sha256sum "${FILE}" | command awk '{print $1}'
+    command bssl sha256sum "${LOCAL_NVM_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "sha1sum"; then
     nvm_err 'Computing checksum with sha1sum'
-    command sha1sum "${FILE}" | command awk '{print $1}'
+    command sha1sum "${LOCAL_NVM_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "sha1"; then
     nvm_err 'Computing checksum with sha1 -q'
-    command sha1 -q "${FILE}"
+    command sha1 -q "${LOCAL_NVM_FILE}"
   fi
 }
 
 nvm_compare_checksum() {
-  local FILE
-  FILE="${1-}"
-  if [ -z "${FILE}" ]; then
+  local LOCAL_NVM_FILE
+  LOCAL_NVM_FILE="${1-}"
+  if [ -z "${LOCAL_NVM_FILE}" ]; then
     nvm_err 'Provided file to checksum is empty.'
     return 4
-  elif ! [ -f "${FILE}" ]; then
+  elif ! [ -f "${LOCAL_NVM_FILE}" ]; then
     nvm_err 'Provided file to checksum does not exist.'
     return 3
   fi
 
-  local COMPUTED_SUM
-  COMPUTED_SUM="$(nvm_compute_checksum "${FILE}")"
+  local LOCAL_NVM_COMPUTED_SUM
+  LOCAL_NVM_COMPUTED_SUM="$(nvm_compute_checksum "${LOCAL_NVM_FILE}")"
 
-  local CHECKSUM
-  CHECKSUM="${2-}"
-  if [ -z "${CHECKSUM}" ]; then
+  local LOCAL_NVM_CHECKSUM
+  LOCAL_NVM_CHECKSUM="${2-}"
+  if [ -z "${LOCAL_NVM_CHECKSUM}" ]; then
     nvm_err 'Provided checksum to compare to is empty.'
     return 2
   fi
 
-  if [ -z "${COMPUTED_SUM}" ]; then
-    nvm_err "Computed checksum of '${FILE}' is empty." # missing in raspberry pi binary
+  if [ -z "${LOCAL_NVM_COMPUTED_SUM}" ]; then
+    nvm_err "Computed checksum of '${LOCAL_NVM_FILE}' is empty." # missing in raspberry pi binary
     nvm_err 'WARNING: Continuing *without checksum verification*'
     return
-  elif [ "${COMPUTED_SUM}" != "${CHECKSUM}" ]; then
-    nvm_err "Checksums do not match: '${COMPUTED_SUM}' found, '${CHECKSUM}' expected."
+  elif [ "${LOCAL_NVM_COMPUTED_SUM}" != "${LOCAL_NVM_CHECKSUM}" ]; then
+    nvm_err "Checksums do not match: '${LOCAL_NVM_COMPUTED_SUM}' found, '${LOCAL_NVM_CHECKSUM}' expected."
     return 1
   fi
   nvm_err 'Checksums matched!'
@@ -1610,128 +1612,128 @@ nvm_compare_checksum() {
 
 # args: flavor, type, version, slug, compression
 nvm_get_checksum() {
-  local FLAVOR
+  local LOCAL_NVM_FLAVOR
   case "${1-}" in
-    node | iojs) FLAVOR="${1}" ;;
+    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 2
     ;;
   esac
 
-  local MIRROR
-  MIRROR="$(nvm_get_mirror "${FLAVOR}" "${2-}")"
-  if [ -z "${MIRROR}" ]; then
+  local LOCAL_NVM_MIRROR
+  LOCAL_NVM_MIRROR="$(nvm_get_mirror "${LOCAL_NVM_FLAVOR}" "${2-}")"
+  if [ -z "${LOCAL_NVM_MIRROR}" ]; then
     return 1
   fi
 
-  local SHASUMS_URL
+  local LOCAL_NVM_SHASUMS_URL
   if [ "$(nvm_get_checksum_alg)" = 'sha-256' ]; then
-    SHASUMS_URL="${MIRROR}/${3}/SHASUMS256.txt"
+    LOCAL_NVM_SHASUMS_URL="${LOCAL_NVM_MIRROR}/${3}/SHASUMS256.txt"
   else
-    SHASUMS_URL="${MIRROR}/${3}/SHASUMS.txt"
+    LOCAL_NVM_SHASUMS_URL="${LOCAL_NVM_MIRROR}/${3}/SHASUMS.txt"
   fi
 
-  nvm_download -L -s "${SHASUMS_URL}" -o - | command awk "{ if (\"${4}.${5}\" == \$2) print \$1}"
+  nvm_download -L -s "${LOCAL_NVM_SHASUMS_URL}" -o - | command awk "{ if (\"${4}.${5}\" == \$2) print \$1}"
 }
 
 nvm_print_versions() {
-  local VERSION
-  local LTS
-  local FORMAT
-  local NVM_CURRENT
-  local NVM_LATEST_LTS_COLOR
-  local NVM_OLD_LTS_COLOR
+  local LOCAL_NVM_VERSION
+  local LOCAL_NVM_LTS
+  local LOCAL_NVM_FORMAT
+  local LOCAL_NVM_CURRENT
+  local LOCAL_NVM_LATEST_LTS_COLOR
+  local LOCAL_NVM_OLD_LTS_COLOR
 
-  local INSTALLED_COLOR
-  local SYSTEM_COLOR
-  local CURRENT_COLOR
-  local NOT_INSTALLED_COLOR
-  local DEFAULT_COLOR
-  local LTS_COLOR
+  local LOCAL_NVM_INSTALLED_COLOR
+  local LOCAL_NVM_SYSTEM_COLOR
+  local LOCAL_NVM_CURRENT_COLOR
+  local LOCAL_NVM_NOT_INSTALLED_COLOR
+  local LOCAL_NVM_DEFAULT_COLOR
+  local LOCAL_NVM_LTS_COLOR
 
-  INSTALLED_COLOR=$(nvm_get_colors 1)
-  SYSTEM_COLOR=$(nvm_get_colors 2)
-  CURRENT_COLOR=$(nvm_get_colors 3)
-  NOT_INSTALLED_COLOR=$(nvm_get_colors 4)
-  DEFAULT_COLOR=$(nvm_get_colors 5)
-  LTS_COLOR=$(nvm_get_colors 6)
+  LOCAL_NVM_INSTALLED_COLOR=$(nvm_get_colors 1)
+  LOCAL_NVM_SYSTEM_COLOR=$(nvm_get_colors 2)
+  LOCAL_NVM_CURRENT_COLOR=$(nvm_get_colors 3)
+  LOCAL_NVM_NOT_INSTALLED_COLOR=$(nvm_get_colors 4)
+  LOCAL_NVM_DEFAULT_COLOR=$(nvm_get_colors 5)
+  LOCAL_NVM_LTS_COLOR=$(nvm_get_colors 6)
 
-  NVM_CURRENT=$(nvm_ls_current)
-  NVM_LATEST_LTS_COLOR=$(nvm_echo "${CURRENT_COLOR}" | command tr '0;' '1;')
-  NVM_OLD_LTS_COLOR="${DEFAULT_COLOR}"
-  local NVM_HAS_COLORS
+  LOCAL_NVM_CURRENT=$(nvm_ls_current)
+  LOCAL_NVM_LATEST_LTS_COLOR=$(nvm_echo "${LOCAL_NVM_CURRENT_COLOR}" | command tr '0;' '1;')
+  LOCAL_NVM_OLD_LTS_COLOR="${LOCAL_NVM_DEFAULT_COLOR}"
+  local LOCAL_NVM_HAS_COLORS
   if [ -z "${NVM_NO_COLORS-}" ] && nvm_has_colors; then
-    NVM_HAS_COLORS=1
+    LOCAL_NVM_HAS_COLORS=1
   fi
-  local LTS_LENGTH
-  local LTS_FORMAT
+  local LOCAL_NVM_LTS_LENGTH
+  local LOCAL_NVM_LTS_FORMAT
   nvm_echo "${1-}" \
   | command sed '1!G;h;$!d' \
   | command awk '{ if ($2 && $3 && $3 == "*") { print $1, "(Latest LTS: " $2 ")" } else if ($2) { print $1, "(LTS: " $2 ")" } else { print $1 } }' \
   | command sed '1!G;h;$!d' \
-  | while read -r VERSION_LINE; do
-    VERSION="${VERSION_LINE%% *}"
-    LTS="${VERSION_LINE#* }"
-    FORMAT='%15s'
-    if [ "_${VERSION}" = "_${NVM_CURRENT}" ]; then
-      if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-        FORMAT="\033[${CURRENT_COLOR}-> %12s\033[0m"
+  | while read -r LOCAL_NVM_VERSION_LINE; do
+    LOCAL_NVM_VERSION="${LOCAL_NVM_VERSION_LINE%% *}"
+    LOCAL_NVM_LTS="${LOCAL_NVM_VERSION_LINE#* }"
+    LOCAL_NVM_FORMAT='%15s'
+    if [ "_${LOCAL_NVM_VERSION}" = "_${LOCAL_NVM_CURRENT}" ]; then
+      if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
+        LOCAL_NVM_FORMAT="\033[${LOCAL_NVM_CURRENT_COLOR}-> %12s\033[0m"
       else
-        FORMAT='-> %12s *'
+        LOCAL_NVM_FORMAT='-> %12s *'
       fi
-    elif [ "${VERSION}" = "system" ]; then
-      if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-        FORMAT="\033[${SYSTEM_COLOR}%15s\033[0m"
+    elif [ "${LOCAL_NVM_VERSION}" = "system" ]; then
+      if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
+        LOCAL_NVM_FORMAT="\033[${LOCAL_NVM_SYSTEM_COLOR}%15s\033[0m"
       else
-        FORMAT='%15s *'
+        LOCAL_NVM_FORMAT='%15s *'
       fi
-    elif nvm_is_version_installed "${VERSION}"; then
-      if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-        FORMAT="\033[${INSTALLED_COLOR}%15s\033[0m"
+    elif nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
+      if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
+        LOCAL_NVM_FORMAT="\033[${LOCAL_NVM_INSTALLED_COLOR}%15s\033[0m"
       else
-        FORMAT='%15s *'
+        LOCAL_NVM_FORMAT='%15s *'
       fi
     fi
-    if [ "${LTS}" != "${VERSION}" ]; then
-      case "${LTS}" in
+    if [ "${LOCAL_NVM_LTS}" != "${LOCAL_NVM_VERSION}" ]; then
+      case "${LOCAL_NVM_LTS}" in
         *Latest*)
-          LTS="${LTS##Latest }"
-          LTS_LENGTH="${#LTS}"
-          if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-            LTS_FORMAT="  \\033[${NVM_LATEST_LTS_COLOR}%${LTS_LENGTH}s\\033[0m"
+          LOCAL_NVM_LTS="${LOCAL_NVM_LTS##Latest }"
+          LOCAL_NVM_LTS_LENGTH="${#LOCAL_NVM_LTS}"
+          if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
+            LOCAL_NVM_LTS_FORMAT="  \\033[${LOCAL_NVM_LATEST_LTS_COLOR}%${LOCAL_NVM_LTS_LENGTH}s\\033[0m"
           else
-            LTS_FORMAT="  %${LTS_LENGTH}s"
+            LOCAL_NVM_LTS_FORMAT="  %${LOCAL_NVM_LTS_LENGTH}s"
           fi
         ;;
         *)
-          LTS_LENGTH="${#LTS}"
-          if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-            LTS_FORMAT="  \\033[${NVM_OLD_LTS_COLOR}%${LTS_LENGTH}s\\033[0m"
+          LOCAL_NVM_LTS_LENGTH="${#LOCAL_NVM_LTS}"
+          if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
+            LOCAL_NVM_LTS_FORMAT="  \\033[${LOCAL_NVM_OLD_LTS_COLOR}%${LOCAL_NVM_LTS_LENGTH}s\\033[0m"
           else
-            LTS_FORMAT="  %${LTS_LENGTH}s"
+            LOCAL_NVM_LTS_FORMAT="  %${LOCAL_NVM_LTS_LENGTH}s"
           fi
         ;;
       esac
-      command printf -- "${FORMAT}${LTS_FORMAT}\\n" "${VERSION}" " ${LTS}"
+      command printf -- "${LOCAL_NVM_FORMAT}${LOCAL_NVM_LTS_FORMAT}\\n" "${LOCAL_NVM_VERSION}" " ${LOCAL_NVM_LTS}"
     else
-      command printf -- "${FORMAT}\\n" "${VERSION}"
+      command printf -- "${LOCAL_NVM_FORMAT}\\n" "${LOCAL_NVM_VERSION}"
     fi
   done
 }
 
 nvm_validate_implicit_alias() {
-  local NVM_IOJS_PREFIX
-  NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local NVM_NODE_PREFIX
-  NVM_NODE_PREFIX="$(nvm_node_prefix)"
+  local LOCAL_NVM_IOJS_PREFIX
+  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local LOCAL_NVM_NODE_PREFIX
+  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
 
   case "$1" in
-    "stable" | "unstable" | "${NVM_IOJS_PREFIX}" | "${NVM_NODE_PREFIX}")
+    "stable" | "unstable" | "${LOCAL_NVM_IOJS_PREFIX}" | "${LOCAL_NVM_NODE_PREFIX}")
       return
     ;;
     *)
-      nvm_err "Only implicit aliases 'stable', 'unstable', '${NVM_IOJS_PREFIX}', and '${NVM_NODE_PREFIX}' are supported."
+      nvm_err "Only implicit aliases 'stable', 'unstable', '${LOCAL_NVM_IOJS_PREFIX}', and '${LOCAL_NVM_NODE_PREFIX}' are supported."
       return 1
     ;;
   esac
@@ -1743,190 +1745,189 @@ nvm_print_implicit_alias() {
     return 1
   fi
 
-  local NVM_IMPLICIT
-  NVM_IMPLICIT="$2"
-  if ! nvm_validate_implicit_alias "${NVM_IMPLICIT}"; then
+  local LOCAL_NVM_IMPLICIT
+  LOCAL_NVM_IMPLICIT="$2"
+  if ! nvm_validate_implicit_alias "${LOCAL_NVM_IMPLICIT}"; then
     return 2
   fi
 
-  local NVM_IOJS_PREFIX
-  NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local NVM_NODE_PREFIX
-  NVM_NODE_PREFIX="$(nvm_node_prefix)"
-  local NVM_COMMAND
-  local NVM_ADD_PREFIX_COMMAND
-  local LAST_TWO
-  case "${NVM_IMPLICIT}" in
-    "${NVM_IOJS_PREFIX}")
-      NVM_COMMAND="nvm_ls_remote_iojs"
-      NVM_ADD_PREFIX_COMMAND="nvm_add_iojs_prefix"
+  local LOCAL_NVM_IOJS_PREFIX
+  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local LOCAL_NVM_NODE_PREFIX
+  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
+  local LOCAL_NVM_COMMAND
+  local LOCAL_NVM_ADD_PREFIX_COMMAND
+  local LOCAL_NVM_LAST_TWO
+  case "${LOCAL_NVM_IMPLICIT}" in
+    "${LOCAL_NVM_IOJS_PREFIX}")
+      LOCAL_NVM_COMMAND="nvm_ls_remote_iojs"
+      LOCAL_NVM_ADD_PREFIX_COMMAND="nvm_add_iojs_prefix"
       if [ "_$1" = "_local" ]; then
-        NVM_COMMAND="nvm_ls ${NVM_IMPLICIT}"
+        LOCAL_NVM_COMMAND="nvm_ls ${LOCAL_NVM_IMPLICIT}"
       fi
 
       nvm_is_zsh && setopt local_options shwordsplit
 
-      local NVM_IOJS_VERSION
-      local EXIT_CODE
-      NVM_IOJS_VERSION="$(${NVM_COMMAND})" &&:
-      EXIT_CODE="$?"
-      if [ "_${EXIT_CODE}" = "_0" ]; then
-        NVM_IOJS_VERSION="$(nvm_echo "${NVM_IOJS_VERSION}" | command sed "s/^${NVM_IMPLICIT}-//" | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2 | uniq | command tail -1)"
+      local LOCAL_NVM_IOJS_VERSION
+      local LOCAL_NVM_EXIT_CODE
+      LOCAL_NVM_IOJS_VERSION="$(${LOCAL_NVM_COMMAND})" &&:
+      LOCAL_NVM_EXIT_CODE="$?"
+      if [ "_${LOCAL_NVM_EXIT_CODE}" = "_0" ]; then
+        LOCAL_NVM_IOJS_VERSION="$(nvm_echo "${LOCAL_NVM_IOJS_VERSION}" | command sed "s/^${LOCAL_NVM_IMPLICIT}-//" | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2 | uniq | command tail -1)"
       fi
 
-      if [ "_$NVM_IOJS_VERSION" = "_N/A" ]; then
+      if [ "_${LOCAL_NVM_IOJS_VERSION}" = "_N/A" ]; then
         nvm_echo 'N/A'
       else
-        ${NVM_ADD_PREFIX_COMMAND} "${NVM_IOJS_VERSION}"
+        ${LOCAL_NVM_ADD_PREFIX_COMMAND} "${LOCAL_NVM_IOJS_VERSION}"
       fi
-      return $EXIT_CODE
+      return ${LOCAL_NVM_EXIT_CODE}
     ;;
-    "${NVM_NODE_PREFIX}")
+    "${LOCAL_NVM_NODE_PREFIX}")
       nvm_echo 'stable'
       return
     ;;
     *)
-      NVM_COMMAND="nvm_ls_remote"
+      LOCAL_NVM_COMMAND="nvm_ls_remote"
       if [ "_$1" = "_local" ]; then
-        NVM_COMMAND="nvm_ls node"
+        LOCAL_NVM_COMMAND="nvm_ls node"
       fi
 
       nvm_is_zsh && setopt local_options shwordsplit
 
-      LAST_TWO=$($NVM_COMMAND | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2 | uniq)
+      LOCAL_NVM_LAST_TWO=$(${LOCAL_NVM_COMMAND} | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2 | uniq)
     ;;
   esac
-  local MINOR
-  local STABLE
-  local UNSTABLE
-  local MOD
-  local NORMALIZED_VERSION
+  local LOCAL_NVM_MINOR
+  local LOCAL_NVM_STABLE
+  local LOCAL_NVM_UNSTABLE
+  local LOCAL_NVM_MOD
+  local LOCAL_NVM_NORMALIZED_VERSION
 
   nvm_is_zsh && setopt local_options shwordsplit
-  for MINOR in $LAST_TWO; do
-    NORMALIZED_VERSION="$(nvm_normalize_version "$MINOR")"
-    if [ "_0${NORMALIZED_VERSION#?}" != "_$NORMALIZED_VERSION" ]; then
-      STABLE="$MINOR"
+  for LOCAL_NVM_MINOR in ${LOCAL_NVM_LAST_TWO}; do
+    LOCAL_NVM_NORMALIZED_VERSION="$(nvm_normalize_version "${LOCAL_NVM_MINOR}")"
+    if [ "_0${LOCAL_NVM_NORMALIZED_VERSION#?}" != "_${LOCAL_NVM_NORMALIZED_VERSION}" ]; then
+      LOCAL_NVM_STABLE="${LOCAL_NVM_MINOR}"
     else
-      MOD="$(awk 'BEGIN { print int(ARGV[1] / 1000000) % 2 ; exit(0) }' "${NORMALIZED_VERSION}")"
-      if [ "${MOD}" -eq 0 ]; then
-        STABLE="${MINOR}"
-      elif [ "${MOD}" -eq 1 ]; then
-        UNSTABLE="${MINOR}"
+      LOCAL_NVM_MOD="$(awk 'BEGIN { print int(ARGV[1] / 1000000) % 2 ; exit(0) }' "${LOCAL_NVM_NORMALIZED_VERSION}")"
+      if [ "${LOCAL_NVM_MOD}" -eq 0 ]; then
+        LOCAL_NVM_STABLE="${LOCAL_NVM_MINOR}"
+      elif [ "${LOCAL_NVM_MOD}" -eq 1 ]; then
+        LOCAL_NVM_UNSTABLE="${LOCAL_NVM_MINOR}"
       fi
     fi
   done
 
   if [ "_$2" = '_stable' ]; then
-    nvm_echo "${STABLE}"
+    nvm_echo "${LOCAL_NVM_STABLE}"
   elif [ "_$2" = '_unstable' ]; then
-    nvm_echo "${UNSTABLE:-"N/A"}"
+    nvm_echo "${LOCAL_NVM_UNSTABLE:-"N/A"}"
   fi
 }
 
 nvm_get_os() {
-  local NVM_UNAME
-  NVM_UNAME="$(command uname -a)"
-  local NVM_OS
-  case "${NVM_UNAME}" in
-    Linux\ *) NVM_OS=linux ;;
-    Darwin\ *) NVM_OS=darwin ;;
-    SunOS\ *) NVM_OS=sunos ;;
-    FreeBSD\ *) NVM_OS=freebsd ;;
-    OpenBSD\ *) NVM_OS=openbsd ;;
-    AIX\ *) NVM_OS=aix ;;
-    CYGWIN* | MSYS* | MINGW*) NVM_OS=win ;;
+  local LOCAL_NVM_UNAME
+  LOCAL_NVM_UNAME="$(command uname -a)"
+  local LOCAL_NVM_OS
+  case "${LOCAL_NVM_UNAME}" in
+    Linux\ *) LOCAL_NVM_OS=linux ;;
+    Darwin\ *) LOCAL_NVM_OS=darwin ;;
+    SunOS\ *) LOCAL_NVM_OS=sunos ;;
+    FreeBSD\ *) LOCAL_NVM_OS=freebsd ;;
+    OpenBSD\ *) LOCAL_NVM_OS=openbsd ;;
+    AIX\ *) LOCAL_NVM_OS=aix ;;
+    CYGWIN* | MSYS* | MINGW*) LOCAL_NVM_OS=win ;;
   esac
-  nvm_echo "${NVM_OS-}"
+  nvm_echo "${LOCAL_NVM_OS-}"
 }
 
 nvm_get_arch() {
-  local HOST_ARCH
-  local NVM_OS
-  local EXIT_CODE
+  local LOCAL_NVM_HOST_ARCH
+  local LOCAL_NVM_OS
 
-  NVM_OS="$(nvm_get_os)"
+  LOCAL_NVM_OS="$(nvm_get_os)"
   # If the OS is SunOS, first try to use pkgsrc to guess
   # the most appropriate arch. If it's not available, use
   # isainfo to get the instruction set supported by the
   # kernel.
-  if [ "_${NVM_OS}" = "_sunos" ]; then
-    if HOST_ARCH=$(pkg_info -Q MACHINE_ARCH pkg_install); then
-      HOST_ARCH=$(nvm_echo "${HOST_ARCH}" | command tail -1)
+  if [ "_${LOCAL_NVM_OS}" = "_sunos" ]; then
+    if LOCAL_NVM_HOST_ARCH=$(pkg_info -Q MACHINE_ARCH pkg_install); then
+      LOCAL_NVM_HOST_ARCH=$(nvm_echo "${LOCAL_NVM_HOST_ARCH}" | command tail -1)
     else
-      HOST_ARCH=$(isainfo -n)
+      LOCAL_NVM_HOST_ARCH=$(isainfo -n)
     fi
-  elif [ "_${NVM_OS}" = "_aix" ]; then
-    HOST_ARCH=ppc64
+  elif [ "_${LOCAL_NVM_OS}" = "_aix" ]; then
+    LOCAL_NVM_HOST_ARCH=ppc64
   else
-    HOST_ARCH="$(command uname -m)"
+    LOCAL_NVM_HOST_ARCH="$(command uname -m)"
   fi
 
-  local NVM_ARCH
-  case "${HOST_ARCH}" in
-    x86_64 | amd64) NVM_ARCH="x64" ;;
-    i*86) NVM_ARCH="x86" ;;
-    aarch64) NVM_ARCH="arm64" ;;
-    *) NVM_ARCH="${HOST_ARCH}" ;;
+  local LOCAL_NVM_ARCH
+  case "${LOCAL_NVM_HOST_ARCH}" in
+    x86_64 | amd64) LOCAL_NVM_ARCH="x64" ;;
+    i*86) LOCAL_NVM_ARCH="x86" ;;
+    aarch64) LOCAL_NVM_ARCH="arm64" ;;
+    *) LOCAL_NVM_ARCH="${LOCAL_NVM_HOST_ARCH}" ;;
   esac
 
   # If running a 64bit ARM kernel but a 32bit ARM userland,
   # change ARCH to 32bit ARM (armv7l) if /sbin/init is 32bit executable
-  local L
-  if [ "$(uname)" = "Linux" ] && [ "${NVM_ARCH}" = arm64 ] &&
-    L="$(ls -dl /sbin/init 2>/dev/null)" &&
-    [ "$(od -An -t x1 -j 4 -N 1 "${L#*-> }")" = ' 01' ]; then
-    NVM_ARCH=armv7l
-    HOST_ARCH=armv7l
+  local LOCAL_NVM_L
+  if [ "$(uname)" = "Linux" ] && [ "${LOCAL_NVM_ARCH}" = arm64 ] &&
+    LOCAL_NVM_L="$(ls -dl /sbin/init 2>/dev/null)" &&
+    [ "$(od -An -t x1 -j 4 -N 1 "${LOCAL_NVM_L#*-> }")" = ' 01' ]; then
+    LOCAL_NVM_ARCH=armv7l
+    LOCAL_NVM_HOST_ARCH=armv7l
   fi
 
-  nvm_echo "${NVM_ARCH}"
+  nvm_echo "${LOCAL_NVM_ARCH}"
 }
 
 nvm_get_minor_version() {
-  local VERSION
-  VERSION="$1"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="$1"
 
-  if [ -z "${VERSION}" ]; then
+  if [ -z "${LOCAL_NVM_VERSION}" ]; then
     nvm_err 'a version is required'
     return 1
   fi
 
-  case "${VERSION}" in
+  case "${LOCAL_NVM_VERSION}" in
     v | .* | *..* | v*[!.0123456789]* | [!v]*[!.0123456789]* | [!v0123456789]* | v[!0123456789]*)
       nvm_err 'invalid version number'
       return 2
     ;;
   esac
 
-  local PREFIXED_VERSION
-  PREFIXED_VERSION="$(nvm_format_version "${VERSION}")"
+  local LOCAL_NVM_PREFIXED_VERSION
+  LOCAL_NVM_PREFIXED_VERSION="$(nvm_format_version "${LOCAL_NVM_VERSION}")"
 
-  local MINOR
-  MINOR="$(nvm_echo "${PREFIXED_VERSION}" | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2)"
-  if [ -z "${MINOR}" ]; then
+  local LOCAL_NVM_MINOR
+  LOCAL_NVM_MINOR="$(nvm_echo "${LOCAL_NVM_PREFIXED_VERSION}" | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2)"
+  if [ -z "${LOCAL_NVM_MINOR}" ]; then
     nvm_err 'invalid version number! (please report this)'
     return 3
   fi
-  nvm_echo "${MINOR}"
+  nvm_echo "${LOCAL_NVM_MINOR}"
 }
 
 nvm_ensure_default_set() {
-  local VERSION
-  VERSION="$1"
-  if [ -z "${VERSION}" ]; then
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="$1"
+  if [ -z "${LOCAL_NVM_VERSION}" ]; then
     nvm_err 'nvm_ensure_default_set: a version is required'
     return 1
   elif nvm_alias default >/dev/null 2>&1; then
     # default already set
     return 0
   fi
-  local OUTPUT
-  OUTPUT="$(nvm alias default "${VERSION}")"
-  local EXIT_CODE
-  EXIT_CODE="$?"
-  nvm_echo "Creating default alias: ${OUTPUT}"
-  return $EXIT_CODE
+  local LOCAL_NVM_OUTPUT
+  LOCAL_NVM_OUTPUT="$(nvm alias default "${LOCAL_NVM_VERSION}")"
+  local LOCAL_NVM_EXIT_CODE
+  LOCAL_NVM_EXIT_CODE="$?"
+  nvm_echo "Creating default alias: ${LOCAL_NVM_OUTPUT}"
+  return ${LOCAL_NVM_EXIT_CODE}
 }
 
 nvm_is_merged_node_version() {
@@ -1951,295 +1952,295 @@ nvm_install_binary_extract() {
     return 1
   fi
 
-  local NVM_OS
-  local PREFIXED_VERSION
-  local VERSION
-  local TARBALL
-  local TMPDIR
-  NVM_OS="${1}"
-  PREFIXED_VERSION="${2}"
-  VERSION="${3}"
-  TARBALL="${4}"
-  TMPDIR="${5}"
+  local LOCAL_NVM_OS
+  local LOCAL_NVM_PREFIXED_VERSION
+  local LOCAL_NVM_VERSION
+  local LOCAL_NVM_TARBALL
+  local LOCAL_NVM_TMPDIR
+  LOCAL_NVM_OS="${1}"
+  LOCAL_NVM_PREFIXED_VERSION="${2}"
+  LOCAL_NVM_VERSION="${3}"
+  LOCAL_NVM_TARBALL="${4}"
+  LOCAL_NVM_TMPDIR="${5}"
 
-  local VERSION_PATH
+  local LOCAL_NVM_VERSION_PATH
 
-  [ -n "${TMPDIR-}" ] && \
-  command mkdir -p "${TMPDIR}" && \
-  VERSION_PATH="$(nvm_version_path "${PREFIXED_VERSION}")" || return 1
+  [ -n "${LOCAL_NVM_TMPDIR-}" ] && \
+  command mkdir -p "${LOCAL_NVM_TMPDIR}" && \
+  LOCAL_NVM_VERSION_PATH="$(nvm_version_path "${LOCAL_NVM_PREFIXED_VERSION}")" || return 1
 
   # For Windows system (GitBash with MSYS, Cygwin)
-  if [ "${NVM_OS}" = 'win' ]; then
-    VERSION_PATH="${VERSION_PATH}/bin"
-    command unzip -q "${TARBALL}" -d "${TMPDIR}" || return 1
+  if [ "${LOCAL_NVM_OS}" = 'win' ]; then
+    LOCAL_NVM_VERSION_PATH="${LOCAL_NVM_VERSION_PATH}/bin"
+    command unzip -q "${LOCAL_NVM_TARBALL}" -d "${LOCAL_NVM_TMPDIR}" || return 1
   # For non Windows system (including WSL running on Windows)
   else
-    nvm_extract_tarball "${NVM_OS}" "${VERSION}" "${TARBALL}" "${TMPDIR}"
+    nvm_extract_tarball "${LOCAL_NVM_OS}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}"
   fi
 
-  command mkdir -p "${VERSION_PATH}" || return 1
+  command mkdir -p "${LOCAL_NVM_VERSION_PATH}" || return 1
 
-  if [ "${NVM_OS}" = 'win' ]; then
-    command mv "${TMPDIR}/"*/* "${VERSION_PATH}" || return 1
-    command chmod +x "${VERSION_PATH}"/node.exe || return 1
-    command chmod +x "${VERSION_PATH}"/npm || return 1
-    command chmod +x "${VERSION_PATH}"/npx 2>/dev/null
+  if [ "${LOCAL_NVM_OS}" = 'win' ]; then
+    command mv "${LOCAL_NVM_TMPDIR}/"*/* "${LOCAL_NVM_VERSION_PATH}" || return 1
+    command chmod +x "${LOCAL_NVM_VERSION_PATH}"/node.exe || return 1
+    command chmod +x "${LOCAL_NVM_VERSION_PATH}"/npm || return 1
+    command chmod +x "${LOCAL_NVM_VERSION_PATH}"/npx 2>/dev/null
   else
-    command mv "${TMPDIR}/"* "${VERSION_PATH}" || return 1
+    command mv "${LOCAL_NVM_TMPDIR}/"* "${LOCAL_NVM_VERSION_PATH}" || return 1
   fi
 
-  command rm -rf "${TMPDIR}"
+  command rm -rf "${LOCAL_NVM_TMPDIR}"
 
   return 0
 }
 
 # args: flavor, type, version, reinstall
 nvm_install_binary() {
-  local FLAVOR
+  local LOCAL_NVM_FLAVOR
   case "${1-}" in
-    node | iojs) FLAVOR="${1}" ;;
+    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 4
     ;;
   esac
 
-  local TYPE
-  TYPE="${2-}"
+  local LOCAL_NVM_TYPE
+  LOCAL_NVM_TYPE="${2-}"
 
-  local PREFIXED_VERSION
-  PREFIXED_VERSION="${3-}"
-  if [ -z "${PREFIXED_VERSION}" ]; then
+  local LOCAL_NVM_PREFIXED_VERSION
+  LOCAL_NVM_PREFIXED_VERSION="${3-}"
+  if [ -z "${LOCAL_NVM_PREFIXED_VERSION}" ]; then
     nvm_err 'A version number is required.'
     return 3
   fi
 
-  local nosource
-  nosource="${4-}"
+  local LOCAL_NVM_NOSOURCE
+  LOCAL_NVM_NOSOURCE="${4-}"
 
-  local VERSION
-  VERSION="$(nvm_strip_iojs_prefix "${PREFIXED_VERSION}")"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="$(nvm_strip_iojs_prefix "${LOCAL_NVM_PREFIXED_VERSION}")"
 
-  local NVM_OS
-  NVM_OS="$(nvm_get_os)"
+  local LOCAL_NVM_OS
+  LOCAL_NVM_OS="$(nvm_get_os)"
 
-  if [ -z "${NVM_OS}" ]; then
+  if [ -z "${LOCAL_NVM_OS}" ]; then
     return 2
   fi
 
-  local TARBALL
-  local TMPDIR
+  local LOCAL_NVM_TARBALL
+  local LOCAL_NVM_TMPDIR
 
-  local PROGRESS_BAR
-  local NODE_OR_IOJS
-  if [ "${FLAVOR}" = 'node' ]; then
-    NODE_OR_IOJS="${FLAVOR}"
-  elif [ "${FLAVOR}" = 'iojs' ]; then
-    NODE_OR_IOJS="io.js"
+  local LOCAL_NVM_PROGRESS_BAR
+  local LOCAL_NVM_NODE_OR_IOJS
+  if [ "${LOCAL_NVM_FLAVOR}" = 'node' ]; then
+    LOCAL_NVM_NODE_OR_IOJS="${LOCAL_NVM_FLAVOR}"
+  elif [ "${LOCAL_NVM_FLAVOR}" = 'iojs' ]; then
+    LOCAL_NVM_NODE_OR_IOJS="io.js"
   fi
   if [ "${NVM_NO_PROGRESS-}" = "1" ]; then
     # --silent, --show-error, use short option as @samrocketman mentions the compatibility issue.
-    PROGRESS_BAR="-sS"
+    LOCAL_NVM_PROGRESS_BAR="-sS"
   else
-    PROGRESS_BAR="--progress-bar"
+    LOCAL_NVM_PROGRESS_BAR="--progress-bar"
   fi
-  nvm_echo "Downloading and installing ${NODE_OR_IOJS-} ${VERSION}..."
-  TARBALL="$(PROGRESS_BAR="${PROGRESS_BAR}" nvm_download_artifact "${FLAVOR}" binary "${TYPE-}" "${VERSION}" | command tail -1)"
-  if [ -f "${TARBALL}" ]; then
-    TMPDIR="$(dirname "${TARBALL}")/files"
+  nvm_echo "Downloading and installing ${LOCAL_NVM_NODE_OR_IOJS-} ${LOCAL_NVM_VERSION}..."
+  LOCAL_NVM_TARBALL="$(LOCAL_NVM_PROGRESS_BAR="${LOCAL_NVM_PROGRESS_BAR}" nvm_download_artifact "${LOCAL_NVM_FLAVOR}" binary "${LOCAL_NVM_TYPE-}" "${LOCAL_NVM_VERSION}" | command tail -1)"
+  if [ -f "${LOCAL_NVM_TARBALL}" ]; then
+    LOCAL_NVM_TMPDIR="$(dirname "${LOCAL_NVM_TARBALL}")/files"
   fi
 
-  if nvm_install_binary_extract "${NVM_OS}" "${PREFIXED_VERSION}" "${VERSION}" "${TARBALL}" "${TMPDIR}"; then
-    if [ -n "${ALIAS-}" ]; then
-      nvm alias "${ALIAS}" "${provided_version}"
+  if nvm_install_binary_extract "${LOCAL_NVM_OS}" "${LOCAL_NVM_PREFIXED_VERSION}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}"; then
+    if [ -n "${LOCAL_NVM_ALIAS-}" ]; then
+      nvm alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_PROVIDED_VERSION}"
     fi
     return 0
   fi
 
 
-  # Read nosource from arguments
-  if [ "${nosource-}" = '1' ]; then
+  # Read LOCAL_NVM_NOSOURCE from arguments
+  if [ "${LOCAL_NVM_NOSOURCE-}" = '1' ]; then
       nvm_err 'Binary download failed. Download from source aborted.'
       return 0
   fi
 
   nvm_err 'Binary download failed, trying source.'
-  if [ -n "${TMPDIR-}" ]; then
-    command rm -rf "${TMPDIR}"
+  if [ -n "${LOCAL_NVM_TMPDIR-}" ]; then
+    command rm -rf "${LOCAL_NVM_TMPDIR}"
   fi
   return 1
 }
 
 # args: flavor, kind, version
 nvm_get_download_slug() {
-  local FLAVOR
+  local LOCAL_NVM_FLAVOR
   case "${1-}" in
-    node | iojs) FLAVOR="${1}" ;;
+    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 1
     ;;
   esac
 
-  local KIND
+  local LOCAL_NVM_KIND
   case "${2-}" in
-    binary | source) KIND="${2}" ;;
+    binary | source) LOCAL_NVM_KIND="${2}" ;;
     *)
       nvm_err 'supported kinds: binary, source'
       return 2
     ;;
   esac
 
-  local VERSION
-  VERSION="${3-}"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="${3-}"
 
-  local NVM_OS
-  NVM_OS="$(nvm_get_os)"
+  local LOCAL_NVM_OS
+  LOCAL_NVM_OS="$(nvm_get_os)"
 
-  local NVM_ARCH
-  NVM_ARCH="$(nvm_get_arch)"
-  if ! nvm_is_merged_node_version "${VERSION}"; then
-    if [ "${NVM_ARCH}" = 'armv6l' ] || [ "${NVM_ARCH}" = 'armv7l' ]; then
-      NVM_ARCH="arm-pi"
+  local LOCAL_NVM_ARCH
+  LOCAL_NVM_ARCH="$(nvm_get_arch)"
+  if ! nvm_is_merged_node_version "${LOCAL_NVM_VERSION}"; then
+    if [ "${LOCAL_NVM_ARCH}" = 'armv6l' ] || [ "${LOCAL_NVM_ARCH}" = 'armv7l' ]; then
+      LOCAL_NVM_ARCH="arm-pi"
     fi
   fi
 
   # If node version in below 16.0.0 then there is no arm64 packages available in node repositories, so we have to install "x64" arch packages
   # If running MAC M1 :: arm64 arch and Darwin OS then use "x64" Architecture because node doesn't provide darwin_arm64 package below v16.0.0
-  if nvm_version_greater '16.0.0' "${VERSION}"; then
-    if [ "_${NVM_OS}" = '_darwin' ] && [ "${NVM_ARCH}" = 'arm64' ]; then
-      NVM_ARCH=x64
+  if nvm_version_greater '16.0.0' "${LOCAL_NVM_VERSION}"; then
+    if [ "_${LOCAL_NVM_OS}" = '_darwin' ] && [ "${LOCAL_NVM_ARCH}" = 'arm64' ]; then
+      LOCAL_NVM_ARCH=x64
     fi
   fi
 
-  if [ "${KIND}" = 'binary' ]; then
-    nvm_echo "${FLAVOR}-${VERSION}-${NVM_OS}-${NVM_ARCH}"
-  elif [ "${KIND}" = 'source' ]; then
-    nvm_echo "${FLAVOR}-${VERSION}"
+  if [ "${LOCAL_NVM_KIND}" = 'binary' ]; then
+    nvm_echo "${LOCAL_NVM_FLAVOR}-${LOCAL_NVM_VERSION}-${LOCAL_NVM_OS}-${LOCAL_NVM_ARCH}"
+  elif [ "${LOCAL_NVM_KIND}" = 'source' ]; then
+    nvm_echo "${LOCAL_NVM_FLAVOR}-${LOCAL_NVM_VERSION}"
   fi
 }
 
 nvm_get_artifact_compression() {
-  local VERSION
-  VERSION="${1-}"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="${1-}"
 
-  local NVM_OS
-  NVM_OS="$(nvm_get_os)"
+  local LOCAL_NVM_OS
+  LOCAL_NVM_OS="$(nvm_get_os)"
 
-  local COMPRESSION
-  COMPRESSION='tar.gz'
-  if [ "_${NVM_OS}" = '_win' ]; then
-    COMPRESSION='zip'
-  elif nvm_supports_xz "${VERSION}"; then
-    COMPRESSION='tar.xz'
+  local LOCAL_NVM_COMPRESSION
+  LOCAL_NVM_COMPRESSION='tar.gz'
+  if [ "_${LOCAL_NVM_OS}" = '_win' ]; then
+    LOCAL_NVM_COMPRESSION='zip'
+  elif nvm_supports_xz "${LOCAL_NVM_VERSION}"; then
+    LOCAL_NVM_COMPRESSION='tar.xz'
   fi
 
-  nvm_echo "${COMPRESSION}"
+  nvm_echo "${LOCAL_NVM_COMPRESSION}"
 }
 
 # args: flavor, kind, type, version
 nvm_download_artifact() {
-  local FLAVOR
+  local LOCAL_NVM_FLAVOR
   case "${1-}" in
-    node | iojs) FLAVOR="${1}" ;;
+    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 1
     ;;
   esac
 
-  local KIND
+  local LOCAL_NVM_KIND
   case "${2-}" in
-    binary | source) KIND="${2}" ;;
+    binary | source) LOCAL_NVM_KIND="${2}" ;;
     *)
       nvm_err 'supported kinds: binary, source'
       return 1
     ;;
   esac
 
-  local TYPE
-  TYPE="${3-}"
+  local LOCAL_NVM_TYPE
+  LOCAL_NVM_TYPE="${3-}"
 
-  local MIRROR
-  MIRROR="$(nvm_get_mirror "${FLAVOR}" "${TYPE}")"
-  if [ -z "${MIRROR}" ]; then
+  local LOCAL_NVM_MIRROR
+  LOCAL_NVM_MIRROR="$(nvm_get_mirror "${LOCAL_NVM_FLAVOR}" "${LOCAL_NVM_TYPE}")"
+  if [ -z "${LOCAL_NVM_MIRROR}" ]; then
     return 2
   fi
 
-  local VERSION
-  VERSION="${4}"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="${4}"
 
-  if [ -z "${VERSION}" ]; then
+  if [ -z "${LOCAL_NVM_VERSION}" ]; then
     nvm_err 'A version number is required.'
     return 3
   fi
 
-  if [ "${KIND}" = 'binary' ] && ! nvm_binary_available "${VERSION}"; then
-    nvm_err "No precompiled binary available for ${VERSION}."
+  if [ "${LOCAL_NVM_KIND}" = 'binary' ] && ! nvm_binary_available "${LOCAL_NVM_VERSION}"; then
+    nvm_err "No precompiled binary available for ${LOCAL_NVM_VERSION}."
     return
   fi
 
-  local SLUG
-  SLUG="$(nvm_get_download_slug "${FLAVOR}" "${KIND}" "${VERSION}")"
+  local LOCAL_NVM_SLUG
+  LOCAL_NVM_SLUG="$(nvm_get_download_slug "${LOCAL_NVM_FLAVOR}" "${LOCAL_NVM_KIND}" "${LOCAL_NVM_VERSION}")"
 
-  local COMPRESSION
-  COMPRESSION="$(nvm_get_artifact_compression "${VERSION}")"
+  local LOCAL_NVM_COMPRESSION
+  LOCAL_NVM_COMPRESSION="$(nvm_get_artifact_compression "${LOCAL_NVM_VERSION}")"
 
-  local CHECKSUM
-  CHECKSUM="$(nvm_get_checksum "${FLAVOR}" "${TYPE}" "${VERSION}" "${SLUG}" "${COMPRESSION}")"
+  local LOCAL_NVM_CHECKSUM
+  LOCAL_NVM_CHECKSUM="$(nvm_get_checksum "${LOCAL_NVM_FLAVOR}" "${LOCAL_NVM_TYPE}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_SLUG}" "${LOCAL_NVM_COMPRESSION}")"
 
-  local tmpdir
-  if [ "${KIND}" = 'binary' ]; then
-    tmpdir="$(nvm_cache_dir)/bin/${SLUG}"
+  local LOCAL_NVM_TMPDIR
+  if [ "${LOCAL_NVM_KIND}" = 'binary' ]; then
+    LOCAL_NVM_TMPDIR="$(nvm_cache_dir)/bin/${LOCAL_NVM_SLUG}"
   else
-    tmpdir="$(nvm_cache_dir)/src/${SLUG}"
+    LOCAL_NVM_TMPDIR="$(nvm_cache_dir)/src/${LOCAL_NVM_SLUG}"
   fi
-  command mkdir -p "${tmpdir}/files" || (
-    nvm_err "creating directory ${tmpdir}/files failed"
+  command mkdir -p "${LOCAL_NVM_TMPDIR}/files" || (
+    nvm_err "creating directory ${LOCAL_NVM_TMPDIR}/files failed"
     return 3
   )
 
-  local TARBALL
-  TARBALL="${tmpdir}/${SLUG}.${COMPRESSION}"
-  local TARBALL_URL
-  if nvm_version_greater_than_or_equal_to "${VERSION}" 0.1.14; then
-    TARBALL_URL="${MIRROR}/${VERSION}/${SLUG}.${COMPRESSION}"
+  local LOCAL_NVM_TARBALL
+  LOCAL_NVM_TARBALL="${LOCAL_NVM_TMPDIR}/${LOCAL_NVM_SLUG}.${LOCAL_NVM_COMPRESSION}"
+  local LOCAL_NVM_TARBALL_URL
+  if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_VERSION}" 0.1.14; then
+    LOCAL_NVM_TARBALL_URL="${LOCAL_NVM_MIRROR}/${LOCAL_NVM_VERSION}/${LOCAL_NVM_SLUG}.${LOCAL_NVM_COMPRESSION}"
   else
     # node <= 0.1.13 does not have a directory
-    TARBALL_URL="${MIRROR}/${SLUG}.${COMPRESSION}"
+    LOCAL_NVM_TARBALL_URL="${LOCAL_NVM_MIRROR}/${LOCAL_NVM_SLUG}.${LOCAL_NVM_COMPRESSION}"
   fi
 
-  if [ -r "${TARBALL}" ]; then
-    nvm_err "Local cache found: $(nvm_sanitize_path "${TARBALL}")"
-    if nvm_compare_checksum "${TARBALL}" "${CHECKSUM}" >/dev/null 2>&1; then
-      nvm_err "Checksums match! Using existing downloaded archive $(nvm_sanitize_path "${TARBALL}")"
-      nvm_echo "${TARBALL}"
+  if [ -r "${LOCAL_NVM_TARBALL}" ]; then
+    nvm_err "Local cache found: $(nvm_sanitize_path "${LOCAL_NVM_TARBALL}")"
+    if nvm_compare_checksum "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_CHECKSUM}" >/dev/null 2>&1; then
+      nvm_err "Checksums match! Using existing downloaded archive $(nvm_sanitize_path "${LOCAL_NVM_TARBALL}")"
+      nvm_echo "${LOCAL_NVM_TARBALL}"
       return 0
     fi
-    nvm_compare_checksum "${TARBALL}" "${CHECKSUM}"
+    nvm_compare_checksum "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_CHECKSUM}"
     nvm_err "Checksum check failed!"
     nvm_err "Removing the broken local cache..."
-    command rm -rf "${TARBALL}"
+    command rm -rf "${LOCAL_NVM_TARBALL}"
   fi
-  nvm_err "Downloading ${TARBALL_URL}..."
-  nvm_download -L -C - "${PROGRESS_BAR}" "${TARBALL_URL}" -o "${TARBALL}" || (
-    command rm -rf "${TARBALL}" "${tmpdir}"
-    nvm_err "Binary download from ${TARBALL_URL} failed, trying source."
+  nvm_err "Downloading ${LOCAL_NVM_TARBALL_URL}..."
+  nvm_download -L -C - "${LOCAL_NVM_PROGRESS_BAR}" "${LOCAL_NVM_TARBALL_URL}" -o "${LOCAL_NVM_TARBALL}" || (
+    command rm -rf "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}"
+    nvm_err "Binary download from ${LOCAL_NVM_TARBALL_URL} failed, trying source."
     return 4
   )
 
-  if nvm_grep '404 Not Found' "${TARBALL}" >/dev/null; then
-    command rm -rf "${TARBALL}" "${tmpdir}"
-    nvm_err "HTTP 404 at URL ${TARBALL_URL}"
+  if nvm_grep '404 Not Found' "${LOCAL_NVM_TARBALL}" >/dev/null; then
+    command rm -rf "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}"
+    nvm_err "HTTP 404 at URL ${LOCAL_NVM_TARBALL_URL}"
     return 5
   fi
 
-  nvm_compare_checksum "${TARBALL}" "${CHECKSUM}" || (
-    command rm -rf "${tmpdir}/files"
+  nvm_compare_checksum "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_CHECKSUM}" || (
+    command rm -rf "${LOCAL_NVM_TMPDIR}/files"
     return 6
   )
 
-  nvm_echo "${TARBALL}"
+  nvm_echo "${LOCAL_NVM_TARBALL}"
 }
 
 # args: nvm_os, version, tarball, tmpdir
@@ -2249,78 +2250,78 @@ nvm_extract_tarball() {
     return 5
   fi
 
-  local NVM_OS
-  NVM_OS="${1-}"
+  local LOCAL_NVM_OS
+  LOCAL_NVM_OS="${1-}"
 
-  local VERSION
-  VERSION="${2-}"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="${2-}"
 
-  local TARBALL
-  TARBALL="${3-}"
+  local LOCAL_NVM_TARBALL
+  LOCAL_NVM_TARBALL="${3-}"
 
-  local TMPDIR
-  TMPDIR="${4-}"
+  local LOCAL_NVM_TMPDIR
+  LOCAL_NVM_TMPDIR="${4-}"
 
-  local tar_compression_flag
-  tar_compression_flag='z'
-  if nvm_supports_xz "${VERSION}"; then
-    tar_compression_flag='J'
+  local LOCAL_NVM_TAR_COMPRESSION_FLAG
+  LOCAL_NVM_TAR_COMPRESSION_FLAG='z'
+  if nvm_supports_xz "${LOCAL_NVM_VERSION}"; then
+    LOCAL_NVM_TAR_COMPRESSION_FLAG='J'
   fi
 
-  local tar
-  tar='tar'
-  if [ "${NVM_OS}" = 'aix' ]; then
-    tar='gtar'
+  local LOCAL_NVM_TOOL_TAR
+  LOCAL_NVM_TOOL_TAR='tar'
+  if [ "${LOCAL_NVM_OS}" = 'aix' ]; then
+    LOCAL_NVM_TOOL_TAR='gtar'
   fi
 
-  if [ "${NVM_OS}" = 'openbsd' ]; then
-    if [ "${tar_compression_flag}" = 'J' ]; then
-      command xzcat "${TARBALL}" | "${tar}" -xf - -C "${TMPDIR}" -s '/[^\/]*\///' || return 1
+  if [ "${LOCAL_NVM_OS}" = 'openbsd' ]; then
+    if [ "${LOCAL_NVM_TAR_COMPRESSION_FLAG}" = 'J' ]; then
+      command xzcat "${LOCAL_NVM_TARBALL}" | "${LOCAL_NVM_TOOL_TAR}" -xf - -C "${LOCAL_NVM_TMPDIR}" -s '/[^\/]*\///' || return 1
     else
-      command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" -s '/[^\/]*\///' || return 1
+      command "${LOCAL_NVM_TOOL_TAR}" -x${LOCAL_NVM_TAR_COMPRESSION_FLAG}f "${LOCAL_NVM_TARBALL}" -C "${LOCAL_NVM_TMPDIR}" -s '/[^\/]*\///' || return 1
     fi
   else
-    command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" --strip-components 1 || return 1
+    command "${LOCAL_NVM_TOOL_TAR}" -x${LOCAL_NVM_TAR_COMPRESSION_FLAG}f "${LOCAL_NVM_TARBALL}" -C "${LOCAL_NVM_TMPDIR}" --strip-components 1 || return 1
   fi
 }
 
 nvm_get_make_jobs() {
   if nvm_is_natural_num "${1-}"; then
-    NVM_MAKE_JOBS="$1"
-    nvm_echo "number of \`make\` jobs: ${NVM_MAKE_JOBS}"
+    LOCAL_NVM_MAKE_JOBS="$1"
+    nvm_echo "number of \`make\` jobs: ${LOCAL_NVM_MAKE_JOBS}"
     return
   elif [ -n "${1-}" ]; then
-    unset NVM_MAKE_JOBS
+    unset LOCAL_NVM_MAKE_JOBS
     nvm_err "$1 is invalid for number of \`make\` jobs, must be a natural number"
   fi
-  local NVM_OS
-  NVM_OS="$(nvm_get_os)"
-  local NVM_CPU_CORES
-  case "_${NVM_OS}" in
+  local LOCAL_NVM_OS
+  LOCAL_NVM_OS="$(nvm_get_os)"
+  local LOCAL_NVM_CPU_CORES
+  case "_${LOCAL_NVM_OS}" in
     "_linux")
-      NVM_CPU_CORES="$(nvm_grep -c -E '^processor.+: [0-9]+' /proc/cpuinfo)"
+      LOCAL_NVM_CPU_CORES="$(nvm_grep -c -E '^processor.+: [0-9]+' /proc/cpuinfo)"
     ;;
     "_freebsd" | "_darwin" | "_openbsd")
-      NVM_CPU_CORES="$(sysctl -n hw.ncpu)"
+      LOCAL_NVM_CPU_CORES="$(sysctl -n hw.ncpu)"
     ;;
     "_sunos")
-      NVM_CPU_CORES="$(psrinfo | wc -l)"
+      LOCAL_NVM_CPU_CORES="$(psrinfo | wc -l)"
     ;;
     "_aix")
-      NVM_CPU_CORES="$(pmcycles -m | wc -l)"
+      LOCAL_NVM_CPU_CORES="$(pmcycles -m | wc -l)"
     ;;
   esac
-  if ! nvm_is_natural_num "${NVM_CPU_CORES}"; then
+  if ! nvm_is_natural_num "${LOCAL_NVM_CPU_CORES}"; then
     nvm_err 'Can not determine how many core(s) are available, running in single-threaded mode.'
     nvm_err 'Please report an issue on GitHub to help us make nvm run faster on your computer!'
-    NVM_MAKE_JOBS=1
+    LOCAL_NVM_MAKE_JOBS=1
   else
-    nvm_echo "Detected that you have ${NVM_CPU_CORES} CPU core(s)"
-    if [ "${NVM_CPU_CORES}" -gt 2 ]; then
-      NVM_MAKE_JOBS=$((NVM_CPU_CORES - 1))
-      nvm_echo "Running with ${NVM_MAKE_JOBS} threads to speed up the build"
+    nvm_echo "Detected that you have ${LOCAL_NVM_CPU_CORES} CPU core(s)"
+    if [ "${LOCAL_NVM_CPU_CORES}" -gt 2 ]; then
+      LOCAL_NVM_MAKE_JOBS=$((LOCAL_NVM_CPU_CORES - 1))
+      nvm_echo "Running with ${LOCAL_NVM_MAKE_JOBS} threads to speed up the build"
     else
-      NVM_MAKE_JOBS=1
+      LOCAL_NVM_MAKE_JOBS=1
       nvm_echo 'Number of CPU core(s) less than or equal to 2, running in single-threaded mode'
     fi
   fi
@@ -2328,103 +2329,103 @@ nvm_get_make_jobs() {
 
 # args: flavor, type, version, make jobs, additional
 nvm_install_source() {
-  local FLAVOR
+  local LOCAL_NVM_FLAVOR
   case "${1-}" in
-    node | iojs) FLAVOR="${1}" ;;
+    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 4
     ;;
   esac
 
-  local TYPE
-  TYPE="${2-}"
+  local LOCAL_NVM_TYPE
+  LOCAL_NVM_TYPE="${2-}"
 
-  local PREFIXED_VERSION
-  PREFIXED_VERSION="${3-}"
-  if [ -z "${PREFIXED_VERSION}" ]; then
+  local LOCAL_NVM_PREFIXED_VERSION
+  LOCAL_NVM_PREFIXED_VERSION="${3-}"
+  if [ -z "${LOCAL_NVM_PREFIXED_VERSION}" ]; then
     nvm_err 'A version number is required.'
     return 3
   fi
 
-  local VERSION
-  VERSION="$(nvm_strip_iojs_prefix "${PREFIXED_VERSION}")"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="$(nvm_strip_iojs_prefix "${LOCAL_NVM_PREFIXED_VERSION}")"
 
-  local NVM_MAKE_JOBS
-  NVM_MAKE_JOBS="${4-}"
+  local LOCAL_NVM_MAKE_JOBS
+  LOCAL_NVM_MAKE_JOBS="${4-}"
 
-  local ADDITIONAL_PARAMETERS
-  ADDITIONAL_PARAMETERS="${5-}"
+  local LOCAL_NVM_ADDITIONAL_PARAMETERS
+  LOCAL_NVM_ADDITIONAL_PARAMETERS="${5-}"
 
-  local NVM_ARCH
-  NVM_ARCH="$(nvm_get_arch)"
-  if [ "${NVM_ARCH}" = 'armv6l' ] || [ "${NVM_ARCH}" = 'armv7l' ]; then
-    if [ -n "${ADDITIONAL_PARAMETERS}" ]; then
-      ADDITIONAL_PARAMETERS="--without-snapshot ${ADDITIONAL_PARAMETERS}"
+  local LOCAL_NVM_ARCH
+  LOCAL_NVM_ARCH="$(nvm_get_arch)"
+  if [ "${LOCAL_NVM_ARCH}" = 'armv6l' ] || [ "${LOCAL_NVM_ARCH}" = 'armv7l' ]; then
+    if [ -n "${LOCAL_NVM_ADDITIONAL_PARAMETERS}" ]; then
+      LOCAL_NVM_ADDITIONAL_PARAMETERS="--without-snapshot ${LOCAL_NVM_ADDITIONAL_PARAMETERS}"
     else
-      ADDITIONAL_PARAMETERS='--without-snapshot'
+      LOCAL_NVM_ADDITIONAL_PARAMETERS='--without-snapshot'
     fi
   fi
 
-  if [ -n "${ADDITIONAL_PARAMETERS}" ]; then
-    nvm_echo "Additional options while compiling: ${ADDITIONAL_PARAMETERS}"
+  if [ -n "${LOCAL_NVM_ADDITIONAL_PARAMETERS}" ]; then
+    nvm_echo "Additional options while compiling: ${LOCAL_NVM_ADDITIONAL_PARAMETERS}"
   fi
 
-  local NVM_OS
-  NVM_OS="$(nvm_get_os)"
+  local LOCAL_NVM_OS
+  LOCAL_NVM_OS="$(nvm_get_os)"
 
-  local make
-  make='make'
-  local MAKE_CXX
-  case "${NVM_OS}" in
+  local LOCAL_NVM_TOOL_MAKE
+  LOCAL_NVM_TOOL_MAKE='make'
+  local LOCAL_NVM_MAKE_CXX
+  case "${LOCAL_NVM_OS}" in
     'freebsd' | 'openbsd')
-      make='gmake'
-      MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
+      LOCAL_NVM_TOOL_MAKE='gmake'
+      LOCAL_NVM_MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
     ;;
     'darwin')
-      MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
+      LOCAL_NVM_MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
     ;;
     'aix')
-      make='gmake'
+      LOCAL_NVM_TOOL_MAKE='gmake'
     ;;
   esac
   if nvm_has "clang++" && nvm_has "clang" && nvm_version_greater_than_or_equal_to "$(nvm_clang_version)" 3.5; then
     if [ -z "${CC-}" ] || [ -z "${CXX-}" ]; then
       nvm_echo "Clang v3.5+ detected! CC or CXX not specified, will use Clang as C/C++ compiler!"
-      MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
+      LOCAL_NVM_MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
     fi
   fi
 
-  local TARBALL
-  local TMPDIR
-  local VERSION_PATH
+  local LOCAL_NVM_TARBALL
+  local LOCAL_NVM_TMPDIR
+  local LOCAL_NVM_VERSION_PATH
 
   if [ "${NVM_NO_PROGRESS-}" = "1" ]; then
     # --silent, --show-error, use short option as @samrocketman mentions the compatibility issue.
-    PROGRESS_BAR="-sS"
+    LOCAL_NVM_PROGRESS_BAR="-sS"
   else
-    PROGRESS_BAR="--progress-bar"
+    LOCAL_NVM_PROGRESS_BAR="--progress-bar"
   fi
 
   nvm_is_zsh && setopt local_options shwordsplit
 
-  TARBALL="$(PROGRESS_BAR="${PROGRESS_BAR}" nvm_download_artifact "${FLAVOR}" source "${TYPE}" "${VERSION}" | command tail -1)" && \
-  [ -f "${TARBALL}" ] && \
-  TMPDIR="$(dirname "${TARBALL}")/files" && \
+  LOCAL_NVM_TARBALL="$(LOCAL_NVM_PROGRESS_BAR="${LOCAL_NVM_PROGRESS_BAR}" nvm_download_artifact "${LOCAL_NVM_FLAVOR}" source "${LOCAL_NVM_TYPE}" "${LOCAL_NVM_VERSION}" | command tail -1)" && \
+  [ -f "${LOCAL_NVM_TARBALL}" ] && \
+  LOCAL_NVM_TMPDIR="$(dirname "${LOCAL_NVM_TARBALL}")/files" && \
   if ! (
     # shellcheck disable=SC2086
-    command mkdir -p "${TMPDIR}" && \
-    nvm_extract_tarball "${NVM_OS}" "${VERSION}" "${TARBALL}" "${TMPDIR}" && \
-    VERSION_PATH="$(nvm_version_path "${PREFIXED_VERSION}")" && \
-    nvm_cd "${TMPDIR}" && \
-    nvm_echo '$>'./configure --prefix="${VERSION_PATH}" $ADDITIONAL_PARAMETERS'<' && \
-    ./configure --prefix="${VERSION_PATH}" $ADDITIONAL_PARAMETERS && \
-    $make -j "${NVM_MAKE_JOBS}" ${MAKE_CXX-} && \
-    command rm -f "${VERSION_PATH}" 2>/dev/null && \
-    $make -j "${NVM_MAKE_JOBS}" ${MAKE_CXX-} install
+    command mkdir -p "${LOCAL_NVM_TMPDIR}" && \
+    nvm_extract_tarball "${LOCAL_NVM_OS}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}" && \
+    LOCAL_NVM_VERSION_PATH="$(nvm_version_path "${LOCAL_NVM_PREFIXED_VERSION}")" && \
+    nvm_cd "${LOCAL_NVM_TMPDIR}" && \
+    nvm_echo '$>'./configure --prefix="${LOCAL_NVM_VERSION_PATH}" ${LOCAL_NVM_ADDITIONAL_PARAMETERS}'<' && \
+    ./configure --prefix="${LOCAL_NVM_VERSION_PATH}" ${LOCAL_NVM_ADDITIONAL_PARAMETERS} && \
+    ${LOCAL_NVM_TOOL_MAKE} -j "${LOCAL_NVM_MAKE_JOBS}" ${LOCAL_NVM_MAKE_CXX-} && \
+    command rm -f "${LOCAL_NVM_VERSION_PATH}" 2>/dev/null && \
+    ${LOCAL_NVM_TOOL_MAKE} -j "${LOCAL_NVM_MAKE_JOBS}" ${LOCAL_NVM_MAKE_CXX-} install
   ); then
-    nvm_err "nvm: install ${VERSION} failed!"
-    command rm -rf "${TMPDIR-}"
+    nvm_err "nvm: install ${LOCAL_NVM_VERSION} failed!"
+    command rm -rf "${LOCAL_NVM_TMPDIR-}"
     return 1
   fi
 }
@@ -2437,14 +2438,14 @@ nvm_use_if_needed() {
 }
 
 nvm_install_npm_if_needed() {
-  local VERSION
-  VERSION="$(nvm_ls_current)"
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="$(nvm_ls_current)"
   if ! nvm_has "npm"; then
     nvm_echo 'Installing npm...'
-    if nvm_version_greater 0.2.0 "${VERSION}"; then
+    if nvm_version_greater 0.2.0 "${LOCAL_NVM_VERSION}"; then
       nvm_err 'npm requires node v0.2.3 or higher'
-    elif nvm_version_greater_than_or_equal_to "${VERSION}" 0.2.0; then
-      if nvm_version_greater 0.2.3 "${VERSION}"; then
+    elif nvm_version_greater_than_or_equal_to "${LOCAL_NVM_VERSION}" 0.2.0; then
+      if nvm_version_greater 0.2.3 "${LOCAL_NVM_VERSION}"; then
         nvm_err 'npm requires node v0.2.3 or higher'
       else
         nvm_download -L https://npmjs.org/install.sh -o - | clean=yes npm_install=0.2.19 sh
@@ -2457,69 +2458,69 @@ nvm_install_npm_if_needed() {
 }
 
 nvm_match_version() {
-  local NVM_IOJS_PREFIX
-  NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local PROVIDED_VERSION
-  PROVIDED_VERSION="$1"
-  case "_${PROVIDED_VERSION}" in
-    "_${NVM_IOJS_PREFIX}" | '_io.js')
-      nvm_version "${NVM_IOJS_PREFIX}"
+  local LOCAL_NVM_IOJS_PREFIX
+  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local LOCAL_NVM_PROVIDED_VERSION
+  LOCAL_NVM_PROVIDED_VERSION="$1"
+  case "_${LOCAL_NVM_PROVIDED_VERSION}" in
+    "_${LOCAL_NVM_IOJS_PREFIX}" | '_io.js')
+      nvm_version "${LOCAL_NVM_IOJS_PREFIX}"
     ;;
     '_system')
       nvm_echo 'system'
     ;;
     *)
-      nvm_version "${PROVIDED_VERSION}"
+      nvm_version "${LOCAL_NVM_PROVIDED_VERSION}"
     ;;
   esac
 }
 
 nvm_npm_global_modules() {
-  local NPMLIST
-  local VERSION
-  VERSION="$1"
-  NPMLIST=$(nvm use "${VERSION}" >/dev/null && npm list -g --depth=0 2>/dev/null | command sed 1,1d | nvm_grep -v 'UNMET PEER DEPENDENCY')
+  local LOCAL_NVM_NPMLIST
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="$1"
+  LOCAL_NVM_NPMLIST=$(nvm use "${LOCAL_NVM_VERSION}" >/dev/null && npm list -g --depth=0 2>/dev/null | command sed 1,1d | nvm_grep -v 'UNMET PEER DEPENDENCY')
 
-  local INSTALLS
-  INSTALLS=$(nvm_echo "${NPMLIST}" | command sed -e '/ -> / d' -e '/\(empty\)/ d' -e 's/^.* \(.*@[^ ]*\).*/\1/' -e '/^npm@[^ ]*.*$/ d' | command xargs)
+  local LOCAL_NVM_INSTALLS
+  LOCAL_NVM_INSTALLS=$(nvm_echo "${LOCAL_NVM_NPMLIST}" | command sed -e '/ -> / d' -e '/\(empty\)/ d' -e 's/^.* \(.*@[^ ]*\).*/\1/' -e '/^npm@[^ ]*.*$/ d' | command xargs)
 
-  local LINKS
-  LINKS="$(nvm_echo "${NPMLIST}" | command sed -n 's/.* -> \(.*\)/\1/ p')"
+  local LOCAL_NVM_LINKS
+  LOCAL_NVM_LINKS="$(nvm_echo "${LOCAL_NVM_NPMLIST}" | command sed -n 's/.* -> \(.*\)/\1/ p')"
 
-  nvm_echo "${INSTALLS} //// ${LINKS}"
+  nvm_echo "${LOCAL_NVM_INSTALLS} //// ${LOCAL_NVM_LINKS}"
 }
 
 nvm_npmrc_bad_news_bears() {
-  local NVM_NPMRC
-  NVM_NPMRC="${1-}"
-  if [ -n "${NVM_NPMRC}" ] && [ -f "${NVM_NPMRC}" ] && nvm_grep -Ee '^(prefix|globalconfig) *=' <"${NVM_NPMRC}" >/dev/null; then
+  local LOCAL_NVM_NPMRC
+  LOCAL_NVM_NPMRC="${1-}"
+  if [ -n "${LOCAL_NVM_NPMRC}" ] && [ -f "${LOCAL_NVM_NPMRC}" ] && nvm_grep -Ee '^(prefix|globalconfig) *=' <"${LOCAL_NVM_NPMRC}" >/dev/null; then
     return 0
   fi
   return 1
 }
 
 nvm_die_on_prefix() {
-  local NVM_DELETE_PREFIX
-  NVM_DELETE_PREFIX="${1-}"
-  case "${NVM_DELETE_PREFIX}" in
+  local LOCAL_NVM_DELETE_PREFIX
+  LOCAL_NVM_DELETE_PREFIX="${1-}"
+  case "${LOCAL_NVM_DELETE_PREFIX}" in
     0 | 1) ;;
     *)
       nvm_err 'First argument "delete the prefix" must be zero or one'
       return 1
     ;;
   esac
-  local NVM_COMMAND
-  NVM_COMMAND="${2-}"
-  local NVM_VERSION_DIR
-  NVM_VERSION_DIR="${3-}"
-  if [ -z "${NVM_COMMAND}" ] || [ -z "${NVM_VERSION_DIR}" ]; then
+  local LOCAL_NVM_COMMAND
+  LOCAL_NVM_COMMAND="${2-}"
+  local LOCAL_NVM_VERSION_DIR
+  LOCAL_NVM_VERSION_DIR="${3-}"
+  if [ -z "${LOCAL_NVM_COMMAND}" ] || [ -z "${LOCAL_NVM_VERSION_DIR}" ]; then
     nvm_err 'Second argument "nvm command", and third argument "nvm version dir", must both be nonempty'
     return 2
   fi
 
-  # npm first looks at $PREFIX (case-sensitive)
+  # npm first looks at ${PREFIX} (case-sensitive)
   # we do not bother to test the value here; if this env var is set, unset it to continue.
-  # however, `npm exec` in npm v7.2+ sets $PREFIX; if set, inherit it
+  # however, `npm exec` in npm v7.2+ sets ${PREFIX}; if set, inherit it
   if [ -n "${PREFIX-}" ] && [ "$(nvm_version_path "$(node -v)")" != "${PREFIX}" ]; then
     nvm deactivate >/dev/null 2>&1
     nvm_err "nvm is not compatible with the \"PREFIX\" environment variable: currently set to \"${PREFIX}\""
@@ -2527,8 +2528,8 @@ nvm_die_on_prefix() {
     return 3
   fi
 
-  local NVM_OS
-  NVM_OS="$(nvm_get_os)"
+  local LOCAL_NVM_OS
+  LOCAL_NVM_OS="$(nvm_get_os)"
 
   # npm normalizes NPM_CONFIG_-prefixed env vars
   # https://github.com/npm/npmconf/blob/22827e4038d6eebaafeb5c13ed2b92cf97b8fb82/npmconf.js#L331-L348
@@ -2536,18 +2537,18 @@ nvm_die_on_prefix() {
   #
   # here, we avoid trying to replicate "which one wins" or testing the value; if any are defined, it errors
   # until none are left.
-  local NVM_NPM_CONFIG_x_PREFIX_ENV
-  NVM_NPM_CONFIG_x_PREFIX_ENV="$(command awk 'BEGIN { for (name in ENVIRON) if (toupper(name) == "NPM_CONFIG_PREFIX") { print name; break } }')"
-  if [ -n "${NVM_NPM_CONFIG_x_PREFIX_ENV-}" ]; then
-    local NVM_CONFIG_VALUE
-    eval "NVM_CONFIG_VALUE=\"\$${NVM_NPM_CONFIG_x_PREFIX_ENV}\""
-    if [ -n "${NVM_CONFIG_VALUE-}" ] && [ "_${NVM_OS}" = "_win" ]; then
-      NVM_CONFIG_VALUE="$(cd "$NVM_CONFIG_VALUE" 2>/dev/null && pwd)"
+  local LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV
+  LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV="$(command awk 'BEGIN { for (name in ENVIRON) if (toupper(name) == "NPM_CONFIG_PREFIX") { print name; break } }')"
+  if [ -n "${LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV-}" ]; then
+    local LOCAL_NVM_CONFIG_VALUE
+    eval "LOCAL_NVM_CONFIG_VALUE=\"\$${LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV}\""
+    if [ -n "${LOCAL_NVM_CONFIG_VALUE-}" ] && [ "_${LOCAL_NVM_OS}" = "_win" ]; then
+      LOCAL_NVM_CONFIG_VALUE="$(cd "${LOCAL_NVM_CONFIG_VALUE}" 2>/dev/null && pwd)"
     fi
-    if [ -n "${NVM_CONFIG_VALUE-}" ] && ! nvm_tree_contains_path "${NVM_DIR}" "${NVM_CONFIG_VALUE}"; then
+    if [ -n "${LOCAL_NVM_CONFIG_VALUE-}" ] && ! nvm_tree_contains_path "${NVM_DIR}" "${LOCAL_NVM_CONFIG_VALUE}"; then
       nvm deactivate >/dev/null 2>&1
-      nvm_err "nvm is not compatible with the \"${NVM_NPM_CONFIG_x_PREFIX_ENV}\" environment variable: currently set to \"${NVM_CONFIG_VALUE}\""
-      nvm_err "Run \`unset ${NVM_NPM_CONFIG_x_PREFIX_ENV}\` to unset it."
+      nvm_err "nvm is not compatible with the \"${LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV}\" environment variable: currently set to \"${LOCAL_NVM_CONFIG_VALUE}\""
+      nvm_err "Run \`unset ${LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV}\` to unset it."
       return 4
     fi
   fi
@@ -2558,131 +2559,132 @@ nvm_die_on_prefix() {
   # there are 4 npmrc locations to check: project, global, user, and builtin
   # project: find the closest node_modules or package.json-containing dir, `.npmrc`
   # global: default prefix + `/etc/npmrc`
-  # user: $HOME/.npmrc
+  # user: ${HOME}/.npmrc
   # builtin: npm install location, `npmrc`
   #
   # if any of them have a `prefix`, fail.
   # if any have `globalconfig`, fail also, just in case, to avoid spidering configs.
 
-  local NVM_NPM_BUILTIN_NPMRC
-  NVM_NPM_BUILTIN_NPMRC="${NVM_VERSION_DIR}/lib/node_modules/npm/npmrc"
-  if nvm_npmrc_bad_news_bears "${NVM_NPM_BUILTIN_NPMRC}"; then
-    if [ "_${NVM_DELETE_PREFIX}" = "_1" ]; then
-      npm config --loglevel=warn delete prefix --userconfig="${NVM_NPM_BUILTIN_NPMRC}"
-      npm config --loglevel=warn delete globalconfig --userconfig="${NVM_NPM_BUILTIN_NPMRC}"
+  local LOCAL_NVM_NPM_BUILTIN_NPMRC
+  LOCAL_NVM_NPM_BUILTIN_NPMRC="${LOCAL_NVM_VERSION_DIR}/lib/node_modules/npm/npmrc"
+  if nvm_npmrc_bad_news_bears "${LOCAL_NVM_NPM_BUILTIN_NPMRC}"; then
+    if [ "_${LOCAL_NVM_DELETE_PREFIX}" = "_1" ]; then
+      npm config --loglevel=warn delete prefix --userconfig="${LOCAL_NVM_NPM_BUILTIN_NPMRC}"
+      npm config --loglevel=warn delete globalconfig --userconfig="${LOCAL_NVM_NPM_BUILTIN_NPMRC}"
     else
-      nvm_err "Your builtin npmrc file ($(nvm_sanitize_path "${NVM_NPM_BUILTIN_NPMRC}"))"
+      nvm_err "Your builtin npmrc file ($(nvm_sanitize_path "${LOCAL_NVM_NPM_BUILTIN_NPMRC}"))"
       nvm_err 'has a `globalconfig` and/or a `prefix` setting, which are incompatible with nvm.'
-      nvm_err "Run \`${NVM_COMMAND}\` to unset it."
+      nvm_err "Run \`${LOCAL_NVM_COMMAND}\` to unset it."
       return 10
     fi
   fi
 
-  local NVM_NPM_GLOBAL_NPMRC
-  NVM_NPM_GLOBAL_NPMRC="${NVM_VERSION_DIR}/etc/npmrc"
-  if nvm_npmrc_bad_news_bears "${NVM_NPM_GLOBAL_NPMRC}"; then
-    if [ "_${NVM_DELETE_PREFIX}" = "_1" ]; then
+  local LOCAL_NVM_NPM_GLOBAL_NPMRC
+  LOCAL_NVM_NPM_GLOBAL_NPMRC="${LOCAL_NVM_VERSION_DIR}/etc/npmrc"
+  if nvm_npmrc_bad_news_bears "${LOCAL_NVM_NPM_GLOBAL_NPMRC}"; then
+    if [ "_${LOCAL_NVM_DELETE_PREFIX}" = "_1" ]; then
       npm config --global --loglevel=warn delete prefix
       npm config --global --loglevel=warn delete globalconfig
     else
-      nvm_err "Your global npmrc file ($(nvm_sanitize_path "${NVM_NPM_GLOBAL_NPMRC}"))"
+      nvm_err "Your global npmrc file ($(nvm_sanitize_path "${LOCAL_NVM_NPM_GLOBAL_NPMRC}"))"
       nvm_err 'has a `globalconfig` and/or a `prefix` setting, which are incompatible with nvm.'
-      nvm_err "Run \`${NVM_COMMAND}\` to unset it."
+      nvm_err "Run \`${LOCAL_NVM_COMMAND}\` to unset it."
       return 10
     fi
   fi
 
-  local NVM_NPM_USER_NPMRC
-  NVM_NPM_USER_NPMRC="${HOME}/.npmrc"
-  if nvm_npmrc_bad_news_bears "${NVM_NPM_USER_NPMRC}"; then
-    if [ "_${NVM_DELETE_PREFIX}" = "_1" ]; then
-      npm config --loglevel=warn delete prefix --userconfig="${NVM_NPM_USER_NPMRC}"
-      npm config --loglevel=warn delete globalconfig --userconfig="${NVM_NPM_USER_NPMRC}"
+  local LOCAL_NVM_NPM_USER_NPMRC
+  LOCAL_NVM_NPM_USER_NPMRC="${HOME}/.npmrc"
+  if nvm_npmrc_bad_news_bears "${LOCAL_NVM_NPM_USER_NPMRC}"; then
+    if [ "_${LOCAL_NVM_DELETE_PREFIX}" = "_1" ]; then
+      npm config --loglevel=warn delete prefix --userconfig="${LOCAL_NVM_NPM_USER_NPMRC}"
+      npm config --loglevel=warn delete globalconfig --userconfig="${LOCAL_NVM_NPM_USER_NPMRC}"
     else
-      nvm_err "Your user’s .npmrc file ($(nvm_sanitize_path "${NVM_NPM_USER_NPMRC}"))"
+      nvm_err "Your user’s .npmrc file ($(nvm_sanitize_path "${LOCAL_NVM_NPM_USER_NPMRC}"))"
       nvm_err 'has a `globalconfig` and/or a `prefix` setting, which are incompatible with nvm.'
-      nvm_err "Run \`${NVM_COMMAND}\` to unset it."
+      nvm_err "Run \`${LOCAL_NVM_COMMAND}\` to unset it."
       return 10
     fi
   fi
 
-  local NVM_NPM_PROJECT_NPMRC
-  NVM_NPM_PROJECT_NPMRC="$(nvm_find_project_dir)/.npmrc"
-  if nvm_npmrc_bad_news_bears "${NVM_NPM_PROJECT_NPMRC}"; then
-    if [ "_${NVM_DELETE_PREFIX}" = "_1" ]; then
+  local LOCAL_NVM_NPM_PROJECT_NPMRC
+  LOCAL_NVM_NPM_PROJECT_NPMRC="$(nvm_find_project_dir)/.npmrc"
+  if nvm_npmrc_bad_news_bears "${LOCAL_NVM_NPM_PROJECT_NPMRC}"; then
+    if [ "_${LOCAL_NVM_DELETE_PREFIX}" = "_1" ]; then
       npm config --loglevel=warn delete prefix
       npm config --loglevel=warn delete globalconfig
     else
-      nvm_err "Your project npmrc file ($(nvm_sanitize_path "${NVM_NPM_PROJECT_NPMRC}"))"
+      nvm_err "Your project npmrc file ($(nvm_sanitize_path "${LOCAL_NVM_NPM_PROJECT_NPMRC}"))"
       nvm_err 'has a `globalconfig` and/or a `prefix` setting, which are incompatible with nvm.'
-      nvm_err "Run \`${NVM_COMMAND}\` to unset it."
+      nvm_err "Run \`${LOCAL_NVM_COMMAND}\` to unset it."
       return 10
     fi
   fi
 }
 
-# Succeeds if $IOJS_VERSION represents an io.js version that has a
+# Succeeds if ${LOCAL_NVM_IOJS_VERSION} represents an io.js version that has a
 # Solaris binary, fails otherwise.
 # Currently, only io.js 3.3.1 has a Solaris binary available, and it's the
 # latest io.js version available. The expectation is that any potential io.js
 # version later than v3.3.1 will also have Solaris binaries.
 nvm_iojs_version_has_solaris_binary() {
-  local IOJS_VERSION
-  IOJS_VERSION="$1"
-  local STRIPPED_IOJS_VERSION
-  STRIPPED_IOJS_VERSION="$(nvm_strip_iojs_prefix "${IOJS_VERSION}")"
-  if [ "_${STRIPPED_IOJS_VERSION}" = "${IOJS_VERSION}" ]; then
+  local LOCAL_NVM_IOJS_VERSION
+  LOCAL_NVM_IOJS_VERSION="$1"
+  local LOCAL_NVM_STRIPPED_IOJS_VERSION
+  LOCAL_NVM_STRIPPED_IOJS_VERSION="$(nvm_strip_iojs_prefix "${LOCAL_NVM_IOJS_VERSION}")"
+  if [ "_${LOCAL_NVM_STRIPPED_IOJS_VERSION}" = "${LOCAL_NVM_IOJS_VERSION}" ]; then
     return 1
   fi
 
   # io.js started shipping Solaris binaries with io.js v3.3.1
-  nvm_version_greater_than_or_equal_to "${STRIPPED_IOJS_VERSION}" v3.3.1
+  nvm_version_greater_than_or_equal_to "${LOCAL_NVM_STRIPPED_IOJS_VERSION}" v3.3.1
 }
 
-# Succeeds if $NODE_VERSION represents a node version that has a
+# Succeeds if ${LOCAL_NVM_NODE_VERSION} represents a node version that has a
 # Solaris binary, fails otherwise.
 # Currently, node versions starting from v0.8.6 have a Solaris binary
 # available.
 nvm_node_version_has_solaris_binary() {
-  local NODE_VERSION
-  NODE_VERSION="$1"
-  # Error out if $NODE_VERSION is actually an io.js version
-  local STRIPPED_IOJS_VERSION
-  STRIPPED_IOJS_VERSION="$(nvm_strip_iojs_prefix "${NODE_VERSION}")"
-  if [ "_${STRIPPED_IOJS_VERSION}" != "_${NODE_VERSION}" ]; then
+  local LOCAL_NVM_NODE_VERSION
+  LOCAL_NVM_NODE_VERSION="$1"
+  # Error out if ${LOCAL_NVM_NODE_VERSION} is actually an io.js version
+  local LOCAL_NVM_STRIPPED_IOJS_VERSION
+  LOCAL_NVM_STRIPPED_IOJS_VERSION="$(nvm_strip_iojs_prefix "${LOCAL_NVM_NODE_VERSION}")"
+  if [ "_${LOCAL_NVM_STRIPPED_IOJS_VERSION}" != "_${LOCAL_NVM_NODE_VERSION}" ]; then
     return 1
   fi
 
   # node (unmerged) started shipping Solaris binaries with v0.8.6 and
   # node versions v1.0.0 or greater are not considered valid "unmerged" node
   # versions.
-  nvm_version_greater_than_or_equal_to "${NODE_VERSION}" v0.8.6 \
-  && ! nvm_version_greater_than_or_equal_to "${NODE_VERSION}" v1.0.0
+  nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" v0.8.6 \
+  && ! nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" v1.0.0
 }
 
-# Succeeds if $VERSION represents a version (node, io.js or merged) that has a
+# Succeeds if ${LOCAL_NVM_VERSION} represents a version (node, io.js or merged) that has a
 # Solaris binary, fails otherwise.
 nvm_has_solaris_binary() {
-  local VERSION="${1-}"
-  if nvm_is_merged_node_version "${VERSION}"; then
+  local LOCAL_NVM_VERSION
+  LOCAL_NVM_VERSION="${1-}"
+  if nvm_is_merged_node_version "${LOCAL_NVM_VERSION}"; then
     return 0 # All merged node versions have a Solaris binary
-  elif nvm_is_iojs_version "${VERSION}"; then
-    nvm_iojs_version_has_solaris_binary "${VERSION}"
+  elif nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
+    nvm_iojs_version_has_solaris_binary "${LOCAL_NVM_VERSION}"
   else
-    nvm_node_version_has_solaris_binary "${VERSION}"
+    nvm_node_version_has_solaris_binary "${LOCAL_NVM_VERSION}"
   fi
 }
 
 nvm_sanitize_path() {
-  local SANITIZED_PATH
-  SANITIZED_PATH="${1-}"
-  if [ "_${SANITIZED_PATH}" != "_${NVM_DIR}" ]; then
-    SANITIZED_PATH="$(nvm_echo "${SANITIZED_PATH}" | command sed -e "s#${NVM_DIR}#\${NVM_DIR}#g")"
+  local LOCAL_NVM_SANITIZED_PATH
+  LOCAL_NVM_SANITIZED_PATH="${1-}"
+  if [ "_${LOCAL_NVM_SANITIZED_PATH}" != "_${NVM_DIR}" ]; then
+    LOCAL_NVM_SANITIZED_PATH="$(nvm_echo "${LOCAL_NVM_SANITIZED_PATH}" | command sed -e "s#${NVM_DIR}#\${NVM_DIR}#g")"
   fi
-  if [ "_${SANITIZED_PATH}" != "_${HOME}" ]; then
-    SANITIZED_PATH="$(nvm_echo "${SANITIZED_PATH}" | command sed -e "s#${HOME}#\${HOME}#g")"
+  if [ "_${LOCAL_NVM_SANITIZED_PATH}" != "_${HOME}" ]; then
+    LOCAL_NVM_SANITIZED_PATH="$(nvm_echo "${LOCAL_NVM_SANITIZED_PATH}" | command sed -e "s#${HOME}#\${HOME}#g")"
   fi
-  nvm_echo "${SANITIZED_PATH}"
+  nvm_echo "${LOCAL_NVM_SANITIZED_PATH}"
 }
 
 nvm_is_natural_num() {
@@ -2702,15 +2704,15 @@ nvm_is_natural_num() {
 nvm_check_file_permissions() {
   nvm_is_zsh && setopt local_options nonomatch
   for FILE in "$1"/* "$1"/.[!.]* "$1"/..?* ; do
-    if [ -d "$FILE" ]; then
+    if [ -d "${FILE}" ]; then
       if [ -n "${NVM_DEBUG-}" ]; then
         nvm_err "${FILE}"
       fi
       if ! nvm_check_file_permissions "${FILE}"; then
         return 2
       fi
-    elif [ -e "$FILE" ] && [ ! -w "$FILE" ] && [ ! -O "$FILE" ]; then
-      nvm_err "file is not writable or self-owned: $(nvm_sanitize_path "$FILE")"
+    elif [ -e "${FILE}" ] && [ ! -w "${FILE}" ] && [ ! -O "${FILE}" ]; then
+      nvm_err "file is not writable or self-owned: $(nvm_sanitize_path "${FILE}")"
       return 1
     fi
   done
@@ -2727,94 +2729,94 @@ nvm() {
     return
   fi
 
-  local DEFAULT_IFS
-  DEFAULT_IFS=" $(nvm_echo t | command tr t \\t)
+  local LOCAL_NVM_DEFAULT_IFS
+  LOCAL_NVM_DEFAULT_IFS=" $(nvm_echo t | command tr t \\t)
 "
   if [ "${-#*e}" != "$-" ]; then
     set +e
-    local EXIT_CODE
-    IFS="${DEFAULT_IFS}" nvm "$@"
-    EXIT_CODE="$?"
+    local LOCAL_NVM_EXIT_CODE
+    IFS="${LOCAL_NVM_DEFAULT_IFS}" nvm "$@"
+    LOCAL_NVM_EXIT_CODE="$?"
     set -e
-    return "$EXIT_CODE"
+    return "${LOCAL_NVM_EXIT_CODE}"
   elif [ "${-#*a}" != "$-" ]; then
     set +a
-    local EXIT_CODE
-    IFS="${DEFAULT_IFS}" nvm "$@"
-    EXIT_CODE="$?"
+    local LOCAL_NVM_EXIT_CODE
+    IFS="${LOCAL_NVM_DEFAULT_IFS}" nvm "$@"
+    LOCAL_NVM_EXIT_CODE="$?"
     set -a
-    return "$EXIT_CODE"
+    return "${LOCAL_NVM_EXIT_CODE}"
   elif [ -n "${BASH-}" ] && [ "${-#*E}" != "$-" ]; then
     # shellcheck disable=SC3041
     set +E
-    local EXIT_CODE
-    IFS="${DEFAULT_IFS}" nvm "$@"
-    EXIT_CODE="$?"
+    local LOCAL_NVM_EXIT_CODE
+    IFS="${LOCAL_NVM_DEFAULT_IFS}" nvm "$@"
+    LOCAL_NVM_EXIT_CODE="$?"
     # shellcheck disable=SC3041
     set -E
-    return "$EXIT_CODE"
-  elif [ "${IFS}" != "${DEFAULT_IFS}" ]; then
-    IFS="${DEFAULT_IFS}" nvm "$@"
+    return "${LOCAL_NVM_EXIT_CODE}"
+  elif [ "${IFS}" != "${LOCAL_NVM_DEFAULT_IFS}" ]; then
+    IFS="${LOCAL_NVM_DEFAULT_IFS}" nvm "$@"
     return "$?"
   fi
 
-  local i
-  for i in "$@"
-  do
-    case $i in
+  local LOCAL_NVM_I
+  for LOCAL_NVM_I in "$@"; do
+    case ${LOCAL_NVM_I} in
       --) break ;;
       '-h'|'help'|'--help')
         NVM_NO_COLORS=""
-        for j in "$@"; do
-          if [ "${j}" = '--no-colors' ]; then
-            NVM_NO_COLORS="${j}"
+        for LOCAL_NVM_J in "$@"; do
+          if [ "${LOCAL_NVM_J}" = '--no-colors' ]; then
+            NVM_NO_COLORS="${LOCAL_NVM_J}"
             break
           fi
         done
 
-        local INITIAL_COLOR_INFO
-        local RED_INFO
-        local GREEN_INFO
-        local BLUE_INFO
-        local CYAN_INFO
-        local MAGENTA_INFO
-        local YELLOW_INFO
-        local BLACK_INFO
-        local GREY_WHITE_INFO
+        local LOCAL_NVM_INITIAL_COLOR_INFO
+        local LOCAL_NVM_RED_INFO
+        local LOCAL_NVM_GREEN_INFO
+        local LOCAL_NVM_BLUE_INFO
+        local LOCAL_NVM_CYAN_INFO
+        local LOCAL_NVM_MAGENTA_INFO
+        local LOCAL_NVM_YELLOW_INFO
+        local LOCAL_NVM_BLACK_INFO
+        local LOCAL_NVM_GREY_WHITE_INFO
 
         if [ -z "${NVM_NO_COLORS-}"  ] && nvm_has_colors; then
-          INITIAL_COLOR_INFO='\033[0;32m g\033[0m \033[0;34m b\033[0m \033[0;33m y\033[0m \033[0;31m r\033[0m \033[0;37m e\033[0m'
-          RED_INFO='\033[0;31m r\033[0m/\033[1;31mR\033[0m = \033[0;31mred\033[0m / \033[1;31mbold red\033[0m'
-          GREEN_INFO='\033[0;32m g\033[0m/\033[1;32mG\033[0m = \033[0;32mgreen\033[0m / \033[1;32mbold green\033[0m'
-          BLUE_INFO='\033[0;34m b\033[0m/\033[1;34mB\033[0m = \033[0;34mblue\033[0m / \033[1;34mbold blue\033[0m'
-          CYAN_INFO='\033[0;36m c\033[0m/\033[1;36mC\033[0m = \033[0;36mcyan\033[0m / \033[1;36mbold cyan\033[0m'
-          MAGENTA_INFO='\033[0;35m m\033[0m/\033[1;35mM\033[0m = \033[0;35mmagenta\033[0m / \033[1;35mbold magenta\033[0m'
-          YELLOW_INFO='\033[0;33m y\033[0m/\033[1;33mY\033[0m = \033[0;33myellow\033[0m / \033[1;33mbold yellow\033[0m'
-          BLACK_INFO='\033[0;30m k\033[0m/\033[1;30mK\033[0m = \033[0;30mblack\033[0m / \033[1;30mbold black\033[0m'
-          GREY_WHITE_INFO='\033[0;37m e\033[0m/\033[1;37mW\033[0m = \033[0;37mlight grey\033[0m / \033[1;37mwhite\033[0m'
+          LOCAL_NVM_INITIAL_COLOR_INFO='\033[0;32m g\033[0m \033[0;34m b\033[0m \033[0;33m y\033[0m \033[0;31m r\033[0m \033[0;37m e\033[0m'
+          LOCAL_NVM_RED_INFO='\033[0;31m r\033[0m/\033[1;31mR\033[0m = \033[0;31mred\033[0m / \033[1;31mbold red\033[0m'
+          LOCAL_NVM_GREEN_INFO='\033[0;32m g\033[0m/\033[1;32mG\033[0m = \033[0;32mgreen\033[0m / \033[1;32mbold green\033[0m'
+          LOCAL_NVM_BLUE_INFO='\033[0;34m b\033[0m/\033[1;34mB\033[0m = \033[0;34mblue\033[0m / \033[1;34mbold blue\033[0m'
+          LOCAL_NVM_CYAN_INFO='\033[0;36m c\033[0m/\033[1;36mC\033[0m = \033[0;36mcyan\033[0m / \033[1;36mbold cyan\033[0m'
+          LOCAL_NVM_MAGENTA_INFO='\033[0;35m m\033[0m/\033[1;35mM\033[0m = \033[0;35mmagenta\033[0m / \033[1;35mbold magenta\033[0m'
+          LOCAL_NVM_YELLOW_INFO='\033[0;33m y\033[0m/\033[1;33mY\033[0m = \033[0;33myellow\033[0m / \033[1;33mbold yellow\033[0m'
+          LOCAL_NVM_BLACK_INFO='\033[0;30m k\033[0m/\033[1;30mK\033[0m = \033[0;30mblack\033[0m / \033[1;30mbold black\033[0m'
+          LOCAL_NVM_GREY_WHITE_INFO='\033[0;37m e\033[0m/\033[1;37mW\033[0m = \033[0;37mlight grey\033[0m / \033[1;37mwhite\033[0m'
         else
-          INITIAL_COLOR_INFO='gbYre'
-          RED_INFO='r/R = red / bold red'
-          GREEN_INFO='g/G = green / bold green'
-          BLUE_INFO='b/B = blue / bold blue'
-          CYAN_INFO='c/C = cyan / bold cyan'
-          MAGENTA_INFO='m/M = magenta / bold magenta'
-          YELLOW_INFO='y/Y = yellow / bold yellow'
-          BLACK_INFO='k/K = black / bold black'
-          GREY_WHITE_INFO='e/W = light grey / white'
+          LOCAL_NVM_INITIAL_COLOR_INFO='gbYre'
+          LOCAL_NVM_RED_INFO='r/R = red / bold red'
+          LOCAL_NVM_GREEN_INFO='g/G = green / bold green'
+          LOCAL_NVM_BLUE_INFO='b/B = blue / bold blue'
+          LOCAL_NVM_CYAN_INFO='c/C = cyan / bold cyan'
+          LOCAL_NVM_MAGENTA_INFO='m/M = magenta / bold magenta'
+          LOCAL_NVM_YELLOW_INFO='y/Y = yellow / bold yellow'
+          LOCAL_NVM_BLACK_INFO='k/K = black / bold black'
+          LOCAL_NVM_GREY_WHITE_INFO='e/W = light grey / white'
         fi
 
-        local NVM_IOJS_PREFIX
-        NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-        local NVM_NODE_PREFIX
-        NVM_NODE_PREFIX="$(nvm_node_prefix)"
-        NVM_VERSION="$(nvm --version)"
+        local LOCAL_NVM_IOJS_PREFIX
+        LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+        local LOCAL_NVM_NODE_PREFIX
+        LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
+        local LOCAL_NVM_VERSION
+        LOCAL_NVM_VERSION="$(nvm --version)"
         nvm_echo
-        nvm_echo "Node Version Manager (v${NVM_VERSION})"
+        nvm_echo "Node Version Manager (v${LOCAL_NVM_VERSION})"
         nvm_echo
         nvm_echo 'Note: <version> refers to any version-like string nvm understands. This includes:'
         nvm_echo '  - full or partial version numbers, starting with an optional "v" (0.10, v0.1.2, v1)'
-        nvm_echo "  - default (built-in) aliases: ${NVM_NODE_PREFIX}, stable, unstable, ${NVM_IOJS_PREFIX}, system"
+        nvm_echo "  - default (built-in) aliases: ${LOCAL_NVM_NODE_PREFIX}, stable, unstable, ${LOCAL_NVM_IOJS_PREFIX}, system"
         nvm_echo '  - custom aliases you define with `nvm alias foo`'
         nvm_echo
         nvm_echo ' Any options that produce colorized output should respect the `--no-colors` option.'
@@ -2880,16 +2882,16 @@ nvm() {
         nvm_echo '  nvm cache clear                             Empty cache directory for nvm'
         nvm_echo '  nvm set-colors [<color codes>]              Set five text colors using format "yMeBg". Available when supported.'
         nvm_echo '                                               Initial colors are:'
-        nvm_echo_with_colors "                                                  ${INITIAL_COLOR_INFO}"
+        nvm_echo_with_colors "                                                  ${LOCAL_NVM_INITIAL_COLOR_INFO}"
         nvm_echo '                                               Color codes:'
-        nvm_echo_with_colors "                                                ${RED_INFO}"
-        nvm_echo_with_colors "                                                ${GREEN_INFO}"
-        nvm_echo_with_colors "                                                ${BLUE_INFO}"
-        nvm_echo_with_colors "                                                ${CYAN_INFO}"
-        nvm_echo_with_colors "                                                ${MAGENTA_INFO}"
-        nvm_echo_with_colors "                                                ${YELLOW_INFO}"
-        nvm_echo_with_colors "                                                ${BLACK_INFO}"
-        nvm_echo_with_colors "                                                ${GREY_WHITE_INFO}"
+        nvm_echo_with_colors "                                                ${LOCAL_NVM_RED_INFO}"
+        nvm_echo_with_colors "                                                ${LOCAL_NVM_GREEN_INFO}"
+        nvm_echo_with_colors "                                                ${LOCAL_NVM_BLUE_INFO}"
+        nvm_echo_with_colors "                                                ${LOCAL_NVM_CYAN_INFO}"
+        nvm_echo_with_colors "                                                ${LOCAL_NVM_MAGENTA_INFO}"
+        nvm_echo_with_colors "                                                ${LOCAL_NVM_YELLOW_INFO}"
+        nvm_echo_with_colors "                                                ${LOCAL_NVM_BLACK_INFO}"
+        nvm_echo_with_colors "                                                ${LOCAL_NVM_GREY_WHITE_INFO}"
         nvm_echo
         nvm_echo 'Example:'
         nvm_echo '  nvm install 8.0.0                     Install a specific version number'
@@ -2907,32 +2909,32 @@ nvm() {
         nvm_echo '  nvm set-colors cgYmW                  Set text colors to cyan, green, bold yellow, magenta, and white'
         nvm_echo
         nvm_echo 'Note:'
-        nvm_echo '  to remove, delete, or uninstall nvm - just remove the `$NVM_DIR` folder (usually `~/.nvm`)'
+        nvm_echo '  to remove, delete, or uninstall nvm - just remove the `${NVM_DIR}` folder (usually `~/.nvm`)'
         nvm_echo
         return 0;
       ;;
     esac
   done
 
-  local COMMAND
-  COMMAND="${1-}"
+  local LOCAL_NVM_COMMAND
+  LOCAL_NVM_COMMAND="${1-}"
   shift
 
   # initialize local variables
-  local VERSION
-  local ADDITIONAL_PARAMETERS
+  local LOCAL_NVM_VERSION
+  local LOCAL_NVM_ADDITIONAL_PARAMETERS
 
-  case $COMMAND in
+  case ${LOCAL_NVM_COMMAND} in
     "cache")
       case "${1-}" in
         dir) nvm_cache_dir ;;
         clear)
-          local DIR
-          DIR="$(nvm_cache_dir)"
-          if command rm -rf "${DIR}" && command mkdir -p "${DIR}"; then
+          local LOCAL_NVM_DIR
+          LOCAL_NVM_DIR="$(nvm_cache_dir)"
+          if command rm -rf "${LOCAL_NVM_DIR}" && command mkdir -p "${LOCAL_NVM_DIR}"; then
             nvm_echo 'nvm cache cleared.'
           else
-            nvm_err "Unable to clear nvm cache: ${DIR}"
+            nvm_err "Unable to clear nvm cache: ${LOCAL_NVM_DIR}"
             return 1
           fi
         ;;
@@ -2944,37 +2946,37 @@ nvm() {
     ;;
 
     "debug")
-      local OS_VERSION
+      local LOCAL_NVM_OS_VERSION
       nvm_is_zsh && setopt local_options shwordsplit
       nvm_err "nvm --version: v$(nvm --version)"
       if [ -n "${TERM_PROGRAM-}" ]; then
-        nvm_err "\$TERM_PROGRAM: ${TERM_PROGRAM}"
+        nvm_err "\${TERM_PROGRAM}: ${TERM_PROGRAM}"
       fi
-      nvm_err "\$SHELL: ${SHELL}"
+      nvm_err "\${SHELL}: ${SHELL}"
       # shellcheck disable=SC2169,SC3028
-      nvm_err "\$SHLVL: ${SHLVL-}"
+      nvm_err "\${SHLVL}: ${SHLVL-}"
       nvm_err "whoami: '$(whoami)'"
       nvm_err "\${HOME}: ${HOME}"
       nvm_err "\${NVM_DIR}: '$(nvm_sanitize_path "${NVM_DIR}")'"
       nvm_err "\${PATH}: $(nvm_sanitize_path "${PATH}")"
-      nvm_err "\$PREFIX: '$(nvm_sanitize_path "${PREFIX}")'"
+      nvm_err "\${PREFIX}: '$(nvm_sanitize_path "${PREFIX}")'"
       nvm_err "\${NPM_CONFIG_PREFIX}: '$(nvm_sanitize_path "${NPM_CONFIG_PREFIX}")'"
-      nvm_err "\$NVM_NODEJS_ORG_MIRROR: '${NVM_NODEJS_ORG_MIRROR}'"
-      nvm_err "\$NVM_IOJS_ORG_MIRROR: '${NVM_IOJS_ORG_MIRROR}'"
+      nvm_err "\${NVM_NODEJS_ORG_MIRROR}: '${NVM_NODEJS_ORG_MIRROR}'"
+      nvm_err "\${NVM_IOJS_ORG_MIRROR}: '${NVM_IOJS_ORG_MIRROR}'"
       nvm_err "shell version: '$(${SHELL} --version | command head -n 1)'"
       nvm_err "uname -a: '$(command uname -a | command awk '{$2=""; print}' | command xargs)'"
       nvm_err "checksum binary: '$(nvm_get_checksum_binary 2>/dev/null)'"
       if [ "$(nvm_get_os)" = "darwin" ] && nvm_has sw_vers; then
-        OS_VERSION="$(sw_vers | command awk '{print $2}' | command xargs)"
+        LOCAL_NVM_OS_VERSION="$(sw_vers | command awk '{print $2}' | command xargs)"
       elif [ -r "/etc/issue" ]; then
-        OS_VERSION="$(command head -n 1 /etc/issue | command sed 's/\\.//g')"
-        if [ -z "${OS_VERSION}" ] && [ -r "/etc/os-release" ]; then
+        LOCAL_NVM_OS_VERSION="$(command head -n 1 /etc/issue | command sed 's/\\.//g')"
+        if [ -z "${LOCAL_NVM_OS_VERSION}" ] && [ -r "/etc/os-release" ]; then
           # shellcheck disable=SC1091
-          OS_VERSION="$(. /etc/os-release && echo "${NAME}" "${VERSION}")"
+          LOCAL_NVM_OS_VERSION="$(. /etc/os-release && echo "${NAME}" "${VERSION}")"
         fi
       fi
-      if [ -n "${OS_VERSION}" ]; then
-        nvm_err "OS version: ${OS_VERSION}"
+      if [ -n "${LOCAL_NVM_OS_VERSION}" ]; then
+        nvm_err "OS version: ${LOCAL_NVM_OS_VERSION}"
       fi
       if nvm_has "curl"; then
         nvm_err "curl: $(nvm_command_info curl), $(command curl -V | command head -n 1)"
@@ -2987,49 +2989,51 @@ nvm() {
         nvm_err "wget: not found"
       fi
 
-      local TEST_TOOLS ADD_TEST_TOOLS
-      TEST_TOOLS="git grep awk"
-      ADD_TEST_TOOLS="sed cut basename rm mkdir xargs"
+      local LOCAL_NVM_TEST_TOOLS
+      local LOCAL_NVM_ADD_TEST_TOOLS
+      LOCAL_NVM_TEST_TOOLS="git grep awk"
+      LOCAL_NVM_ADD_TEST_TOOLS="sed cut basename rm mkdir xargs"
       if [ "darwin" != "$(nvm_get_os)" ] && [ "freebsd" != "$(nvm_get_os)" ]; then
-        TEST_TOOLS="${TEST_TOOLS} ${ADD_TEST_TOOLS}"
+        LOCAL_NVM_TEST_TOOLS="${LOCAL_NVM_TEST_TOOLS} ${LOCAL_NVM_ADD_TEST_TOOLS}"
       else
-        for tool in ${ADD_TEST_TOOLS} ; do
-          if nvm_has "${tool}"; then
-            nvm_err "${tool}: $(nvm_command_info "${tool}")"
+        for LOCAL_NVM_TOOL in ${LOCAL_NVM_ADD_TEST_TOOLS} ; do
+          if nvm_has "${LOCAL_NVM_TOOL}"; then
+            nvm_err "${LOCAL_NVM_TOOL}: $(nvm_command_info "${LOCAL_NVM_TOOL}")"
           else
-            nvm_err "${tool}: not found"
+            nvm_err "${LOCAL_NVM_TOOL}: not found"
           fi
         done
       fi
-      for tool in ${TEST_TOOLS} ; do
-        local NVM_TOOL_VERSION
-        if nvm_has "${tool}"; then
-          if command ls -l "$(nvm_command_info "${tool}" | command awk '{print $1}')" | command grep -q busybox; then
-            NVM_TOOL_VERSION="$(command "${tool}" --help 2>&1 | command head -n 1)"
+      for LOCAL_NVM_TOOL in ${LOCAL_NVM_TEST_TOOLS} ; do
+        local LOCAL_NVM_TOOL_VERSION
+        if nvm_has "${LOCAL_NVM_TOOL}"; then
+          if command ls -l "$(nvm_command_info "${LOCAL_NVM_TOOL}" | command awk '{print $1}')" | command grep -q busybox; then
+            LOCAL_NVM_TOOL_VERSION="$(command "${LOCAL_NVM_TOOL}" --help 2>&1 | command head -n 1)"
           else
-            NVM_TOOL_VERSION="$(command "${tool}" --version 2>&1 | command head -n 1)"
+            LOCAL_NVM_TOOL_VERSION="$(command "${LOCAL_NVM_TOOL}" --version 2>&1 | command head -n 1)"
           fi
-          nvm_err "${tool}: $(nvm_command_info "${tool}"), ${NVM_TOOL_VERSION}"
+          nvm_err "${LOCAL_NVM_TOOL}: $(nvm_command_info "${LOCAL_NVM_TOOL}"), ${LOCAL_NVM_TOOL_VERSION}"
         else
-          nvm_err "${tool}: not found"
+          nvm_err "${LOCAL_NVM_TOOL}: not found"
         fi
-        unset NVM_TOOL_VERSION
+        unset LOCAL_NVM_TOOL_VERSION
       done
-      unset TEST_TOOLS ADD_TEST_TOOLS
+      unset LOCAL_NVM_TEST_TOOLS
+      unset LOCAL_NVM_ADD_TEST_TOOLS
 
-      local NVM_DEBUG_OUTPUT
+      local LOCAL_NVM_DEBUG_OUTPUT
       for NVM_DEBUG_COMMAND in 'nvm current' 'which node' 'which iojs' 'which npm' 'npm config get prefix' 'npm root -g'; do
-        NVM_DEBUG_OUTPUT="$(${NVM_DEBUG_COMMAND} 2>&1)"
-        nvm_err "${NVM_DEBUG_COMMAND}: $(nvm_sanitize_path "${NVM_DEBUG_OUTPUT}")"
+        LOCAL_NVM_DEBUG_OUTPUT="$(${NVM_DEBUG_COMMAND} 2>&1)"
+        nvm_err "${NVM_DEBUG_COMMAND}: $(nvm_sanitize_path "${LOCAL_NVM_DEBUG_OUTPUT}")"
       done
       return 42
     ;;
 
     "install" | "i")
-      local version_not_provided
-      version_not_provided=0
-      local NVM_OS
-      NVM_OS="$(nvm_get_os)"
+      local LOCAL_NVM_VERSION_NOT_PROVIDED
+      LOCAL_NVM_VERSION_NOT_PROVIDED=0
+      local LOCAL_NVM_OS
+      LOCAL_NVM_OS="$(nvm_get_os)"
 
       if ! nvm_has "curl" && ! nvm_has "wget"; then
         nvm_err 'nvm needs curl or wget to proceed.'
@@ -3037,24 +3041,24 @@ nvm() {
       fi
 
       if [ $# -lt 1 ]; then
-        version_not_provided=1
+        LOCAL_NVM_VERSION_NOT_PROVIDED=1
       fi
 
-      local nobinary
-      local nosource
-      local noprogress
-      nobinary=0
-      noprogress=0
-      nosource=0
-      local LTS
-      local ALIAS
-      local NVM_UPGRADE_NPM
-      NVM_UPGRADE_NPM=0
+      local LOCAL_NVM_NOBINARY
+      local LOCAL_NVM_NOSOURCE
+      local LOCAL_NVM_NOPROGRESS
+      LOCAL_NVM_NOBINARY=0
+      LOCAL_NVM_NOPROGRESS=0
+      LOCAL_NVM_NOSOURCE=0
+      local LOCAL_NVM_LTS
+      local LOCAL_NVM_ALIAS
+      local LOCAL_NVM_UPGRADE_NPM
+      LOCAL_NVM_UPGRADE_NPM=0
 
-      local PROVIDED_REINSTALL_PACKAGES_FROM
-      local REINSTALL_PACKAGES_FROM
-      local SKIP_DEFAULT_PACKAGES
-      local DEFAULT_PACKAGES
+      local LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM
+      local LOCAL_NVM_REINSTALL_PACKAGES_FROM
+      local LOCAL_NVM_SKIP_DEFAULT_PACKAGES
+      local LOCAL_NVM_DEFAULT_PACKAGES
 
       while [ $# -ne 0 ]; do
         case "$1" in
@@ -3064,16 +3068,16 @@ nvm() {
           ;;
           -s)
             shift # consume "-s"
-            nobinary=1
-            if [ $nosource -eq 1 ]; then
+            LOCAL_NVM_NOBINARY=1
+            if [ ${LOCAL_NVM_NOSOURCE} -eq 1 ]; then
                 nvm err '-s and -b cannot be set together since they would skip install from both binary and source'
                 return 6
             fi
           ;;
           -b)
             shift # consume "-b"
-            nosource=1
-            if [ $nobinary -eq 1 ]; then
+            LOCAL_NVM_NOSOURCE=1
+            if [ ${LOCAL_NVM_NOBINARY} -eq 1 ]; then
                 nvm err '-s and -b cannot be set together since they would skip install from both binary and source'
                 return 6
             fi
@@ -3084,61 +3088,61 @@ nvm() {
             shift # consume job count
           ;;
           --no-progress)
-            noprogress=1
+            LOCAL_NVM_NOPROGRESS=1
             shift
           ;;
           --lts)
-            LTS='*'
+            LOCAL_NVM_LTS='*'
             shift
           ;;
           --lts=*)
-            LTS="${1##--lts=}"
+            LOCAL_NVM_LTS="${1##--lts=}"
             shift
           ;;
           --latest-npm)
-            NVM_UPGRADE_NPM=1
+            LOCAL_NVM_UPGRADE_NPM=1
             shift
           ;;
           --default)
-            if [ -n "${ALIAS-}" ]; then
+            if [ -n "${LOCAL_NVM_ALIAS-}" ]; then
               nvm_err '--default and --alias are mutually exclusive, and may not be provided more than once'
               return 6
             fi
-            ALIAS='default'
+            LOCAL_NVM_ALIAS='default'
             shift
           ;;
           --alias=*)
-            if [ -n "${ALIAS-}" ]; then
+            if [ -n "${LOCAL_NVM_ALIAS-}" ]; then
               nvm_err '--default and --alias are mutually exclusive, and may not be provided more than once'
               return 6
             fi
-            ALIAS="${1##--alias=}"
+            LOCAL_NVM_ALIAS="${1##--alias=}"
             shift
           ;;
           --reinstall-packages-from=*)
-            if [ -n "${PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
+            if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
               nvm_err '--reinstall-packages-from may not be provided more than once'
               return 6
             fi
-            PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 27-)"
-            if [ -z "${PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
+            LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 27-)"
+            if [ -z "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
               nvm_err 'If --reinstall-packages-from is provided, it must point to an installed version of node.'
               return 6
             fi
-            REINSTALL_PACKAGES_FROM="$(nvm_version "${PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
+            LOCAL_NVM_REINSTALL_PACKAGES_FROM="$(nvm_version "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
             shift
           ;;
           --copy-packages-from=*)
-            if [ -n "${PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
+            if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
               nvm_err '--reinstall-packages-from may not be provided more than once, or combined with `--copy-packages-from`'
               return 6
             fi
-            PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 22-)"
-            if [ -z "${PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
+            LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 22-)"
+            if [ -z "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
               nvm_err 'If --copy-packages-from is provided, it must point to an installed version of node.'
               return 6
             fi
-            REINSTALL_PACKAGES_FROM="$(nvm_version "${PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
+            LOCAL_NVM_REINSTALL_PACKAGES_FROM="$(nvm_version "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
             shift
           ;;
           --reinstall-packages-from | --copy-packages-from)
@@ -3146,7 +3150,7 @@ nvm() {
             return 6
           ;;
           --skip-default-packages)
-            SKIP_DEFAULT_PACKAGES=true
+            LOCAL_NVM_SKIP_DEFAULT_PACKAGES=true
             shift
           ;;
           *)
@@ -3155,236 +3159,236 @@ nvm() {
         esac
       done
 
-      local provided_version
-      provided_version="${1-}"
+      local LOCAL_NVM_PROVIDED_VERSION
+      LOCAL_NVM_PROVIDED_VERSION="${1-}"
 
-      if [ -z "${provided_version}" ]; then
-        if [ "_${LTS-}" = '_*' ]; then
+      if [ -z "${LOCAL_NVM_PROVIDED_VERSION}" ]; then
+        if [ "_${LOCAL_NVM_LTS-}" = '_*' ]; then
           nvm_echo 'Installing latest LTS version.'
           if [ $# -gt 0 ]; then
             shift
           fi
-        elif [ "_${LTS-}" != '_' ]; then
-          nvm_echo "Installing with latest version of LTS line: ${LTS}"
+        elif [ "_${LOCAL_NVM_LTS-}" != '_' ]; then
+          nvm_echo "Installing with latest version of LTS line: ${LOCAL_NVM_LTS}"
           if [ $# -gt 0 ]; then
             shift
           fi
         else
           nvm_rc_version
-          if [ $version_not_provided -eq 1 ] && [ -z "${NVM_RC_VERSION}" ]; then
+          if [ ${LOCAL_NVM_VERSION_NOT_PROVIDED} -eq 1 ] && [ -z "${NVM_RC_VERSION}" ]; then
             unset NVM_RC_VERSION
             >&2 nvm --help
             return 127
           fi
-          provided_version="${NVM_RC_VERSION}"
+          LOCAL_NVM_PROVIDED_VERSION="${NVM_RC_VERSION}"
           unset NVM_RC_VERSION
         fi
       elif [ $# -gt 0 ]; then
         shift
       fi
 
-      case "${provided_version}" in
+      case "${LOCAL_NVM_PROVIDED_VERSION}" in
         'lts/*')
-          LTS='*'
-          provided_version=''
+          LOCAL_NVM_LTS='*'
+          LOCAL_NVM_PROVIDED_VERSION=''
         ;;
         lts/*)
-          LTS="${provided_version##lts/}"
-          provided_version=''
+          LOCAL_NVM_LTS="${LOCAL_NVM_PROVIDED_VERSION##lts/}"
+          LOCAL_NVM_PROVIDED_VERSION=''
         ;;
       esac
 
-      VERSION="$(NVM_VERSION_ONLY=true NVM_LTS="${LTS-}" nvm_remote_version "${provided_version}")"
+      LOCAL_NVM_VERSION="$(NVM_VERSION_ONLY=true NVM_LTS="${LOCAL_NVM_LTS-}" nvm_remote_version "${LOCAL_NVM_PROVIDED_VERSION}")"
 
-      if [ "${VERSION}" = 'N/A' ]; then
-        local LTS_MSG
-        local REMOTE_CMD
-        if [ "${LTS-}" = '*' ]; then
-          LTS_MSG='(with LTS filter) '
-          REMOTE_CMD='nvm ls-remote --lts'
-        elif [ -n "${LTS-}" ]; then
-          LTS_MSG="(with LTS filter '${LTS}') "
-          REMOTE_CMD="nvm ls-remote --lts=${LTS}"
+      if [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
+        local LOCAL_NVM_LTS_MSG
+        local LOCAL_NVM_REMOTE_CMD
+        if [ "${LOCAL_NVM_LTS-}" = '*' ]; then
+          LOCAL_NVM_LTS_MSG='(with LTS filter) '
+          LOCAL_NVM_REMOTE_CMD='nvm ls-remote --lts'
+        elif [ -n "${LOCAL_NVM_LTS-}" ]; then
+          LOCAL_NVM_LTS_MSG="(with LTS filter '${LOCAL_NVM_LTS}') "
+          LOCAL_NVM_REMOTE_CMD="nvm ls-remote --lts=${LOCAL_NVM_LTS}"
         else
-          REMOTE_CMD='nvm ls-remote'
+          LOCAL_NVM_REMOTE_CMD='nvm ls-remote'
         fi
-        nvm_err "Version '${provided_version}' ${LTS_MSG-}not found - try \`${REMOTE_CMD}\` to browse available versions."
+        nvm_err "Version '${LOCAL_NVM_PROVIDED_VERSION}' ${LOCAL_NVM_LTS_MSG-}not found - try \`${LOCAL_NVM_REMOTE_CMD}\` to browse available versions."
         return 3
       fi
 
-      ADDITIONAL_PARAMETERS=''
+      LOCAL_NVM_ADDITIONAL_PARAMETERS=''
 
       while [ $# -ne 0 ]; do
         case "$1" in
           --reinstall-packages-from=*)
-            if [ -n "${PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
+            if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
               nvm_err '--reinstall-packages-from may not be provided more than once'
               return 6
             fi
-            PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 27-)"
-            if [ -z "${PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
+            LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 27-)"
+            if [ -z "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
               nvm_err 'If --reinstall-packages-from is provided, it must point to an installed version of node.'
               return 6
             fi
-            REINSTALL_PACKAGES_FROM="$(nvm_version "${PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
+            LOCAL_NVM_REINSTALL_PACKAGES_FROM="$(nvm_version "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
           ;;
           --copy-packages-from=*)
-            if [ -n "${PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
+            if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
               nvm_err '--reinstall-packages-from may not be provided more than once, or combined with `--copy-packages-from`'
               return 6
             fi
-            PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 22-)"
-            if [ -z "${PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
+            LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 22-)"
+            if [ -z "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
               nvm_err 'If --copy-packages-from is provided, it must point to an installed version of node.'
               return 6
             fi
-            REINSTALL_PACKAGES_FROM="$(nvm_version "${PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
+            LOCAL_NVM_REINSTALL_PACKAGES_FROM="$(nvm_version "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
           ;;
           --reinstall-packages-from | --copy-packages-from)
             nvm_err "If ${1} is provided, it must point to an installed version of node using \`=\`."
             return 6
           ;;
           --skip-default-packages)
-            SKIP_DEFAULT_PACKAGES=true
+            LOCAL_NVM_SKIP_DEFAULT_PACKAGES=true
           ;;
           *)
-            ADDITIONAL_PARAMETERS="${ADDITIONAL_PARAMETERS} $1"
+            LOCAL_NVM_ADDITIONAL_PARAMETERS="${LOCAL_NVM_ADDITIONAL_PARAMETERS} $1"
           ;;
         esac
         shift
       done
 
-      if [ -z "${SKIP_DEFAULT_PACKAGES-}" ]; then
-        DEFAULT_PACKAGES="$(nvm_get_default_packages)"
-        EXIT_CODE=$?
-        if [ $EXIT_CODE -ne 0 ]; then
-          return $EXIT_CODE
+      local LOCAL_NVM_EXIT_CODE
+      if [ -z "${LOCAL_NVM_SKIP_DEFAULT_PACKAGES-}" ]; then
+        LOCAL_NVM_DEFAULT_PACKAGES="$(nvm_get_default_packages)"
+        LOCAL_NVM_EXIT_CODE=$?
+        if [ ${LOCAL_NVM_EXIT_CODE} -ne 0 ]; then
+          return ${LOCAL_NVM_EXIT_CODE}
         fi
       fi
 
-      if [ -n "${PROVIDED_REINSTALL_PACKAGES_FROM-}" ] && [ "$(nvm_ensure_version_prefix "${PROVIDED_REINSTALL_PACKAGES_FROM}")" = "${VERSION}" ]; then
+      if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ] && [ "$(nvm_ensure_version_prefix "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" = "${LOCAL_NVM_VERSION}" ]; then
         nvm_err "You can't reinstall global packages from the same version of node you're installing."
         return 4
-      elif [ "${REINSTALL_PACKAGES_FROM-}" = 'N/A' ]; then
+      elif [ "${LOCAL_NVM_REINSTALL_PACKAGES_FROM-}" = 'N/A' ]; then
         nvm_err "If --reinstall-packages-from is provided, it must point to an installed version of node."
         return 5
       fi
 
-      local FLAVOR
-      if nvm_is_iojs_version "${VERSION}"; then
-        FLAVOR="$(nvm_iojs_prefix)"
+      local LOCAL_NVM_FLAVOR
+      if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
+        LOCAL_NVM_FLAVOR="$(nvm_iojs_prefix)"
       else
-        FLAVOR="$(nvm_node_prefix)"
+        LOCAL_NVM_FLAVOR="$(nvm_node_prefix)"
       fi
 
-      if nvm_is_version_installed "${VERSION}"; then
-        nvm_err "${VERSION} is already installed."
-        if nvm use "${VERSION}"; then
-          if [ "${NVM_UPGRADE_NPM}" = 1 ]; then
+      if nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
+        nvm_err "${LOCAL_NVM_VERSION} is already installed."
+        if nvm use "${LOCAL_NVM_VERSION}"; then
+          if [ "${LOCAL_NVM_UPGRADE_NPM}" = 1 ]; then
             nvm install-latest-npm
           fi
-          if [ -z "${SKIP_DEFAULT_PACKAGES-}" ] && [ -n "${DEFAULT_PACKAGES-}" ]; then
-            nvm_install_default_packages "${DEFAULT_PACKAGES}"
+          if [ -z "${LOCAL_NVM_SKIP_DEFAULT_PACKAGES-}" ] && [ -n "${LOCAL_NVM_DEFAULT_PACKAGES-}" ]; then
+            nvm_install_default_packages "${LOCAL_NVM_DEFAULT_PACKAGES}"
           fi
-          if [ -n "${REINSTALL_PACKAGES_FROM-}" ] && [ "_${REINSTALL_PACKAGES_FROM}" != "_N/A" ]; then
-            nvm reinstall-packages "${REINSTALL_PACKAGES_FROM}"
+          if [ -n "${LOCAL_NVM_REINSTALL_PACKAGES_FROM-}" ] && [ "_${LOCAL_NVM_REINSTALL_PACKAGES_FROM}" != "_N/A" ]; then
+            nvm reinstall-packages "${LOCAL_NVM_REINSTALL_PACKAGES_FROM}"
           fi
         fi
-        if [ -n "${LTS-}" ]; then
-          LTS="$(echo "${LTS}" | tr '[:upper:]' '[:lower:]')"
-          nvm_ensure_default_set "lts/${LTS}"
+        if [ -n "${LOCAL_NVM_LTS-}" ]; then
+          LOCAL_NVM_LTS="$(echo "${LOCAL_NVM_LTS}" | tr '[:upper:]' '[:lower:]')"
+          nvm_ensure_default_set "lts/${LOCAL_NVM_LTS}"
         else
-          nvm_ensure_default_set "${provided_version}"
+          nvm_ensure_default_set "${LOCAL_NVM_PROVIDED_VERSION}"
         fi
 
-        if [ -n "${ALIAS-}" ]; then
-          nvm alias "${ALIAS}" "${provided_version}"
+        if [ -n "${LOCAL_NVM_ALIAS-}" ]; then
+          nvm alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_PROVIDED_VERSION}"
         fi
 
         return $?
       fi
 
-      local EXIT_CODE
-      EXIT_CODE=-1
+      LOCAL_NVM_EXIT_CODE=-1
       if [ -n "${NVM_INSTALL_THIRD_PARTY_HOOK-}" ]; then
-        nvm_err '** $NVM_INSTALL_THIRD_PARTY_HOOK env var set; dispatching to third-party installation method **'
-        local NVM_METHOD_PREFERENCE
-        NVM_METHOD_PREFERENCE='binary'
-        if [ $nobinary -eq 1 ]; then
-          NVM_METHOD_PREFERENCE='source'
+        nvm_err '** ${NVM_INSTALL_THIRD_PARTY_HOOK} env var set; dispatching to third-party installation method **'
+        local LOCAL_NVM_METHOD_PREFERENCE
+        LOCAL_NVM_METHOD_PREFERENCE='binary'
+        if [ ${LOCAL_NVM_NOBINARY} -eq 1 ]; then
+          LOCAL_NVM_METHOD_PREFERENCE='source'
         fi
-        local VERSION_PATH
-        VERSION_PATH="$(nvm_version_path "${VERSION}")"
-        "${NVM_INSTALL_THIRD_PARTY_HOOK}" "${VERSION}" "${FLAVOR}" std "${NVM_METHOD_PREFERENCE}" "${VERSION_PATH}" || {
-          EXIT_CODE=$?
-          nvm_err '*** Third-party $NVM_INSTALL_THIRD_PARTY_HOOK env var failed to install! ***'
-          return $EXIT_CODE
+        local LOCAL_NVM_VERSION_PATH
+        LOCAL_NVM_VERSION_PATH="$(nvm_version_path "${LOCAL_NVM_VERSION}")"
+        "${NVM_INSTALL_THIRD_PARTY_HOOK}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_FLAVOR}" std "${LOCAL_NVM_METHOD_PREFERENCE}" "${LOCAL_NVM_VERSION_PATH}" || {
+          LOCAL_NVM_EXIT_CODE=$?
+          nvm_err '*** Third-party ${NVM_INSTALL_THIRD_PARTY_HOOK} env var failed to install! ***'
+          return ${LOCAL_NVM_EXIT_CODE}
         }
-        if ! nvm_is_version_installed "${VERSION}"; then
-          nvm_err '*** Third-party $NVM_INSTALL_THIRD_PARTY_HOOK env var claimed to succeed, but failed to install! ***'
+        if ! nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
+          nvm_err '*** Third-party ${NVM_INSTALL_THIRD_PARTY_HOOK} env var claimed to succeed, but failed to install! ***'
           return 33
         fi
-        EXIT_CODE=0
+        LOCAL_NVM_EXIT_CODE=0
       else
 
-        if [ "_${NVM_OS}" = "_freebsd" ]; then
+        if [ "_${LOCAL_NVM_OS}" = "_freebsd" ]; then
           # node.js and io.js do not have a FreeBSD binary
-          nobinary=1
+          LOCAL_NVM_NOBINARY=1
           nvm_err "Currently, there is no binary for FreeBSD"
-        elif [ "_$NVM_OS" = "_openbsd" ]; then
+        elif [ "_${LOCAL_NVM_OS}" = "_openbsd" ]; then
           # node.js and io.js do not have a OpenBSD binary
-          nobinary=1
+          LOCAL_NVM_NOBINARY=1
           nvm_err "Currently, there is no binary for OpenBSD"
-        elif [ "_${NVM_OS}" = "_sunos" ]; then
+        elif [ "_${LOCAL_NVM_OS}" = "_sunos" ]; then
           # Not all node/io.js versions have a Solaris binary
-          if ! nvm_has_solaris_binary "${VERSION}"; then
-            nobinary=1
-            nvm_err "Currently, there is no binary of version ${VERSION} for SunOS"
+          if ! nvm_has_solaris_binary "${LOCAL_NVM_VERSION}"; then
+            LOCAL_NVM_NOBINARY=1
+            nvm_err "Currently, there is no binary of version ${LOCAL_NVM_VERSION} for SunOS"
           fi
         fi
 
-        # skip binary install if "nobinary" option specified.
-        if [ $nobinary -ne 1 ] && nvm_binary_available "${VERSION}"; then
-          NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${noprogress}}" nvm_install_binary "${FLAVOR}" std "${VERSION}" "${nosource}"
-          EXIT_CODE=$?
+        # skip binary install if "LOCAL_NVM_NOBINARY" option specified.
+        if [ ${LOCAL_NVM_NOBINARY} -ne 1 ] && nvm_binary_available "${LOCAL_NVM_VERSION}"; then
+          NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${LOCAL_NVM_NOPROGRESS}}" nvm_install_binary "${LOCAL_NVM_FLAVOR}" std "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_NOSOURCE}"
+          LOCAL_NVM_EXIT_CODE=$?
         fi
-        if [ $EXIT_CODE -ne 0 ]; then
-          if [ -z "${NVM_MAKE_JOBS-}" ]; then
+        if [ ${LOCAL_NVM_EXIT_CODE} -ne 0 ]; then
+          if [ -z "${LOCAL_NVM_MAKE_JOBS-}" ]; then
             nvm_get_make_jobs
           fi
 
-          if [ "_${NVM_OS}" = "_win" ]; then
+          if [ "_${LOCAL_NVM_OS}" = "_win" ]; then
             nvm_err 'Installing from source on non-WSL Windows is not supported'
-            EXIT_CODE=87
+            LOCAL_NVM_EXIT_CODE=87
           else
-            NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${noprogress}}" nvm_install_source "${FLAVOR}" std "${VERSION}" "${NVM_MAKE_JOBS}" "${ADDITIONAL_PARAMETERS}"
-            EXIT_CODE=$?
+            NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${LOCAL_NVM_NOPROGRESS}}" nvm_install_source "${LOCAL_NVM_FLAVOR}" std "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_MAKE_JOBS}" "${LOCAL_NVM_ADDITIONAL_PARAMETERS}"
+            LOCAL_NVM_EXIT_CODE=$?
           fi
         fi
 
       fi
 
-      if [ $EXIT_CODE -eq 0 ] && nvm_use_if_needed "${VERSION}" && nvm_install_npm_if_needed "${VERSION}"; then
-        if [ -n "${LTS-}" ]; then
-          nvm_ensure_default_set "lts/${LTS}"
+      if [ ${LOCAL_NVM_EXIT_CODE} -eq 0 ] && nvm_use_if_needed "${LOCAL_NVM_VERSION}" && nvm_install_npm_if_needed "${LOCAL_NVM_VERSION}"; then
+        if [ -n "${LOCAL_NVM_LTS-}" ]; then
+          nvm_ensure_default_set "lts/${LOCAL_NVM_LTS}"
         else
-          nvm_ensure_default_set "${provided_version}"
+          nvm_ensure_default_set "${LOCAL_NVM_PROVIDED_VERSION}"
         fi
-        if [ "${NVM_UPGRADE_NPM}" = 1 ]; then
+        if [ "${LOCAL_NVM_UPGRADE_NPM}" = 1 ]; then
           nvm install-latest-npm
-          EXIT_CODE=$?
+          LOCAL_NVM_EXIT_CODE=$?
         fi
-        if [ -z "${SKIP_DEFAULT_PACKAGES-}" ] && [ -n "${DEFAULT_PACKAGES-}" ]; then
-          nvm_install_default_packages "${DEFAULT_PACKAGES}"
+        if [ -z "${LOCAL_NVM_SKIP_DEFAULT_PACKAGES-}" ] && [ -n "${LOCAL_NVM_DEFAULT_PACKAGES-}" ]; then
+          nvm_install_default_packages "${LOCAL_NVM_DEFAULT_PACKAGES}"
         fi
-        if [ -n "${REINSTALL_PACKAGES_FROM-}" ] && [ "_${REINSTALL_PACKAGES_FROM}" != "_N/A" ]; then
-          nvm reinstall-packages "${REINSTALL_PACKAGES_FROM}"
-          EXIT_CODE=$?
+        if [ -n "${LOCAL_NVM_REINSTALL_PACKAGES_FROM-}" ] && [ "_${LOCAL_NVM_REINSTALL_PACKAGES_FROM}" != "_N/A" ]; then
+          nvm reinstall-packages "${LOCAL_NVM_REINSTALL_PACKAGES_FROM}"
+          LOCAL_NVM_EXIT_CODE=$?
         fi
       else
-        EXIT_CODE=$?
+        LOCAL_NVM_EXIT_CODE=$?
       fi
-      return $EXIT_CODE
+      return ${LOCAL_NVM_EXIT_CODE}
     ;;
     "uninstall")
       if [ $# -ne 1 ]; then
@@ -3392,122 +3396,122 @@ nvm() {
         return 127
       fi
 
-      local PATTERN
-      PATTERN="${1-}"
-      case "${PATTERN-}" in
+      local LOCAL_NVM_PATTERN
+      LOCAL_NVM_PATTERN="${1-}"
+      case "${LOCAL_NVM_PATTERN-}" in
         --) ;;
         --lts | 'lts/*')
-          VERSION="$(nvm_match_version "lts/*")"
+          LOCAL_NVM_VERSION="$(nvm_match_version "lts/*")"
         ;;
         lts/*)
-          VERSION="$(nvm_match_version "lts/${PATTERN##lts/}")"
+          LOCAL_NVM_VERSION="$(nvm_match_version "lts/${LOCAL_NVM_PATTERN##lts/}")"
         ;;
         --lts=*)
-          VERSION="$(nvm_match_version "lts/${PATTERN##--lts=}")"
+          LOCAL_NVM_VERSION="$(nvm_match_version "lts/${LOCAL_NVM_PATTERN##--lts=}")"
         ;;
         *)
-          VERSION="$(nvm_version "${PATTERN}")"
+          LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PATTERN}")"
         ;;
       esac
 
-      if [ "_${VERSION}" = "_$(nvm_ls_current)" ]; then
-        if nvm_is_iojs_version "${VERSION}"; then
-          nvm_err "nvm: Cannot uninstall currently-active io.js version, ${VERSION} (inferred from ${PATTERN})."
+      if [ "_${LOCAL_NVM_VERSION}" = "_$(nvm_ls_current)" ]; then
+        if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
+          nvm_err "nvm: Cannot uninstall currently-active io.js version, ${LOCAL_NVM_VERSION} (inferred from ${LOCAL_NVM_PATTERN})."
         else
-          nvm_err "nvm: Cannot uninstall currently-active node version, ${VERSION} (inferred from ${PATTERN})."
+          nvm_err "nvm: Cannot uninstall currently-active node version, ${LOCAL_NVM_VERSION} (inferred from ${LOCAL_NVM_PATTERN})."
         fi
         return 1
       fi
 
-      if ! nvm_is_version_installed "${VERSION}"; then
-        nvm_err "${VERSION} version is not installed..."
+      if ! nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
+        nvm_err "${LOCAL_NVM_VERSION} version is not installed..."
         return
       fi
 
-      local SLUG_BINARY
-      local SLUG_SOURCE
-      if nvm_is_iojs_version "${VERSION}"; then
-        SLUG_BINARY="$(nvm_get_download_slug iojs binary std "${VERSION}")"
-        SLUG_SOURCE="$(nvm_get_download_slug iojs source std "${VERSION}")"
+      local LOCAL_NVM_SLUG_BINARY
+      local LOCAL_NVM_SLUG_SOURCE
+      if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
+        LOCAL_NVM_SLUG_BINARY="$(nvm_get_download_slug iojs binary std "${LOCAL_NVM_VERSION}")"
+        LOCAL_NVM_SLUG_SOURCE="$(nvm_get_download_slug iojs source std "${LOCAL_NVM_VERSION}")"
       else
-        SLUG_BINARY="$(nvm_get_download_slug node binary std "${VERSION}")"
-        SLUG_SOURCE="$(nvm_get_download_slug node source std "${VERSION}")"
+        LOCAL_NVM_SLUG_BINARY="$(nvm_get_download_slug node binary std "${LOCAL_NVM_VERSION}")"
+        LOCAL_NVM_SLUG_SOURCE="$(nvm_get_download_slug node source std "${LOCAL_NVM_VERSION}")"
       fi
 
-      local NVM_SUCCESS_MSG
-      if nvm_is_iojs_version "${VERSION}"; then
-        NVM_SUCCESS_MSG="Uninstalled io.js $(nvm_strip_iojs_prefix "${VERSION}")"
+      local LOCAL_NVM_SUCCESS_MSG
+      if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
+        LOCAL_NVM_SUCCESS_MSG="Uninstalled io.js $(nvm_strip_iojs_prefix "${LOCAL_NVM_VERSION}")"
       else
-        NVM_SUCCESS_MSG="Uninstalled node ${VERSION}"
+        LOCAL_NVM_SUCCESS_MSG="Uninstalled node ${LOCAL_NVM_VERSION}"
       fi
 
-      local VERSION_PATH
-      VERSION_PATH="$(nvm_version_path "${VERSION}")"
-      if ! nvm_check_file_permissions "${VERSION_PATH}"; then
+      local LOCAL_NVM_VERSION_PATH
+      LOCAL_NVM_VERSION_PATH="$(nvm_version_path "${LOCAL_NVM_VERSION}")"
+      if ! nvm_check_file_permissions "${LOCAL_NVM_VERSION_PATH}"; then
         nvm_err 'Cannot uninstall, incorrect permissions on installation folder.'
         nvm_err 'This is usually caused by running `npm install -g` as root. Run the following commands as root to fix the permissions and then try again.'
         nvm_err
-        nvm_err "  chown -R $(whoami) \"$(nvm_sanitize_path "${VERSION_PATH}")\""
-        nvm_err "  chmod -R u+w \"$(nvm_sanitize_path "${VERSION_PATH}")\""
+        nvm_err "  chown -R $(whoami) \"$(nvm_sanitize_path "${LOCAL_NVM_VERSION_PATH}")\""
+        nvm_err "  chmod -R u+w \"$(nvm_sanitize_path "${LOCAL_NVM_VERSION_PATH}")\""
         return 1
       fi
 
       # Delete all files related to target version.
-      local CACHE_DIR
-      CACHE_DIR="$(nvm_cache_dir)"
+      local LOCAL_NVM_CACHE_DIR
+      LOCAL_NVM_CACHE_DIR="$(nvm_cache_dir)"
       command rm -rf \
-        "${CACHE_DIR}/bin/${SLUG_BINARY}/files" \
-        "${CACHE_DIR}/src/${SLUG_SOURCE}/files" \
-        "${VERSION_PATH}" 2>/dev/null
-      nvm_echo "${NVM_SUCCESS_MSG}"
+        "${LOCAL_NVM_CACHE_DIR}/bin/${LOCAL_NVM_SLUG_BINARY}/files" \
+        "${LOCAL_NVM_CACHE_DIR}/src/${LOCAL_NVM_SLUG_SOURCE}/files" \
+        "${LOCAL_NVM_VERSION_PATH}" 2>/dev/null
+      nvm_echo "${LOCAL_NVM_SUCCESS_MSG}"
 
       # rm any aliases that point to uninstalled version.
-      for ALIAS in $(nvm_grep -l "${VERSION}" "$(nvm_alias_path)/*" 2>/dev/null); do
-        nvm unalias "$(command basename "${ALIAS}")"
+      for LOCAL_NVM_FOR_ALIAS in $(nvm_grep -l "${LOCAL_NVM_VERSION}" "$(nvm_alias_path)/*" 2>/dev/null); do
+        nvm unalias "$(command basename "${LOCAL_NVM_FOR_ALIAS}")"
       done
     ;;
     "deactivate")
-      local NVM_SILENT
+      local LOCAL_NVM_SILENT
       while [ $# -ne 0 ]; do
         case "${1}" in
-          --silent) NVM_SILENT=1 ;;
+          --silent) LOCAL_NVM_SILENT=1 ;;
           --) ;;
         esac
         shift
       done
-      local NEWPATH
-      NEWPATH="$(nvm_strip_path "${PATH}" "/bin")"
-      if [ "_${PATH}" = "_${NEWPATH}" ]; then
-        if [ "${NVM_SILENT:-0}" -ne 1 ]; then
+      local LOCAL_NVM_NEWPATH
+      LOCAL_NVM_NEWPATH="$(nvm_strip_path "${PATH}" "/bin")"
+      if [ "_${PATH}" = "_${LOCAL_NVM_NEWPATH}" ]; then
+        if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
           nvm_err "Could not find ${NVM_DIR}/*/bin in \${PATH}"
         fi
       else
-        export PATH="${NEWPATH}"
+        export PATH="${LOCAL_NVM_NEWPATH}"
         hash -r
-        if [ "${NVM_SILENT:-0}" -ne 1 ]; then
+        if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
           nvm_echo "${NVM_DIR}/*/bin removed from \${PATH}"
         fi
       fi
 
       if [ -n "${MANPATH-}" ]; then
-        NEWPATH="$(nvm_strip_path "${MANPATH}" "/share/man")"
-        if [ "_${MANPATH}" = "_${NEWPATH}" ]; then
-          if [ "${NVM_SILENT:-0}" -ne 1 ]; then
+        LOCAL_NVM_NEWPATH="$(nvm_strip_path "${MANPATH}" "/share/man")"
+        if [ "_${MANPATH}" = "_${LOCAL_NVM_NEWPATH}" ]; then
+          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
             nvm_err "Could not find ${NVM_DIR}/*/share/man in \${MANPATH}"
           fi
         else
-          export MANPATH="${NEWPATH}"
-          if [ "${NVM_SILENT:-0}" -ne 1 ]; then
+          export MANPATH="${LOCAL_NVM_NEWPATH}"
+          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
             nvm_echo "${NVM_DIR}/*/share/man removed from \${MANPATH}"
           fi
         fi
       fi
 
       if [ -n "${NODE_PATH-}" ]; then
-        NEWPATH="$(nvm_strip_path "${NODE_PATH}" "/lib/node_modules")"
-        if [ "_${NODE_PATH}" != "_${NEWPATH}" ]; then
-          export NODE_PATH="${NEWPATH}"
-          if [ "${NVM_SILENT:-0}" -ne 1 ]; then
+        LOCAL_NVM_NEWPATH="$(nvm_strip_path "${NODE_PATH}" "/lib/node_modules")"
+        if [ "_${NODE_PATH}" != "_${LOCAL_NVM_NEWPATH}" ]; then
+          export NODE_PATH="${LOCAL_NVM_NEWPATH}"
+          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
             nvm_echo "${NVM_DIR}/*/lib/node_modules removed from \${NODE_PATH}"
           fi
         fi
@@ -3516,154 +3520,154 @@ nvm() {
       unset NVM_INC
     ;;
     "use")
-      local PROVIDED_VERSION
-      local NVM_SILENT
-      local NVM_SILENT_ARG
-      local NVM_DELETE_PREFIX
-      NVM_DELETE_PREFIX=0
-      local NVM_LTS
+      local LOCAL_NVM_PROVIDED_VERSION
+      local LOCAL_NVM_SILENT
+      local LOCAL_NVM_SILENT_ARG
+      local LOCAL_NVM_DELETE_PREFIX
+      LOCAL_NVM_DELETE_PREFIX=0
+      local LOCAL_NVM_LTS
 
       while [ $# -ne 0 ]; do
         case "$1" in
           --silent)
-            NVM_SILENT=1
-            NVM_SILENT_ARG='--silent'
+            LOCAL_NVM_SILENT=1
+            LOCAL_NVM_SILENT_ARG='--silent'
           ;;
-          --delete-prefix) NVM_DELETE_PREFIX=1 ;;
+          --delete-prefix) LOCAL_NVM_DELETE_PREFIX=1 ;;
           --) ;;
-          --lts) NVM_LTS='*' ;;
-          --lts=*) NVM_LTS="${1##--lts=}" ;;
+          --lts) LOCAL_NVM_LTS='*' ;;
+          --lts=*) LOCAL_NVM_LTS="${1##--lts=}" ;;
           --*) ;;
           *)
             if [ -n "${1-}" ]; then
-              PROVIDED_VERSION="$1"
+              LOCAL_NVM_PROVIDED_VERSION="$1"
             fi
           ;;
         esac
         shift
       done
 
-      if [ -n "${NVM_LTS-}" ]; then
-        VERSION="$(nvm_match_version "lts/${NVM_LTS:-*}")"
-      elif [ -z "${PROVIDED_VERSION-}" ]; then
-        NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version
+      if [ -n "${LOCAL_NVM_LTS-}" ]; then
+        LOCAL_NVM_VERSION="$(nvm_match_version "lts/${LOCAL_NVM_LTS:-*}")"
+      elif [ -z "${LOCAL_NVM_PROVIDED_VERSION-}" ]; then
+        LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version
         if [ -n "${NVM_RC_VERSION-}" ]; then
-          PROVIDED_VERSION="${NVM_RC_VERSION}"
-          VERSION="$(nvm_version "${PROVIDED_VERSION}")"
+          LOCAL_NVM_PROVIDED_VERSION="${NVM_RC_VERSION}"
+          LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")"
         fi
         unset NVM_RC_VERSION
-        if [ -z "${VERSION}" ]; then
+        if [ -z "${LOCAL_NVM_VERSION}" ]; then
           nvm_err 'Please see `nvm --help` or https://github.com/nvm-sh/nvm#nvmrc for more information.'
           return 127
         fi
       else
-        VERSION="$(nvm_match_version "${PROVIDED_VERSION}")"
+        LOCAL_NVM_VERSION="$(nvm_match_version "${LOCAL_NVM_PROVIDED_VERSION}")"
       fi
 
-      if [ -z "${VERSION}" ]; then
+      if [ -z "${LOCAL_NVM_VERSION}" ]; then
         >&2 nvm --help
         return 127
       fi
 
-      if [ "_${VERSION}" = '_system' ]; then
-        if nvm_has_system_node && nvm deactivate "${NVM_SILENT_ARG-}" >/dev/null 2>&1; then
-          if [ "${NVM_SILENT:-0}" -ne 1 ]; then
+      if [ "_${LOCAL_NVM_VERSION}" = '_system' ]; then
+        if nvm_has_system_node && nvm deactivate "${LOCAL_NVM_SILENT_ARG-}" >/dev/null 2>&1; then
+          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
             nvm_echo "Now using system version of node: $(node -v 2>/dev/null)$(nvm_print_npm_version)"
           fi
           return
-        elif nvm_has_system_iojs && nvm deactivate "${NVM_SILENT_ARG-}" >/dev/null 2>&1; then
-          if [ "${NVM_SILENT:-0}" -ne 1 ]; then
+        elif nvm_has_system_iojs && nvm deactivate "${LOCAL_NVM_SILENT_ARG-}" >/dev/null 2>&1; then
+          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
             nvm_echo "Now using system version of io.js: $(iojs --version 2>/dev/null)$(nvm_print_npm_version)"
           fi
           return
-        elif [ "${NVM_SILENT:-0}" -ne 1 ]; then
+        elif [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
           nvm_err 'System version of node not found.'
         fi
         return 127
-      elif [ "_${VERSION}" = "_∞" ]; then
-        if [ "${NVM_SILENT:-0}" -ne 1 ]; then
-          nvm_err "The alias \"${PROVIDED_VERSION}\" leads to an infinite loop. Aborting."
+      elif [ "_${LOCAL_NVM_VERSION}" = "_∞" ]; then
+        if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+          nvm_err "The alias \"${LOCAL_NVM_PROVIDED_VERSION}\" leads to an infinite loop. Aborting."
         fi
         return 8
       fi
-      if [ "${VERSION}" = 'N/A' ]; then
-        if [ "${NVM_SILENT:-0}" -ne 1 ]; then
-          nvm_err "N/A: version \"${PROVIDED_VERSION} -> ${VERSION}\" is not yet installed."
+      if [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
+        if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+          nvm_err "N/A: version \"${LOCAL_NVM_PROVIDED_VERSION} -> ${LOCAL_NVM_VERSION}\" is not yet installed."
           nvm_err ""
-          nvm_err "You need to run \"nvm install ${PROVIDED_VERSION}\" to install it before using it."
+          nvm_err "You need to run \"nvm install ${LOCAL_NVM_PROVIDED_VERSION}\" to install it before using it."
         fi
         return 3
       # This nvm_ensure_version_installed call can be a performance bottleneck
       # on shell startup. Perhaps we can optimize it away or make it faster.
-      elif ! nvm_ensure_version_installed "${VERSION}"; then
+      elif ! nvm_ensure_version_installed "${LOCAL_NVM_VERSION}"; then
         return $?
       fi
 
-      local NVM_VERSION_DIR
-      NVM_VERSION_DIR="$(nvm_version_path "${VERSION}")"
+      local LOCAL_NVM_VERSION_DIR
+      LOCAL_NVM_VERSION_DIR="$(nvm_version_path "${LOCAL_NVM_VERSION}")"
 
       # Change current version
-      PATH="$(nvm_change_path "${PATH}" "/bin" "${NVM_VERSION_DIR}")"
+      PATH="$(nvm_change_path "${PATH}" "/bin" "${LOCAL_NVM_VERSION_DIR}")"
       if nvm_has manpath; then
         if [ -z "${MANPATH-}" ]; then
           local MANPATH
           MANPATH=$(manpath)
         fi
         # Change current version
-        MANPATH="$(nvm_change_path "${MANPATH}" "/share/man" "${NVM_VERSION_DIR}")"
+        MANPATH="$(nvm_change_path "${MANPATH}" "/share/man" "${LOCAL_NVM_VERSION_DIR}")"
         export MANPATH
       fi
       export PATH
       hash -r
-      export NVM_BIN="${NVM_VERSION_DIR}/bin"
-      export NVM_INC="${NVM_VERSION_DIR}/include/node"
+      export NVM_BIN="${LOCAL_NVM_VERSION_DIR}/bin"
+      export NVM_INC="${LOCAL_NVM_VERSION_DIR}/include/node"
       if [ "${NVM_SYMLINK_CURRENT-}" = true ]; then
-        command rm -f "${NVM_DIR}/current" && ln -s "${NVM_VERSION_DIR}" "${NVM_DIR}/current"
+        command rm -f "${NVM_DIR}/current" && ln -s "${LOCAL_NVM_VERSION_DIR}" "${NVM_DIR}/current"
       fi
-      local NVM_USE_OUTPUT
-      NVM_USE_OUTPUT=''
-      if [ "${NVM_SILENT:-0}" -ne 1 ]; then
-        if nvm_is_iojs_version "${VERSION}"; then
-          NVM_USE_OUTPUT="Now using io.js $(nvm_strip_iojs_prefix "${VERSION}")$(nvm_print_npm_version)"
+      local LOCAL_NVM_USE_OUTPUT
+      LOCAL_NVM_USE_OUTPUT=''
+      if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+        if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
+          LOCAL_NVM_USE_OUTPUT="Now using io.js $(nvm_strip_iojs_prefix "${LOCAL_NVM_VERSION}")$(nvm_print_npm_version)"
         else
-          NVM_USE_OUTPUT="Now using node ${VERSION}$(nvm_print_npm_version)"
+          LOCAL_NVM_USE_OUTPUT="Now using node ${LOCAL_NVM_VERSION}$(nvm_print_npm_version)"
         fi
       fi
-      if [ "_${VERSION}" != "_system" ]; then
-        local NVM_USE_CMD
-        NVM_USE_CMD="nvm use --delete-prefix"
-        if [ -n "${PROVIDED_VERSION}" ]; then
-          NVM_USE_CMD="${NVM_USE_CMD} ${VERSION}"
+      if [ "_${LOCAL_NVM_VERSION}" != "_system" ]; then
+        local LOCAL_NVM_USE_CMD
+        LOCAL_NVM_USE_CMD="nvm use --delete-prefix"
+        if [ -n "${LOCAL_NVM_PROVIDED_VERSION}" ]; then
+          LOCAL_NVM_USE_CMD="${LOCAL_NVM_USE_CMD} ${LOCAL_NVM_VERSION}"
         fi
-        if [ "${NVM_SILENT:-0}" -eq 1 ]; then
-          NVM_USE_CMD="${NVM_USE_CMD} --silent"
+        if [ "${LOCAL_NVM_SILENT:-0}" -eq 1 ]; then
+          LOCAL_NVM_USE_CMD="${LOCAL_NVM_USE_CMD} --silent"
         fi
-        if ! nvm_die_on_prefix "${NVM_DELETE_PREFIX}" "${NVM_USE_CMD}" "${NVM_VERSION_DIR}"; then
+        if ! nvm_die_on_prefix "${LOCAL_NVM_DELETE_PREFIX}" "${LOCAL_NVM_USE_CMD}" "${LOCAL_NVM_VERSION_DIR}"; then
           return 11
         fi
       fi
-      if [ -n "${NVM_USE_OUTPUT-}" ] && [ "${NVM_SILENT:-0}" -ne 1 ]; then
-        nvm_echo "${NVM_USE_OUTPUT}"
+      if [ -n "${LOCAL_NVM_USE_OUTPUT-}" ] && [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+        nvm_echo "${LOCAL_NVM_USE_OUTPUT}"
       fi
     ;;
     "run")
-      local provided_version
-      local has_checked_nvmrc
-      has_checked_nvmrc=0
+      local LOCAL_NVM_PROVIDED_VERSION
+      local LOCAL_NVM_HAS_CHECKED_NVMRC
+      LOCAL_NVM_HAS_CHECKED_NVMRC=0
       # run given version of node
 
-      local NVM_SILENT
-      local NVM_SILENT_ARG
-      local NVM_LTS
+      local LOCAL_NVM_SILENT
+      local LOCAL_NVM_SILENT_ARG
+      local LOCAL_NVM_LTS
       while [ $# -gt 0 ]; do
         case "$1" in
           --silent)
-            NVM_SILENT=1
-            NVM_SILENT_ARG='--silent'
+            LOCAL_NVM_SILENT=1
+            LOCAL_NVM_SILENT_ARG='--silent'
             shift
           ;;
-          --lts) NVM_LTS='*' ; shift ;;
-          --lts=*) NVM_LTS="${1##--lts=}" ; shift ;;
+          --lts) LOCAL_NVM_LTS='*' ; shift ;;
+          --lts=*) LOCAL_NVM_LTS="${1##--lts=}" ; shift ;;
           *)
             if [ -n "$1" ]; then
               break
@@ -3674,28 +3678,28 @@ nvm() {
         esac
       done
 
-      if [ $# -lt 1 ] && [ -z "${NVM_LTS-}" ]; then
-        NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
+      if [ $# -lt 1 ] && [ -z "${LOCAL_NVM_LTS-}" ]; then
+        LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version && LOCAL_NVM_HAS_CHECKED_NVMRC=1
         if [ -n "${NVM_RC_VERSION-}" ]; then
-          VERSION="$(nvm_version "${NVM_RC_VERSION-}")" ||:
+          LOCAL_NVM_VERSION="$(nvm_version "${NVM_RC_VERSION-}")" ||:
         fi
         unset NVM_RC_VERSION
-        if [ "${VERSION:-N/A}" = 'N/A' ]; then
+        if [ "${LOCAL_NVM_VERSION:-N/A}" = 'N/A' ]; then
           >&2 nvm --help
           return 127
         fi
       fi
 
-      if [ -z "${NVM_LTS-}" ]; then
-        provided_version="$1"
-        if [ -n "${provided_version}" ]; then
-          VERSION="$(nvm_version "${provided_version}")" ||:
-          if [ "_${VERSION:-N/A}" = '_N/A' ] && ! nvm_is_valid_version "${provided_version}"; then
-            provided_version=''
-            if [ $has_checked_nvmrc -ne 1 ]; then
-              NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
+      if [ -z "${LOCAL_NVM_LTS-}" ]; then
+        LOCAL_NVM_PROVIDED_VERSION="$1"
+        if [ -n "${LOCAL_NVM_PROVIDED_VERSION}" ]; then
+          LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
+          if [ "_${LOCAL_NVM_VERSION:-N/A}" = '_N/A' ] && ! nvm_is_valid_version "${LOCAL_NVM_PROVIDED_VERSION}"; then
+            LOCAL_NVM_PROVIDED_VERSION=''
+            if [ ${LOCAL_NVM_HAS_CHECKED_NVMRC} -ne 1 ]; then
+              LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version && LOCAL_NVM_HAS_CHECKED_NVMRC=1
             fi
-            VERSION="$(nvm_version "${NVM_RC_VERSION}")" ||:
+            LOCAL_NVM_VERSION="$(nvm_version "${NVM_RC_VERSION}")" ||:
             unset NVM_RC_VERSION
           else
             shift
@@ -3703,37 +3707,37 @@ nvm() {
         fi
       fi
 
-      local NVM_IOJS
-      if nvm_is_iojs_version "${VERSION}"; then
-        NVM_IOJS=true
+      local LOCAL_NVM_IOJS
+      if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
+        LOCAL_NVM_IOJS=true
       fi
 
-      local EXIT_CODE
+      local LOCAL_NVM_EXIT_CODE
 
       nvm_is_zsh && setopt local_options shwordsplit
-      local LTS_ARG
-      if [ -n "${NVM_LTS-}" ]; then
-        LTS_ARG="--lts=${NVM_LTS-}"
-        VERSION=''
+      local LOCAL_NVM_LTS_ARG
+      if [ -n "${LOCAL_NVM_LTS-}" ]; then
+        LOCAL_NVM_LTS_ARG="--lts=${LOCAL_NVM_LTS-}"
+        LOCAL_NVM_VERSION=''
       fi
-      if [ "_${VERSION}" = "_N/A" ]; then
-        nvm_ensure_version_installed "${provided_version}"
-      elif [ "${NVM_IOJS}" = true ]; then
-        nvm exec "${NVM_SILENT_ARG-}" "${LTS_ARG-}" "${VERSION}" iojs "$@"
+      if [ "_${LOCAL_NVM_VERSION}" = "_N/A" ]; then
+        nvm_ensure_version_installed "${LOCAL_NVM_PROVIDED_VERSION}"
+      elif [ "${LOCAL_NVM_IOJS}" = true ]; then
+        nvm exec "${LOCAL_NVM_SILENT_ARG-}" "${LOCAL_NVM_LTS_ARG-}" "${LOCAL_NVM_VERSION}" iojs "$@"
       else
-        nvm exec "${NVM_SILENT_ARG-}" "${LTS_ARG-}" "${VERSION}" node "$@"
+        nvm exec "${LOCAL_NVM_SILENT_ARG-}" "${LOCAL_NVM_LTS_ARG-}" "${LOCAL_NVM_VERSION}" node "$@"
       fi
-      EXIT_CODE="$?"
-      return $EXIT_CODE
+      LOCAL_NVM_EXIT_CODE="$?"
+      return ${LOCAL_NVM_EXIT_CODE}
     ;;
     "exec")
-      local NVM_SILENT
-      local NVM_LTS
+      local LOCAL_NVM_SILENT
+      local LOCAL_NVM_LTS
       while [ $# -gt 0 ]; do
         case "$1" in
-          --silent) NVM_SILENT=1 ; shift ;;
-          --lts) NVM_LTS='*' ; shift ;;
-          --lts=*) NVM_LTS="${1##--lts=}" ; shift ;;
+          --silent) LOCAL_NVM_SILENT=1 ; shift ;;
+          --lts) LOCAL_NVM_LTS='*' ; shift ;;
+          --lts=*) LOCAL_NVM_LTS="${1##--lts=}" ; shift ;;
           --) break ;;
           --*)
             nvm_err "Unsupported option \"$1\"."
@@ -3749,111 +3753,112 @@ nvm() {
         esac
       done
 
-      local provided_version
-      provided_version="$1"
-      if [ "${NVM_LTS-}" != '' ]; then
-        provided_version="lts/${NVM_LTS:-*}"
-        VERSION="${provided_version}"
-      elif [ -n "${provided_version}" ]; then
-        VERSION="$(nvm_version "${provided_version}")" ||:
-        if [ "_${VERSION}" = '_N/A' ] && ! nvm_is_valid_version "${provided_version}"; then
-          NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
-          provided_version="${NVM_RC_VERSION}"
+      local LOCAL_NVM_PROVIDED_VERSION
+      LOCAL_NVM_PROVIDED_VERSION="$1"
+      if [ "${LOCAL_NVM_LTS-}" != '' ]; then
+        LOCAL_NVM_PROVIDED_VERSION="lts/${LOCAL_NVM_LTS:-*}"
+        LOCAL_NVM_VERSION="${LOCAL_NVM_PROVIDED_VERSION}"
+      elif [ -n "${LOCAL_NVM_PROVIDED_VERSION}" ]; then
+        LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
+        if [ "_${LOCAL_NVM_VERSION}" = '_N/A' ] && ! nvm_is_valid_version "${LOCAL_NVM_PROVIDED_VERSION}"; then
+          LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version && LOCAL_NVM_HAS_CHECKED_NVMRC=1
+          LOCAL_NVM_PROVIDED_VERSION="${NVM_RC_VERSION}"
           unset NVM_RC_VERSION
-          VERSION="$(nvm_version "${provided_version}")" ||:
+          LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
         else
           shift
         fi
       fi
 
-      nvm_ensure_version_installed "${provided_version}"
-      EXIT_CODE=$?
-      if [ "${EXIT_CODE}" != "0" ]; then
-        return $EXIT_CODE
+      local LOCAL_NVM_EXIT_CODE
+      nvm_ensure_version_installed "${LOCAL_NVM_PROVIDED_VERSION}"
+      LOCAL_NVM_EXIT_CODE=$?
+      if [ "${LOCAL_NVM_EXIT_CODE}" != "0" ]; then
+        return ${LOCAL_NVM_EXIT_CODE}
       fi
 
-      if [ "${NVM_SILENT:-0}" -ne 1 ]; then
-        if [ "${NVM_LTS-}" = '*' ]; then
-          nvm_echo "Running node latest LTS -> $(nvm_version "${VERSION}")$(nvm use --silent "${VERSION}" && nvm_print_npm_version)"
-        elif [ -n "${NVM_LTS-}" ]; then
-          nvm_echo "Running node LTS \"${NVM_LTS-}\" -> $(nvm_version "${VERSION}")$(nvm use --silent "${VERSION}" && nvm_print_npm_version)"
-        elif nvm_is_iojs_version "${VERSION}"; then
-          nvm_echo "Running io.js $(nvm_strip_iojs_prefix "${VERSION}")$(nvm use --silent "${VERSION}" && nvm_print_npm_version)"
+      if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+        if [ "${LOCAL_NVM_LTS-}" = '*' ]; then
+          nvm_echo "Running node latest LTS -> $(nvm_version "${LOCAL_NVM_VERSION}")$(nvm use --silent "${LOCAL_NVM_VERSION}" && nvm_print_npm_version)"
+        elif [ -n "${LOCAL_NVM_LTS-}" ]; then
+          nvm_echo "Running node LTS \"${LOCAL_NVM_LTS-}\" -> $(nvm_version "${LOCAL_NVM_VERSION}")$(nvm use --silent "${LOCAL_NVM_VERSION}" && nvm_print_npm_version)"
+        elif nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
+          nvm_echo "Running io.js $(nvm_strip_iojs_prefix "${LOCAL_NVM_VERSION}")$(nvm use --silent "${LOCAL_NVM_VERSION}" && nvm_print_npm_version)"
         else
-          nvm_echo "Running node ${VERSION}$(nvm use --silent "${VERSION}" && nvm_print_npm_version)"
+          nvm_echo "Running node ${LOCAL_NVM_VERSION}$(nvm use --silent "${LOCAL_NVM_VERSION}" && nvm_print_npm_version)"
         fi
       fi
-      NODE_VERSION="${VERSION}" "${NVM_DIR}/nvm-exec" "$@"
+      NODE_VERSION="${LOCAL_NVM_VERSION}" "${NVM_DIR}/nvm-exec" "$@"
     ;;
     "ls" | "list")
-      local PATTERN
-      local NVM_NO_COLORS
-      local NVM_NO_ALIAS
+      local LOCAL_NVM_PATTERN
+      local LOCAL_NVM_NO_COLORS
+      local LOCAL_NVM_NO_ALIAS
 
       while [ $# -gt 0 ]; do
         case "${1}" in
           --) ;;
-          --no-colors) NVM_NO_COLORS="${1}" ;;
-          --no-alias) NVM_NO_ALIAS="${1}" ;;
+          --no-colors) LOCAL_NVM_NO_COLORS="${1}" ;;
+          --no-alias) LOCAL_NVM_NO_ALIAS="${1}" ;;
           --*)
             nvm_err "Unsupported option \"${1}\"."
             return 55
           ;;
           *)
-            PATTERN="${PATTERN:-$1}"
+            LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN:-$1}"
           ;;
         esac
         shift
       done
-      if [ -n "${PATTERN-}" ] && [ -n "${NVM_NO_ALIAS-}" ]; then
+      if [ -n "${LOCAL_NVM_PATTERN-}" ] && [ -n "${LOCAL_NVM_NO_ALIAS-}" ]; then
         nvm_err '`--no-alias` is not supported when a pattern is provided.'
         return 55
       fi
-      local NVM_LS_OUTPUT
-      local NVM_LS_EXIT_CODE
-      NVM_LS_OUTPUT=$(nvm_ls "${PATTERN-}")
-      NVM_LS_EXIT_CODE=$?
-      NVM_NO_COLORS="${NVM_NO_COLORS-}" nvm_print_versions "${NVM_LS_OUTPUT}"
-      if [ -z "${NVM_NO_ALIAS-}" ] && [ -z "${PATTERN-}" ]; then
-        if [ -n "${NVM_NO_COLORS-}" ]; then
+      local LOCAL_NVM_LS_OUTPUT
+      local LOCAL_NVM_LS_EXIT_CODE
+      LOCAL_NVM_LS_OUTPUT=$(nvm_ls "${LOCAL_NVM_PATTERN-}")
+      LOCAL_NVM_LS_EXIT_CODE=$?
+      LOCAL_NVM_NO_COLORS="${LOCAL_NVM_NO_COLORS-}" nvm_print_versions "${LOCAL_NVM_LS_OUTPUT}"
+      if [ -z "${LOCAL_NVM_NO_ALIAS-}" ] && [ -z "${LOCAL_NVM_PATTERN-}" ]; then
+        if [ -n "${LOCAL_NVM_NO_COLORS-}" ]; then
           nvm alias --no-colors
         else
           nvm alias
         fi
       fi
-      return $NVM_LS_EXIT_CODE
+      return ${LOCAL_NVM_LS_EXIT_CODE}
     ;;
     "ls-remote" | "list-remote")
-      local NVM_LTS
-      local PATTERN
-      local NVM_NO_COLORS
+      local LOCAL_NVM_LTS
+      local LOCAL_NVM_PATTERN
+      local LOCAL_NVM_NO_COLORS
 
       while [ $# -gt 0 ]; do
         case "${1-}" in
           --) ;;
           --lts)
-            NVM_LTS='*'
+            LOCAL_NVM_LTS='*'
           ;;
           --lts=*)
-            NVM_LTS="${1##--lts=}"
+            LOCAL_NVM_LTS="${1##--lts=}"
           ;;
-          --no-colors) NVM_NO_COLORS="${1}" ;;
+          --no-colors) LOCAL_NVM_NO_COLORS="${1}" ;;
           --*)
             nvm_err "Unsupported option \"${1}\"."
             return 55
           ;;
           *)
-            if [ -z "${PATTERN-}" ]; then
-              PATTERN="${1-}"
-              if [ -z "${NVM_LTS-}" ]; then
-                case "${PATTERN}" in
+            if [ -z "${LOCAL_NVM_PATTERN-}" ]; then
+              LOCAL_NVM_PATTERN="${1-}"
+              if [ -z "${LOCAL_NVM_LTS-}" ]; then
+                case "${LOCAL_NVM_PATTERN}" in
                   'lts/*')
-                    NVM_LTS='*'
-                    PATTERN=''
+                    LOCAL_NVM_LTS='*'
+                    LOCAL_NVM_PATTERN=''
                   ;;
                   lts/*)
-                    NVM_LTS="${PATTERN##lts/}"
-                    PATTERN=''
+                    LOCAL_NVM_LTS="${LOCAL_NVM_PATTERN##lts/}"
+                    LOCAL_NVM_PATTERN=''
                   ;;
                 esac
               fi
@@ -3863,136 +3868,137 @@ nvm() {
         shift
       done
 
-      local NVM_OUTPUT
-      local EXIT_CODE
-      NVM_OUTPUT="$(NVM_LTS="${NVM_LTS-}" nvm_remote_versions "${PATTERN}" &&:)"
-      EXIT_CODE=$?
-      if [ -n "${NVM_OUTPUT}" ]; then
-        NVM_NO_COLORS="${NVM_NO_COLORS-}" nvm_print_versions "${NVM_OUTPUT}"
-        return $EXIT_CODE
+      local LOCAL_NVM_OUTPUT
+      local LOCAL_NVM_EXIT_CODE
+      LOCAL_NVM_OUTPUT="$(LOCAL_NVM_LTS="${LOCAL_NVM_LTS-}" nvm_remote_versions "${LOCAL_NVM_PATTERN}" &&:)"
+      LOCAL_NVM_EXIT_CODE=$?
+      if [ -n "${LOCAL_NVM_OUTPUT}" ]; then
+        LOCAL_NVM_NO_COLORS="${LOCAL_NVM_NO_COLORS-}" nvm_print_versions "${LOCAL_NVM_OUTPUT}"
+        return ${LOCAL_NVM_EXIT_CODE}
       fi
-      NVM_NO_COLORS="${NVM_NO_COLORS-}" nvm_print_versions "N/A"
+      LOCAL_NVM_NO_COLORS="${LOCAL_NVM_NO_COLORS-}" nvm_print_versions "N/A"
       return 3
     ;;
     "current")
       nvm_version current
     ;;
     "which")
-      local NVM_SILENT
-      local provided_version
+      local LOCAL_NVM_SILENT
+      local LOCAL_NVM_PROVIDED_VERSION
       while [ $# -ne 0 ]; do
         case "${1}" in
-          --silent) NVM_SILENT=1 ;;
+          --silent) LOCAL_NVM_SILENT=1 ;;
           --) ;;
-          *) provided_version="${1-}" ;;
+          *) LOCAL_NVM_PROVIDED_VERSION="${1-}" ;;
         esac
         shift
       done
-      if [ -z "${provided_version-}" ]; then
-        NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version
+      if [ -z "${LOCAL_NVM_PROVIDED_VERSION-}" ]; then
+        LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version
         if [ -n "${NVM_RC_VERSION}" ]; then
-          provided_version="${NVM_RC_VERSION}"
-          VERSION=$(nvm_version "${NVM_RC_VERSION}") ||:
+          LOCAL_NVM_PROVIDED_VERSION="${NVM_RC_VERSION}"
+          LOCAL_NVM_VERSION=$(nvm_version "${NVM_RC_VERSION}") ||:
         fi
         unset NVM_RC_VERSION
-      elif [ "${provided_version}" != 'system' ]; then
-        VERSION="$(nvm_version "${provided_version}")" ||:
+      elif [ "${LOCAL_NVM_PROVIDED_VERSION}" != 'system' ]; then
+        LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
       else
-        VERSION="${provided_version-}"
+        LOCAL_NVM_VERSION="${LOCAL_NVM_PROVIDED_VERSION-}"
       fi
-      if [ -z "${VERSION}" ]; then
+      if [ -z "${LOCAL_NVM_VERSION}" ]; then
         >&2 nvm --help
         return 127
       fi
 
-      if [ "_${VERSION}" = '_system' ]; then
+      if [ "_${LOCAL_NVM_VERSION}" = '_system' ]; then
         if nvm_has_system_iojs >/dev/null 2>&1 || nvm_has_system_node >/dev/null 2>&1; then
-          local NVM_BIN
-          NVM_BIN="$(nvm use system >/dev/null 2>&1 && command which node)"
-          if [ -n "${NVM_BIN}" ]; then
-            nvm_echo "${NVM_BIN}"
+          local LOCAL_NVM_BIN
+          LOCAL_NVM_BIN="$(nvm use system >/dev/null 2>&1 && command which node)"
+          if [ -n "${LOCAL_NVM_BIN}" ]; then
+            nvm_echo "${LOCAL_NVM_BIN}"
             return
           fi
           return 1
         fi
         nvm_err 'System version of node not found.'
         return 127
-      elif [ "${VERSION}" = '∞' ]; then
+      elif [ "${LOCAL_NVM_VERSION}" = '∞' ]; then
         nvm_err "The alias \"${2}\" leads to an infinite loop. Aborting."
         return 8
       fi
 
-      nvm_ensure_version_installed "${provided_version}"
-      EXIT_CODE=$?
-      if [ "${EXIT_CODE}" != "0" ]; then
-        return $EXIT_CODE
+      local LOCAL_NVM_EXIT_CODE
+      nvm_ensure_version_installed "${LOCAL_NVM_PROVIDED_VERSION}"
+      LOCAL_NVM_EXIT_CODE=$?
+      if [ "${LOCAL_NVM_EXIT_CODE}" != "0" ]; then
+        return ${LOCAL_NVM_EXIT_CODE}
       fi
-      local NVM_VERSION_DIR
-      NVM_VERSION_DIR="$(nvm_version_path "${VERSION}")"
-      nvm_echo "${NVM_VERSION_DIR}/bin/node"
+      local LOCAL_NVM_VERSION_DIR
+      LOCAL_NVM_VERSION_DIR="$(nvm_version_path "${LOCAL_NVM_VERSION}")"
+      nvm_echo "${LOCAL_NVM_VERSION_DIR}/bin/node"
     ;;
     "alias")
-      local NVM_ALIAS_DIR
-      NVM_ALIAS_DIR="$(nvm_alias_path)"
-      local NVM_CURRENT
-      NVM_CURRENT="$(nvm_ls_current)"
+      local LOCAL_NVM_ALIAS_DIR
+      LOCAL_NVM_ALIAS_DIR="$(nvm_alias_path)"
+      local LOCAL_NVM_CURRENT
+      LOCAL_NVM_CURRENT="$(nvm_ls_current)"
 
-      command mkdir -p "${NVM_ALIAS_DIR}/lts"
+      command mkdir -p "${LOCAL_NVM_ALIAS_DIR}/lts"
 
-      local ALIAS
-      local TARGET
-      local NVM_NO_COLORS
-      ALIAS='--'
-      TARGET='--'
+      local LOCAL_NVM_ALIAS
+      local LOCAL_NVM_TARGET
+      local LOCAL_NVM_NO_COLORS
+      LOCAL_NVM_ALIAS='--'
+      LOCAL_NVM_TARGET='--'
 
       while [ $# -gt 0 ]; do
         case "${1-}" in
           --) ;;
-          --no-colors) NVM_NO_COLORS="${1}" ;;
+          --no-colors) LOCAL_NVM_NO_COLORS="${1}" ;;
           --*)
             nvm_err "Unsupported option \"${1}\"."
             return 55
           ;;
           *)
-            if [ "${ALIAS}" = '--' ]; then
-              ALIAS="${1-}"
-            elif [ "${TARGET}" = '--' ]; then
-              TARGET="${1-}"
+            if [ "${LOCAL_NVM_ALIAS}" = '--' ]; then
+              LOCAL_NVM_ALIAS="${1-}"
+            elif [ "${LOCAL_NVM_TARGET}" = '--' ]; then
+              LOCAL_NVM_TARGET="${1-}"
             fi
           ;;
         esac
         shift
       done
 
-      if [ -z "${TARGET}" ]; then
+      if [ -z "${LOCAL_NVM_TARGET}" ]; then
         # for some reason the empty string was explicitly passed as the target
         # so, unalias it.
-        nvm unalias "${ALIAS}"
+        nvm unalias "${LOCAL_NVM_ALIAS}"
         return $?
-      elif [ "${TARGET}" != '--' ]; then
+      elif [ "${LOCAL_NVM_TARGET}" != '--' ]; then
         # a target was passed: create an alias
-        if [ "${ALIAS#*\/}" != "${ALIAS}" ]; then
+        if [ "${LOCAL_NVM_ALIAS#*\/}" != "${LOCAL_NVM_ALIAS}" ]; then
           nvm_err 'Aliases in subdirectories are not supported.'
           return 1
         fi
-        VERSION="$(nvm_version "${TARGET}")" ||:
-        if [ "${VERSION}" = 'N/A' ]; then
-          nvm_err "! WARNING: Version '${TARGET}' does not exist."
+        LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_TARGET}")" ||:
+        if [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
+          nvm_err "! WARNING: Version '${LOCAL_NVM_TARGET}' does not exist."
         fi
-        nvm_make_alias "${ALIAS}" "${TARGET}"
-        NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_CURRENT="${NVM_CURRENT-}" DEFAULT=false nvm_print_formatted_alias "${ALIAS}" "${TARGET}" "${VERSION}"
+        nvm_make_alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_TARGET}"
+        LOCAL_NVM_NO_COLORS="${LOCAL_NVM_NO_COLORS-}" LOCAL_NVM_CURRENT="${LOCAL_NVM_CURRENT-}" NVM_DEFAULT=false nvm_print_formatted_alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_TARGET}" "${LOCAL_NVM_VERSION}"
       else
-        if [ "${ALIAS-}" = '--' ]; then
-          unset ALIAS
+        if [ "${LOCAL_NVM_ALIAS-}" = '--' ]; then
+          unset LOCAL_NVM_ALIAS
         fi
 
-        nvm_list_aliases "${ALIAS-}"
+        nvm_list_aliases "${LOCAL_NVM_ALIAS-}"
       fi
     ;;
     "unalias")
-      local NVM_ALIAS_DIR
-      NVM_ALIAS_DIR="$(nvm_alias_path)"
-      command mkdir -p "${NVM_ALIAS_DIR}"
+      local LOCAL_NVM_ALIAS_DIR
+      LOCAL_NVM_ALIAS_DIR="$(nvm_alias_path)"
+      command mkdir -p "${LOCAL_NVM_ALIAS_DIR}"
       if [ $# -ne 1 ]; then
         >&2 nvm --help
         return 127
@@ -4002,19 +4008,19 @@ nvm() {
         return 1
       fi
 
-      local NVM_IOJS_PREFIX
-      local NVM_NODE_PREFIX
-      NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-      NVM_NODE_PREFIX="$(nvm_node_prefix)"
-      local NVM_ALIAS_EXISTS
-      NVM_ALIAS_EXISTS=0
-      if [ -f "${NVM_ALIAS_DIR}/${1-}" ]; then
-        NVM_ALIAS_EXISTS=1
+      local LOCAL_NVM_IOJS_PREFIX
+      local LOCAL_NVM_NODE_PREFIX
+      LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
+      LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
+      local LOCAL_NVM_ALIAS_EXISTS
+      LOCAL_NVM_ALIAS_EXISTS=0
+      if [ -f "${LOCAL_NVM_ALIAS_DIR}/${1-}" ]; then
+        LOCAL_NVM_ALIAS_EXISTS=1
       fi
 
-      if [ $NVM_ALIAS_EXISTS -eq 0 ]; then
+      if [ ${LOCAL_NVM_ALIAS_EXISTS} -eq 0 ]; then
         case "$1" in
-          "stable" | "unstable" | "${NVM_IOJS_PREFIX}" | "${NVM_NODE_PREFIX}" | "system")
+          "stable" | "unstable" | "${LOCAL_NVM_IOJS_PREFIX}" | "${LOCAL_NVM_NODE_PREFIX}" | "system")
             nvm_err "${1-} is a default (built-in) alias and cannot be deleted."
             return 1
           ;;
@@ -4024,10 +4030,10 @@ nvm() {
         return
       fi
 
-      local NVM_ALIAS_ORIGINAL
-      NVM_ALIAS_ORIGINAL="$(nvm_alias "${1}")"
-      command rm -f "${NVM_ALIAS_DIR}/${1}"
-      nvm_echo "Deleted alias ${1} - restore it with \`nvm alias \"${1}\" \"${NVM_ALIAS_ORIGINAL}\"\`"
+      local LOCAL_NVM_ALIAS_ORIGINAL
+      LOCAL_NVM_ALIAS_ORIGINAL="$(nvm_alias "${1}")"
+      command rm -f "${LOCAL_NVM_ALIAS_DIR}/${1}"
+      nvm_echo "Deleted alias ${1} - restore it with \`nvm alias \"${1}\" \"${LOCAL_NVM_ALIAS_ORIGINAL}\"\`"
     ;;
     "install-latest-npm")
       if [ $# -ne 0 ]; then
@@ -4043,45 +4049,45 @@ nvm() {
         return 127
       fi
 
-      local PROVIDED_VERSION
-      PROVIDED_VERSION="${1-}"
+      local LOCAL_NVM_PROVIDED_VERSION
+      LOCAL_NVM_PROVIDED_VERSION="${1-}"
 
-      if [ "${PROVIDED_VERSION}" = "$(nvm_ls_current)" ] || [ "$(nvm_version "${PROVIDED_VERSION}" ||:)" = "$(nvm_ls_current)" ]; then
+      if [ "${LOCAL_NVM_PROVIDED_VERSION}" = "$(nvm_ls_current)" ] || [ "$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}" ||:)" = "$(nvm_ls_current)" ]; then
         nvm_err 'Can not reinstall packages from the current version of node.'
         return 2
       fi
 
-      local VERSION
-      if [ "_${PROVIDED_VERSION}" = "_system" ]; then
+      local LOCAL_NVM_VERSION
+      if [ "_${LOCAL_NVM_PROVIDED_VERSION}" = "_system" ]; then
         if ! nvm_has_system_node && ! nvm_has_system_iojs; then
           nvm_err 'No system version of node or io.js detected.'
           return 3
         fi
-        VERSION="system"
+        LOCAL_NVM_VERSION="system"
       else
-        VERSION="$(nvm_version "${PROVIDED_VERSION}")" ||:
+        LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
       fi
 
-      local NPMLIST
-      NPMLIST="$(nvm_npm_global_modules "${VERSION}")"
-      local INSTALLS
-      local LINKS
-      INSTALLS="${NPMLIST%% //// *}"
-      LINKS="${NPMLIST##* //// }"
+      local LOCAL_NVM_NPMLIST
+      LOCAL_NVM_NPMLIST="$(nvm_npm_global_modules "${LOCAL_NVM_VERSION}")"
+      local LOCAL_NVM_INSTALLS
+      local LOCAL_NVM_LINKS
+      LOCAL_NVM_INSTALLS="${LOCAL_NVM_NPMLIST%% //// *}"
+      LOCAL_NVM_LINKS="${LOCAL_NVM_NPMLIST##* //// }"
 
-      nvm_echo "Reinstalling global packages from ${VERSION}..."
-      if [ -n "${INSTALLS}" ]; then
-        nvm_echo "${INSTALLS}" | command xargs npm install -g --quiet
+      nvm_echo "Reinstalling global packages from ${LOCAL_NVM_VERSION}..."
+      if [ -n "${LOCAL_NVM_INSTALLS}" ]; then
+        nvm_echo "${LOCAL_NVM_INSTALLS}" | command xargs npm install -g --quiet
       else
         nvm_echo "No installed global packages found..."
       fi
 
-      nvm_echo "Linking global packages from ${VERSION}..."
-      if [ -n "${LINKS}" ]; then
+      nvm_echo "Linking global packages from ${LOCAL_NVM_VERSION}..."
+      if [ -n "${LOCAL_NVM_LINKS}" ]; then
         (
           set -f; IFS='
 ' # necessary to turn off variable expansion except for newlines
-          for LINK in ${LINKS}; do
+          for LINK in ${LOCAL_NVM_LINKS}; do
             set +f; unset IFS # restore variable expansion
             if [ -n "${LINK}" ]; then
               case "${LINK}" in
@@ -4103,38 +4109,38 @@ nvm() {
       nvm_version "${1}"
     ;;
     "version-remote")
-      local NVM_LTS
-      local PATTERN
+      local LOCAL_NVM_LTS
+      local LOCAL_NVM_PATTERN
       while [ $# -gt 0 ]; do
         case "${1-}" in
           --) ;;
           --lts)
-            NVM_LTS='*'
+            LOCAL_NVM_LTS='*'
           ;;
           --lts=*)
-            NVM_LTS="${1##--lts=}"
+            LOCAL_NVM_LTS="${1##--lts=}"
           ;;
           --*)
             nvm_err "Unsupported option \"${1}\"."
             return 55
           ;;
           *)
-            PATTERN="${PATTERN:-${1}}"
+            LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN:-${1}}"
           ;;
         esac
         shift
       done
-      case "${PATTERN-}" in
+      case "${LOCAL_NVM_PATTERN-}" in
         'lts/*')
-          NVM_LTS='*'
-          unset PATTERN
+          LOCAL_NVM_LTS='*'
+          unset LOCAL_NVM_PATTERN
         ;;
         lts/*)
-          NVM_LTS="${PATTERN##lts/}"
-          unset PATTERN
+          LOCAL_NVM_LTS="${LOCAL_NVM_PATTERN##lts/}"
+          unset LOCAL_NVM_PATTERN
         ;;
       esac
-      NVM_VERSION_ONLY=true NVM_LTS="${NVM_LTS-}" nvm_remote_version "${PATTERN:-node}"
+      NVM_VERSION_ONLY=true LOCAL_NVM_LTS="${LOCAL_NVM_LTS-}" nvm_remote_version "${LOCAL_NVM_PATTERN:-node}"
     ;;
     "--version" | "-v")
       nvm_echo '0.39.1'
@@ -4184,16 +4190,16 @@ nvm() {
         nvm_get_artifact_compression nvm_install_binary_extract nvm_extract_tarball \
         >/dev/null 2>&1
       unset NVM_RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR NVM_DIR \
-        NVM_CD_FLAGS NVM_BIN NVM_INC NVM_MAKE_JOBS \
-        NVM_COLORS INSTALLED_COLOR SYSTEM_COLOR \
-        CURRENT_COLOR NOT_INSTALLED_COLOR DEFAULT_COLOR LTS_COLOR \
+        NVM_CD_FLAGS NVM_BIN NVM_INC LOCAL_NVM_MAKE_JOBS \
+        NVM_COLORS LOCAL_NVM_INSTALLED_COLOR LOCAL_NVM_SYSTEM_COLOR \
+        LOCAL_NVM_CURRENT_COLOR LOCAL_NVM_NOT_INSTALLED_COLOR LOCAL_NVM_DEFAULT_COLOR LOCAL_NVM_LTS_COLOR \
         >/dev/null 2>&1
     ;;
     "set-colors")
-      local EXIT_CODE
+      local LOCAL_NVM_EXIT_CODE
       nvm_set_colors "${1-}"
-      EXIT_CODE=$?
-      if [ "$EXIT_CODE" -eq 17 ]; then
+      LOCAL_NVM_EXIT_CODE=$?
+      if [ "${LOCAL_NVM_EXIT_CODE}" -eq 17 ]; then
         >&2 nvm --help
         nvm_echo
         nvm_err_with_colors "\033[1;37mPlease pass in five \033[1;31mvalid color codes\033[1;37m. Choose from: rRgGbBcCyYmMkKeW\033[0m"
@@ -4207,37 +4213,37 @@ nvm() {
 }
 
 nvm_get_default_packages() {
-  local NVM_DEFAULT_PACKAGE_FILE="${NVM_DIR}/default-packages"
-  if [ -f "${NVM_DEFAULT_PACKAGE_FILE}" ]; then
-    local DEFAULT_PACKAGES
-    DEFAULT_PACKAGES=''
+  local LOCAL_NVM_DEFAULT_PACKAGE_FILE="${NVM_DIR}/default-packages"
+  if [ -f "${LOCAL_NVM_DEFAULT_PACKAGE_FILE}" ]; then
+    local LOCAL_NVM_DEFAULT_PACKAGES
+    LOCAL_NVM_DEFAULT_PACKAGES=''
 
-    # Read lines from $NVM_DIR/default-packages
-    local line
+    # Read lines from ${NVM_DIR}/default-packages
+    local LOCAL_NVM_LINE
     # ensure a trailing newline
     WORK=$(mktemp -d) || exit $?
     # shellcheck disable=SC2064
-    trap "command rm -rf '$WORK'" EXIT
+    trap "command rm -rf '${WORK}'" EXIT
     # shellcheck disable=SC1003
-    sed -e '$a\' "${NVM_DEFAULT_PACKAGE_FILE}" > "${WORK}/default-packages"
-    while IFS=' ' read -r line; do
+    sed -e '$a\' "${LOCAL_NVM_DEFAULT_PACKAGE_FILE}" > "${WORK}/default-packages"
+    while IFS=' ' read -r LOCAL_NVM_LINE; do
       # Skip empty lines.
-      [ -n "${line-}" ] || continue
+      [ -n "${LOCAL_NVM_LINE-}" ] || continue
 
       # Skip comment lines that begin with `#`.
-      [ "$(nvm_echo "${line}" | command cut -c1)" != "#" ] || continue
+      [ "$(nvm_echo "${LOCAL_NVM_LINE}" | command cut -c1)" != "#" ] || continue
 
       # Fail on lines that have multiple space-separated words
-      case $line in
+      case ${LOCAL_NVM_LINE} in
         *\ *)
           nvm_err "Only one package per line is allowed in the ${NVM_DIR}/default-packages file. Please remove any lines with multiple space-separated values."
           return 1
         ;;
       esac
 
-      DEFAULT_PACKAGES="${DEFAULT_PACKAGES}${line} "
+      LOCAL_NVM_DEFAULT_PACKAGES="${LOCAL_NVM_DEFAULT_PACKAGES}${LOCAL_NVM_LINE} "
     done < "${WORK}/default-packages"
-    echo "${DEFAULT_PACKAGES}" | command xargs
+    echo "${LOCAL_NVM_DEFAULT_PACKAGES}" | command xargs
   fi
 }
 
@@ -4256,16 +4262,16 @@ nvm_supports_xz() {
     return 1
   fi
 
-  local NVM_OS
-  NVM_OS="$(nvm_get_os)"
-  if [ "_${NVM_OS}" = '_darwin' ]; then
-    local MACOS_VERSION
-    MACOS_VERSION="$(sw_vers -productVersion)"
-    if nvm_version_greater "10.9.0" "${MACOS_VERSION}"; then
+  local LOCAL_NVM_OS
+  LOCAL_NVM_OS="$(nvm_get_os)"
+  if [ "_${LOCAL_NVM_OS}" = '_darwin' ]; then
+    local LOCAL_NVM_MACOS_VERSION
+    LOCAL_NVM_MACOS_VERSION="$(sw_vers -productVersion)"
+    if nvm_version_greater "10.9.0" "${LOCAL_NVM_MACOS_VERSION}"; then
       # macOS 10.8 and earlier doesn't support extracting xz-compressed tarballs with tar
       return 1
     fi
-  elif [ "_${NVM_OS}" = '_freebsd' ]; then
+  elif [ "_${LOCAL_NVM_OS}" = '_freebsd' ]; then
     if ! [ -e '/usr/lib/liblzma.so' ]; then
       # FreeBSD without /usr/lib/liblzma.so doesn't support extracting xz-compressed tarballs with tar
       return 1
@@ -4293,7 +4299,7 @@ nvm_supports_xz() {
     return 0
   fi
 
-  case "${NVM_OS}" in
+  case "${LOCAL_NVM_OS}" in
     darwin)
       # darwin only has xz for io.js v2.3.2 and later
       nvm_version_greater_than_or_equal_to "${1}" "2.3.2"
@@ -4306,46 +4312,46 @@ nvm_supports_xz() {
 }
 
 nvm_auto() {
-  local NVM_MODE
-  NVM_MODE="${1-}"
-  local VERSION
-  local NVM_CURRENT
-  if [ "_${NVM_MODE}" = '_install' ]; then
-    VERSION="$(nvm_alias default 2>/dev/null || nvm_echo)"
-    if [ -n "${VERSION}" ]; then
-      nvm install "${VERSION}" >/dev/null
+  local LOCAL_NVM_MODE
+  LOCAL_NVM_MODE="${1-}"
+  local LOCAL_NVM_VERSION
+  local LOCAL_NVM_CURRENT
+  if [ "_${LOCAL_NVM_MODE}" = '_install' ]; then
+    LOCAL_NVM_VERSION="$(nvm_alias default 2>/dev/null || nvm_echo)"
+    if [ -n "${LOCAL_NVM_VERSION}" ]; then
+      nvm install "${LOCAL_NVM_VERSION}" >/dev/null
     elif nvm_rc_version >/dev/null 2>&1; then
       nvm install >/dev/null
     fi
-  elif [ "_$NVM_MODE" = '_use' ]; then
-    NVM_CURRENT="$(nvm_ls_current)"
-    if [ "_${NVM_CURRENT}" = '_none' ] || [ "_${NVM_CURRENT}" = '_system' ]; then
-      VERSION="$(nvm_resolve_local_alias default 2>/dev/null || nvm_echo)"
-      if [ -n "${VERSION}" ]; then
-        nvm use --silent "${VERSION}" >/dev/null
+  elif [ "_${LOCAL_NVM_MODE}" = '_use' ]; then
+    LOCAL_NVM_CURRENT="$(nvm_ls_current)"
+    if [ "_${LOCAL_NVM_CURRENT}" = '_none' ] || [ "_${LOCAL_NVM_CURRENT}" = '_system' ]; then
+      LOCAL_NVM_VERSION="$(nvm_resolve_local_alias default 2>/dev/null || nvm_echo)"
+      if [ -n "${LOCAL_NVM_VERSION}" ]; then
+        nvm use --silent "${LOCAL_NVM_VERSION}" >/dev/null
       elif nvm_rc_version >/dev/null 2>&1; then
         nvm use --silent >/dev/null
       fi
     else
-      nvm use --silent "${NVM_CURRENT}" >/dev/null
+      nvm use --silent "${LOCAL_NVM_CURRENT}" >/dev/null
     fi
-  elif [ "_${NVM_MODE}" != '_none' ]; then
+  elif [ "_${LOCAL_NVM_MODE}" != '_none' ]; then
     nvm_err 'Invalid auto mode supplied.'
     return 1
   fi
 }
 
 nvm_process_parameters() {
-  local NVM_AUTO_MODE
-  NVM_AUTO_MODE='use'
+  local LOCAL_NVM_AUTO_MODE
+  LOCAL_NVM_AUTO_MODE='use'
   while [ "$#" -ne 0 ]; do
     case "$1" in
-      --install) NVM_AUTO_MODE='install' ;;
-      --no-use) NVM_AUTO_MODE='none' ;;
+      --install) LOCAL_NVM_AUTO_MODE='install' ;;
+      --no-use) LOCAL_NVM_AUTO_MODE='none' ;;
     esac
     shift
   done
-  nvm_auto "${NVM_AUTO_MODE}"
+  nvm_auto "${LOCAL_NVM_AUTO_MODE}"
 }
 
 nvm_process_parameters "$@"

--- a/nvm.sh
+++ b/nvm.sh
@@ -59,31 +59,31 @@ nvm_is_alias() {
 }
 
 nvm_command_info() {
-  local LOCAL_NVM_COMMAND
-  local LOCAL_NVM_INFO
-  LOCAL_NVM_COMMAND="${1}"
-  if type "${LOCAL_NVM_COMMAND}" | nvm_grep -q hashed; then
-    LOCAL_NVM_INFO="$(type "${LOCAL_NVM_COMMAND}" | command sed -E 's/\(|\)//g' | command awk '{print $4}')"
-  elif type "${LOCAL_NVM_COMMAND}" | nvm_grep -q aliased; then
+  local NVM_LOCAL_COMMAND
+  local NVM_LOCAL_INFO
+  NVM_LOCAL_COMMAND="${1}"
+  if type "${NVM_LOCAL_COMMAND}" | nvm_grep -q hashed; then
+    NVM_LOCAL_INFO="$(type "${NVM_LOCAL_COMMAND}" | command sed -E 's/\(|\)//g' | command awk '{print $4}')"
+  elif type "${NVM_LOCAL_COMMAND}" | nvm_grep -q aliased; then
     # shellcheck disable=SC2230
-    LOCAL_NVM_INFO="$(which "${LOCAL_NVM_COMMAND}") ($(type "${LOCAL_NVM_COMMAND}" | command awk '{ $1=$2=$3=$4="" ;print }' | command sed -e 's/^\ *//g' -Ee "s/\`|'//g"))"
-  elif type "${LOCAL_NVM_COMMAND}" | nvm_grep -q "^${LOCAL_NVM_COMMAND} is an alias for"; then
+    NVM_LOCAL_INFO="$(which "${NVM_LOCAL_COMMAND}") ($(type "${NVM_LOCAL_COMMAND}" | command awk '{ $1=$2=$3=$4="" ;print }' | command sed -e 's/^\ *//g' -Ee "s/\`|'//g"))"
+  elif type "${NVM_LOCAL_COMMAND}" | nvm_grep -q "^${NVM_LOCAL_COMMAND} is an alias for"; then
     # shellcheck disable=SC2230
-    LOCAL_NVM_INFO="$(which "${LOCAL_NVM_COMMAND}") ($(type "${LOCAL_NVM_COMMAND}" | command awk '{ $1=$2=$3=$4=$5="" ;print }' | command sed 's/^\ *//g'))"
-  elif type "${LOCAL_NVM_COMMAND}" | nvm_grep -q "^${LOCAL_NVM_COMMAND} is \\/"; then
-    LOCAL_NVM_INFO="$(type "${LOCAL_NVM_COMMAND}" | command awk '{print $3}')"
+    NVM_LOCAL_INFO="$(which "${NVM_LOCAL_COMMAND}") ($(type "${NVM_LOCAL_COMMAND}" | command awk '{ $1=$2=$3=$4=$5="" ;print }' | command sed 's/^\ *//g'))"
+  elif type "${NVM_LOCAL_COMMAND}" | nvm_grep -q "^${NVM_LOCAL_COMMAND} is \\/"; then
+    NVM_LOCAL_INFO="$(type "${NVM_LOCAL_COMMAND}" | command awk '{print $3}')"
   else
-    LOCAL_NVM_INFO="$(type "${LOCAL_NVM_COMMAND}")"
+    NVM_LOCAL_INFO="$(type "${NVM_LOCAL_COMMAND}")"
   fi
-  nvm_echo "${LOCAL_NVM_INFO}"
+  nvm_echo "${NVM_LOCAL_INFO}"
 }
 
 nvm_has_colors() {
-  local LOCAL_NVM_NUM_COLORS
+  local NVM_LOCAL_NUM_COLORS
   if nvm_has tput; then
-    LOCAL_NVM_NUM_COLORS="$(tput -T "${TERM:-vt100}" colors)"
+    NVM_LOCAL_NUM_COLORS="$(tput -T "${TERM:-vt100}" colors)"
   fi
-  [ "${LOCAL_NVM_NUM_COLORS:--1}" -ge 8 ]
+  [ "${NVM_LOCAL_NUM_COLORS:--1}" -ge 8 ]
 }
 
 nvm_curl_libz_support() {
@@ -95,33 +95,33 @@ nvm_curl_use_compression() {
 }
 
 nvm_get_latest() {
-  local LOCAL_NVM_LATEST_URL
-  local LOCAL_NVM_CURL_COMPRESSED_FLAG
+  local NVM_LOCAL_LATEST_URL
+  local NVM_LOCAL_CURL_COMPRESSED_FLAG
   if nvm_has "curl"; then
     if nvm_curl_use_compression; then
-      LOCAL_NVM_CURL_COMPRESSED_FLAG="--compressed"
+      NVM_LOCAL_CURL_COMPRESSED_FLAG="--compressed"
     fi
-    LOCAL_NVM_LATEST_URL="$(curl ${LOCAL_NVM_CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S https://latest.nvm.sh -o /dev/null)"
+    NVM_LOCAL_LATEST_URL="$(curl ${NVM_LOCAL_CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S https://latest.nvm.sh -o /dev/null)"
   elif nvm_has "wget"; then
-    LOCAL_NVM_LATEST_URL="$(wget -q https://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
+    NVM_LOCAL_LATEST_URL="$(wget -q https://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
   else
     nvm_err 'nvm needs curl or wget to proceed.'
     return 1
   fi
-  if [ -z "${LOCAL_NVM_LATEST_URL}" ]; then
+  if [ -z "${NVM_LOCAL_LATEST_URL}" ]; then
     nvm_err "https://latest.nvm.sh did not redirect to the latest release on GitHub"
     return 2
   fi
-  nvm_echo "${LOCAL_NVM_LATEST_URL##*/}"
+  nvm_echo "${NVM_LOCAL_LATEST_URL##*/}"
 }
 
 nvm_download() {
-  local LOCAL_NVM_CURL_COMPRESSED_FLAG
+  local NVM_LOCAL_CURL_COMPRESSED_FLAG
   if nvm_has "curl"; then
     if nvm_curl_use_compression; then
-      LOCAL_NVM_CURL_COMPRESSED_FLAG="--compressed"
+      NVM_LOCAL_CURL_COMPRESSED_FLAG="--compressed"
     fi
-    curl --fail ${LOCAL_NVM_CURL_COMPRESSED_FLAG:-} -q "$@"
+    curl --fail ${NVM_LOCAL_CURL_COMPRESSED_FLAG:-} -q "$@"
   elif nvm_has "wget"; then
     # Emulate curl with wget
     ARGS=$(nvm_echo "$@" | command sed -e 's/--progress-bar /--progress=bar /' \
@@ -150,12 +150,12 @@ nvm_is_version_installed() {
   if [ -z "${1-}" ]; then
     return 1
   fi
-  local LOCAL_NVM_NODE_BINARY
-  LOCAL_NVM_NODE_BINARY='node'
+  local NVM_LOCAL_NODE_BINARY
+  NVM_LOCAL_NODE_BINARY='node'
   if [ "_$(nvm_get_os)" = '_win' ]; then
-    LOCAL_NVM_NODE_BINARY='node.exe'
+    NVM_LOCAL_NODE_BINARY='node.exe'
   fi
-  if [ -x "$(nvm_version_path "$1" 2>/dev/null)/bin/${LOCAL_NVM_NODE_BINARY}" ]; then
+  if [ -x "$(nvm_version_path "$1" 2>/dev/null)/bin/${NVM_LOCAL_NODE_BINARY}" ]; then
     return 0
   fi
   return 1
@@ -169,15 +169,15 @@ nvm_print_npm_version() {
 
 nvm_install_latest_npm() {
   nvm_echo 'Attempting to upgrade to the latest working version of npm...'
-  local LOCAL_NVM_NODE_VERSION
-  LOCAL_NVM_NODE_VERSION="$(nvm_strip_iojs_prefix "$(nvm_ls_current)")"
-  if [ "${LOCAL_NVM_NODE_VERSION}" = 'system' ]; then
-    LOCAL_NVM_NODE_VERSION="$(node --version)"
-  elif [ "${LOCAL_NVM_NODE_VERSION}" = 'none' ]; then
-    nvm_echo "Detected node version ${LOCAL_NVM_NODE_VERSION}, npm version v${LOCAL_NPM_VERSION}"
-    LOCAL_NVM_NODE_VERSION=''
+  local NVM_LOCAL_NODE_VERSION
+  NVM_LOCAL_NODE_VERSION="$(nvm_strip_iojs_prefix "$(nvm_ls_current)")"
+  if [ "${NVM_LOCAL_NODE_VERSION}" = 'system' ]; then
+    NVM_LOCAL_NODE_VERSION="$(node --version)"
+  elif [ "${NVM_LOCAL_NODE_VERSION}" = 'none' ]; then
+    nvm_echo "Detected node version ${NVM_LOCAL_NODE_VERSION}, npm version v${LOCAL_NPM_VERSION}"
+    NVM_LOCAL_NODE_VERSION=''
   fi
-  if [ -z "${LOCAL_NVM_NODE_VERSION}" ]; then
+  if [ -z "${NVM_LOCAL_NODE_VERSION}" ]; then
     nvm_err 'Unable to obtain node version.'
     return 1
   fi
@@ -188,142 +188,142 @@ nvm_install_latest_npm() {
     return 2
   fi
 
-  local LOCAL_NVM_TOOL_NPM
-  LOCAL_NVM_TOOL_NPM='npm'
+  local NVM_LOCAL_TOOL_NPM
+  NVM_LOCAL_TOOL_NPM='npm'
   if [ "${NVM_DEBUG-}" = 1 ]; then
-    nvm_echo "Detected node version ${LOCAL_NVM_NODE_VERSION}, npm version v${LOCAL_NPM_VERSION}"
-    LOCAL_NVM_TOOL_NPM='nvm_echo npm'
+    nvm_echo "Detected node version ${NVM_LOCAL_NODE_VERSION}, npm version v${LOCAL_NPM_VERSION}"
+    NVM_LOCAL_TOOL_NPM='nvm_echo npm'
   fi
 
-  local LOCAL_NVM_IS_0_6
-  LOCAL_NVM_IS_0_6=0
-  if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 0.6.0 && nvm_version_greater 0.7.0 "${LOCAL_NVM_NODE_VERSION}"; then
-    LOCAL_NVM_IS_0_6=1
+  local NVM_LOCAL_IS_0_6
+  NVM_LOCAL_IS_0_6=0
+  if nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 0.6.0 && nvm_version_greater 0.7.0 "${NVM_LOCAL_NODE_VERSION}"; then
+    NVM_LOCAL_IS_0_6=1
   fi
-  local LOCAL_NVM_IS_0_9
-  LOCAL_NVM_IS_0_9=0
-  if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 0.9.0 && nvm_version_greater 0.10.0 "${LOCAL_NVM_NODE_VERSION}"; then
-    LOCAL_NVM_IS_0_9=1
+  local NVM_LOCAL_IS_0_9
+  NVM_LOCAL_IS_0_9=0
+  if nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 0.9.0 && nvm_version_greater 0.10.0 "${NVM_LOCAL_NODE_VERSION}"; then
+    NVM_LOCAL_IS_0_9=1
   fi
 
-  if [ ${LOCAL_NVM_IS_0_6} -eq 1 ]; then
+  if [ ${NVM_LOCAL_IS_0_6} -eq 1 ]; then
     nvm_echo '* `node` v0.6.x can only upgrade to `npm` v1.3.x'
-    ${LOCAL_NVM_TOOL_NPM} install -g npm@1.3
-  elif [ ${LOCAL_NVM_IS_0_9} -eq 0 ]; then
+    ${NVM_LOCAL_TOOL_NPM} install -g npm@1.3
+  elif [ ${NVM_LOCAL_IS_0_9} -eq 0 ]; then
     # node 0.9 breaks here, for some reason
     if nvm_version_greater_than_or_equal_to "${LOCAL_NPM_VERSION}" 1.0.0 && nvm_version_greater 2.0.0 "${LOCAL_NPM_VERSION}"; then
       nvm_echo '* `npm` v1.x needs to first jump to `npm` v1.4.28 to be able to upgrade further'
-      ${LOCAL_NVM_TOOL_NPM} install -g npm@1.4.28
+      ${NVM_LOCAL_TOOL_NPM} install -g npm@1.4.28
     elif nvm_version_greater_than_or_equal_to "${LOCAL_NPM_VERSION}" 2.0.0 && nvm_version_greater 3.0.0 "${LOCAL_NPM_VERSION}"; then
       nvm_echo '* `npm` v2.x needs to first jump to the latest v2 to be able to upgrade further'
-      ${LOCAL_NVM_TOOL_NPM} install -g npm@2
+      ${NVM_LOCAL_TOOL_NPM} install -g npm@2
     fi
   fi
 
-  if [ ${LOCAL_NVM_IS_0_9} -eq 1 ] || [ ${LOCAL_NVM_IS_0_6} -eq 1 ]; then
+  if [ ${NVM_LOCAL_IS_0_9} -eq 1 ] || [ ${NVM_LOCAL_IS_0_6} -eq 1 ]; then
     nvm_echo '* node v0.6 and v0.9 are unable to upgrade further'
-  elif nvm_version_greater 1.1.0 "${LOCAL_NVM_NODE_VERSION}"; then
+  elif nvm_version_greater 1.1.0 "${NVM_LOCAL_NODE_VERSION}"; then
     nvm_echo '* `npm` v4.5.x is the last version that works on `node` versions < v1.1.0'
-    ${LOCAL_NVM_TOOL_NPM} install -g npm@4.5
-  elif nvm_version_greater 4.0.0 "${LOCAL_NVM_NODE_VERSION}"; then
+    ${NVM_LOCAL_TOOL_NPM} install -g npm@4.5
+  elif nvm_version_greater 4.0.0 "${NVM_LOCAL_NODE_VERSION}"; then
     nvm_echo '* `npm` v5 and higher do not work on `node` versions below v4.0.0'
-    ${LOCAL_NVM_TOOL_NPM} install -g npm@4
-  elif [ ${LOCAL_NVM_IS_0_9} -eq 0 ] && [ ${LOCAL_NVM_IS_0_6} -eq 0 ]; then
-    local LOCAL_NVM_IS_4_4_OR_BELOW
-    LOCAL_NVM_IS_4_4_OR_BELOW=0
-    if nvm_version_greater 4.5.0 "${LOCAL_NVM_NODE_VERSION}"; then
-      LOCAL_NVM_IS_4_4_OR_BELOW=1
+    ${NVM_LOCAL_TOOL_NPM} install -g npm@4
+  elif [ ${NVM_LOCAL_IS_0_9} -eq 0 ] && [ ${NVM_LOCAL_IS_0_6} -eq 0 ]; then
+    local NVM_LOCAL_IS_4_4_OR_BELOW
+    NVM_LOCAL_IS_4_4_OR_BELOW=0
+    if nvm_version_greater 4.5.0 "${NVM_LOCAL_NODE_VERSION}"; then
+      NVM_LOCAL_IS_4_4_OR_BELOW=1
     fi
 
-    local LOCAL_NVM_IS_5_OR_ABOVE
-    LOCAL_NVM_IS_5_OR_ABOVE=0
-    if [ ${LOCAL_NVM_IS_4_4_OR_BELOW} -eq 0 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 5.0.0; then
-      LOCAL_NVM_IS_5_OR_ABOVE=1
+    local NVM_LOCAL_IS_5_OR_ABOVE
+    NVM_LOCAL_IS_5_OR_ABOVE=0
+    if [ ${NVM_LOCAL_IS_4_4_OR_BELOW} -eq 0 ] && nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 5.0.0; then
+      NVM_LOCAL_IS_5_OR_ABOVE=1
     fi
 
-    local LOCAL_NVM_IS_6_OR_ABOVE
-    LOCAL_NVM_IS_6_OR_ABOVE=0
-    local LOCAL_NVM_IS_6_2_OR_ABOVE
-    LOCAL_NVM_IS_6_2_OR_ABOVE=0
-    if [ ${LOCAL_NVM_IS_5_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 6.0.0; then
-      LOCAL_NVM_IS_6_OR_ABOVE=1
-      if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 6.2.0; then
-        LOCAL_NVM_IS_6_2_OR_ABOVE=1
+    local NVM_LOCAL_IS_6_OR_ABOVE
+    NVM_LOCAL_IS_6_OR_ABOVE=0
+    local NVM_LOCAL_IS_6_2_OR_ABOVE
+    NVM_LOCAL_IS_6_2_OR_ABOVE=0
+    if [ ${NVM_LOCAL_IS_5_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 6.0.0; then
+      NVM_LOCAL_IS_6_OR_ABOVE=1
+      if nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 6.2.0; then
+        NVM_LOCAL_IS_6_2_OR_ABOVE=1
       fi
     fi
 
-    local LOCAL_NVM_IS_9_OR_ABOVE
-    LOCAL_NVM_IS_9_OR_ABOVE=0
-    local LOCAL_NVM_IS_9_3_OR_ABOVE
-    LOCAL_NVM_IS_9_3_OR_ABOVE=0
-    if [ ${LOCAL_NVM_IS_6_2_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 9.0.0; then
-      LOCAL_NVM_IS_9_OR_ABOVE=1
-      if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 9.3.0; then
-        LOCAL_NVM_IS_9_3_OR_ABOVE=1
+    local NVM_LOCAL_IS_9_OR_ABOVE
+    NVM_LOCAL_IS_9_OR_ABOVE=0
+    local NVM_LOCAL_IS_9_3_OR_ABOVE
+    NVM_LOCAL_IS_9_3_OR_ABOVE=0
+    if [ ${NVM_LOCAL_IS_6_2_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 9.0.0; then
+      NVM_LOCAL_IS_9_OR_ABOVE=1
+      if nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 9.3.0; then
+        NVM_LOCAL_IS_9_3_OR_ABOVE=1
       fi
     fi
 
-    local LOCAL_NVM_IS_10_OR_ABOVE
-    LOCAL_NVM_IS_10_OR_ABOVE=0
-    if [ ${LOCAL_NVM_IS_9_3_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 10.0.0; then
-      LOCAL_NVM_IS_10_OR_ABOVE=1
+    local NVM_LOCAL_IS_10_OR_ABOVE
+    NVM_LOCAL_IS_10_OR_ABOVE=0
+    if [ ${NVM_LOCAL_IS_9_3_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 10.0.0; then
+      NVM_LOCAL_IS_10_OR_ABOVE=1
     fi
-    local LOCAL_NVM_IS_12_LTS_OR_ABOVE
-    LOCAL_NVM_IS_12_LTS_OR_ABOVE=0
-    if [ ${LOCAL_NVM_IS_10_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 12.13.0; then
-      LOCAL_NVM_IS_12_LTS_OR_ABOVE=1
+    local NVM_LOCAL_IS_12_LTS_OR_ABOVE
+    NVM_LOCAL_IS_12_LTS_OR_ABOVE=0
+    if [ ${NVM_LOCAL_IS_10_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 12.13.0; then
+      NVM_LOCAL_IS_12_LTS_OR_ABOVE=1
     fi
-    local LOCAL_NVM_IS_13_OR_ABOVE
-    LOCAL_NVM_IS_13_OR_ABOVE=0
-    if [ ${LOCAL_NVM_IS_12_LTS_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 13.0.0; then
-      LOCAL_NVM_IS_13_OR_ABOVE=1
+    local NVM_LOCAL_IS_13_OR_ABOVE
+    NVM_LOCAL_IS_13_OR_ABOVE=0
+    if [ ${NVM_LOCAL_IS_12_LTS_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 13.0.0; then
+      NVM_LOCAL_IS_13_OR_ABOVE=1
     fi
-    local LOCAL_NVM_IS_14_LTS_OR_ABOVE
-    LOCAL_NVM_IS_14_LTS_OR_ABOVE=0
-    if [ ${LOCAL_NVM_IS_13_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 14.15.0; then
-      LOCAL_NVM_IS_14_LTS_OR_ABOVE=1
+    local NVM_LOCAL_IS_14_LTS_OR_ABOVE
+    NVM_LOCAL_IS_14_LTS_OR_ABOVE=0
+    if [ ${NVM_LOCAL_IS_13_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 14.15.0; then
+      NVM_LOCAL_IS_14_LTS_OR_ABOVE=1
     fi
-    local LOCAL_NVM_IS_15_OR_ABOVE
-    LOCAL_NVM_IS_15_OR_ABOVE=0
-    if [ ${LOCAL_NVM_IS_14_LTS_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 15.0.0; then
-      LOCAL_NVM_IS_15_OR_ABOVE=1
+    local NVM_LOCAL_IS_15_OR_ABOVE
+    NVM_LOCAL_IS_15_OR_ABOVE=0
+    if [ ${NVM_LOCAL_IS_14_LTS_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 15.0.0; then
+      NVM_LOCAL_IS_15_OR_ABOVE=1
     fi
-    local LOCAL_NVM_IS_16_OR_ABOVE
-    LOCAL_NVM_IS_16_OR_ABOVE=0
-    if [ ${LOCAL_NVM_IS_15_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" 16.0.0; then
-      LOCAL_NVM_IS_16_OR_ABOVE=1
+    local NVM_LOCAL_IS_16_OR_ABOVE
+    NVM_LOCAL_IS_16_OR_ABOVE=0
+    if [ ${NVM_LOCAL_IS_15_OR_ABOVE} -eq 1 ] && nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" 16.0.0; then
+      NVM_LOCAL_IS_16_OR_ABOVE=1
     fi
 
-    if [ ${LOCAL_NVM_IS_4_4_OR_BELOW} -eq 1 ] || {
-      [ ${LOCAL_NVM_IS_5_OR_ABOVE} -eq 1 ] && nvm_version_greater 5.10.0 "${LOCAL_NVM_NODE_VERSION}"; \
+    if [ ${NVM_LOCAL_IS_4_4_OR_BELOW} -eq 1 ] || {
+      [ ${NVM_LOCAL_IS_5_OR_ABOVE} -eq 1 ] && nvm_version_greater 5.10.0 "${NVM_LOCAL_NODE_VERSION}"; \
     }; then
       nvm_echo '* `npm` `v5.3.x` is the last version that works on `node` 4.x versions below v4.4, or 5.x versions below v5.10, due to `Buffer.alloc`'
-      ${LOCAL_NVM_TOOL_NPM} install -g npm@5.3
-    elif [ ${LOCAL_NVM_IS_4_4_OR_BELOW} -eq 0 ] && nvm_version_greater 4.7.0 "${LOCAL_NVM_NODE_VERSION}"; then
+      ${NVM_LOCAL_TOOL_NPM} install -g npm@5.3
+    elif [ ${NVM_LOCAL_IS_4_4_OR_BELOW} -eq 0 ] && nvm_version_greater 4.7.0 "${NVM_LOCAL_NODE_VERSION}"; then
       nvm_echo '* `npm` `v5.4.1` is the last version that works on `node` `v4.5` and `v4.6`'
-      ${LOCAL_NVM_TOOL_NPM} install -g npm@5.4.1
-    elif [ ${LOCAL_NVM_IS_6_OR_ABOVE} -eq 0 ]; then
+      ${NVM_LOCAL_TOOL_NPM} install -g npm@5.4.1
+    elif [ ${NVM_LOCAL_IS_6_OR_ABOVE} -eq 0 ]; then
       nvm_echo '* `npm` `v5.x` is the last version that works on `node` below `v6.0.0`'
-      ${LOCAL_NVM_TOOL_NPM} install -g npm@5
+      ${NVM_LOCAL_TOOL_NPM} install -g npm@5
     elif \
-      { [ ${LOCAL_NVM_IS_6_OR_ABOVE} -eq 1 ] && [ ${LOCAL_NVM_IS_6_2_OR_ABOVE} -eq 0 ]; } \
-      || { [ ${LOCAL_NVM_IS_9_OR_ABOVE} -eq 1 ] && [ ${LOCAL_NVM_IS_9_3_OR_ABOVE} -eq 0 ]; } \
+      { [ ${NVM_LOCAL_IS_6_OR_ABOVE} -eq 1 ] && [ ${NVM_LOCAL_IS_6_2_OR_ABOVE} -eq 0 ]; } \
+      || { [ ${NVM_LOCAL_IS_9_OR_ABOVE} -eq 1 ] && [ ${NVM_LOCAL_IS_9_3_OR_ABOVE} -eq 0 ]; } \
     ; then
       nvm_echo '* `npm` `v6.9` is the last version that works on `node` `v6.0.x`, `v6.1.x`, `v9.0.x`, `v9.1.x`, or `v9.2.x`'
-      ${LOCAL_NVM_TOOL_NPM} install -g npm@6.9
-    elif [ ${LOCAL_NVM_IS_10_OR_ABOVE} -eq 0 ]; then
+      ${NVM_LOCAL_TOOL_NPM} install -g npm@6.9
+    elif [ ${NVM_LOCAL_IS_10_OR_ABOVE} -eq 0 ]; then
       nvm_echo '* `npm` `v6.x` is the last version that works on `node` below `v10.0.0`'
-      ${LOCAL_NVM_TOOL_NPM} install -g npm@6
+      ${NVM_LOCAL_TOOL_NPM} install -g npm@6
     elif \
-      [ ${LOCAL_NVM_IS_12_LTS_OR_ABOVE} -eq 0 ] \
-      || { [ ${LOCAL_NVM_IS_13_OR_ABOVE} -eq 1 ] && [ ${LOCAL_NVM_IS_14_LTS_OR_ABOVE} -eq 0 ]; } \
-      || { [ ${LOCAL_NVM_IS_15_OR_ABOVE} -eq 1 ] && [ ${LOCAL_NVM_IS_16_OR_ABOVE} -eq 0 ]; } \
+      [ ${NVM_LOCAL_IS_12_LTS_OR_ABOVE} -eq 0 ] \
+      || { [ ${NVM_LOCAL_IS_13_OR_ABOVE} -eq 1 ] && [ ${NVM_LOCAL_IS_14_LTS_OR_ABOVE} -eq 0 ]; } \
+      || { [ ${NVM_LOCAL_IS_15_OR_ABOVE} -eq 1 ] && [ ${NVM_LOCAL_IS_16_OR_ABOVE} -eq 0 ]; } \
     ; then
       nvm_echo '* `npm` `v7.x` is the last version that works on `node` `v13`, `v15`, below `v12.13`, or `v14.0` - `v14.15`'
-      ${LOCAL_NVM_TOOL_NPM} install -g npm@7
+      ${NVM_LOCAL_TOOL_NPM} install -g npm@7
     else
       nvm_echo '* Installing latest `npm`; if this does not work on your node version, please report a bug!'
-      ${LOCAL_NVM_TOOL_NPM} install -g npm
+      ${NVM_LOCAL_TOOL_NPM} install -g npm
     fi
   fi
   nvm_echo "* npm upgraded to: v$(npm --version 2>/dev/null)"
@@ -360,75 +360,75 @@ fi
 unset NVM_SCRIPT_SOURCE 2>/dev/null
 
 nvm_tree_contains_path() {
-  local LOCAL_NVM_TREE
-  LOCAL_NVM_TREE="${1-}"
-  local LOCAL_NVM_NODE_PATH
-  LOCAL_NVM_NODE_PATH="${2-}"
+  local NVM_LOCAL_TREE
+  NVM_LOCAL_TREE="${1-}"
+  local NVM_LOCAL_NODE_PATH
+  NVM_LOCAL_NODE_PATH="${2-}"
 
-  if [ "@${LOCAL_NVM_TREE}@" = "@@" ] || [ "@${LOCAL_NVM_NODE_PATH}@" = "@@" ]; then
+  if [ "@${NVM_LOCAL_TREE}@" = "@@" ] || [ "@${NVM_LOCAL_NODE_PATH}@" = "@@" ]; then
     nvm_err "both the tree and the node path are required"
     return 2
   fi
 
-  local LOCAL_NVM_PREVIOUS_PATHDIR
-  LOCAL_NVM_PREVIOUS_PATHDIR="${LOCAL_NVM_NODE_PATH}"
-  local LOCAL_NVM_PATHDIR
-  LOCAL_NVM_PATHDIR=$(dirname "${LOCAL_NVM_PREVIOUS_PATHDIR}")
-  while [ "${LOCAL_NVM_PATHDIR}" != '' ] && [ "${LOCAL_NVM_PATHDIR}" != '.' ] && [ "${LOCAL_NVM_PATHDIR}" != '/' ] &&
-      [ "${LOCAL_NVM_PATHDIR}" != "${LOCAL_NVM_TREE}" ] && [ "${LOCAL_NVM_PATHDIR}" != "${LOCAL_NVM_PREVIOUS_PATHDIR}" ]; do
-    LOCAL_NVM_PREVIOUS_PATHDIR="${LOCAL_NVM_PATHDIR}"
-    LOCAL_NVM_PATHDIR=$(dirname "${LOCAL_NVM_PREVIOUS_PATHDIR}")
+  local NVM_LOCAL_PREVIOUS_PATHDIR
+  NVM_LOCAL_PREVIOUS_PATHDIR="${NVM_LOCAL_NODE_PATH}"
+  local NVM_LOCAL_PATHDIR
+  NVM_LOCAL_PATHDIR=$(dirname "${NVM_LOCAL_PREVIOUS_PATHDIR}")
+  while [ "${NVM_LOCAL_PATHDIR}" != '' ] && [ "${NVM_LOCAL_PATHDIR}" != '.' ] && [ "${NVM_LOCAL_PATHDIR}" != '/' ] &&
+      [ "${NVM_LOCAL_PATHDIR}" != "${NVM_LOCAL_TREE}" ] && [ "${NVM_LOCAL_PATHDIR}" != "${NVM_LOCAL_PREVIOUS_PATHDIR}" ]; do
+    NVM_LOCAL_PREVIOUS_PATHDIR="${NVM_LOCAL_PATHDIR}"
+    NVM_LOCAL_PATHDIR=$(dirname "${NVM_LOCAL_PREVIOUS_PATHDIR}")
   done
-  [ "${LOCAL_NVM_PATHDIR}" = "${LOCAL_NVM_TREE}" ]
+  [ "${NVM_LOCAL_PATHDIR}" = "${NVM_LOCAL_TREE}" ]
 }
 
 nvm_find_project_dir() {
-  local LOCAL_NVM_PATH
-  LOCAL_NVM_PATH="${PWD}"
-  while [ "${LOCAL_NVM_PATH}" != "" ] && [ ! -f "${LOCAL_NVM_PATH}/package.json" ] && [ ! -d "${LOCAL_NVM_PATH}/node_modules" ]; do
-    LOCAL_NVM_PATH=${LOCAL_NVM_PATH%/*}
+  local NVM_LOCAL_PATH
+  NVM_LOCAL_PATH="${PWD}"
+  while [ "${NVM_LOCAL_PATH}" != "" ] && [ ! -f "${NVM_LOCAL_PATH}/package.json" ] && [ ! -d "${NVM_LOCAL_PATH}/node_modules" ]; do
+    NVM_LOCAL_PATH=${NVM_LOCAL_PATH%/*}
   done
-  nvm_echo "${LOCAL_NVM_PATH}"
+  nvm_echo "${NVM_LOCAL_PATH}"
 }
 
 # Traverse up in directory tree to find containing folder
 nvm_find_up() {
-  local LOCAL_NVM_PATH
-  LOCAL_NVM_PATH="${PWD}"
-  while [ "${LOCAL_NVM_PATH}" != "" ] && [ ! -f "${LOCAL_NVM_PATH}/${1-}" ]; do
-    LOCAL_NVM_PATH=${LOCAL_NVM_PATH%/*}
+  local NVM_LOCAL_PATH
+  NVM_LOCAL_PATH="${PWD}"
+  while [ "${NVM_LOCAL_PATH}" != "" ] && [ ! -f "${NVM_LOCAL_PATH}/${1-}" ]; do
+    NVM_LOCAL_PATH=${NVM_LOCAL_PATH%/*}
   done
-  nvm_echo "${LOCAL_NVM_PATH}"
+  nvm_echo "${NVM_LOCAL_PATH}"
 }
 
 nvm_find_nvmrc() {
-  local LOCAL_NVM_DIR
-  LOCAL_NVM_DIR="$(nvm_find_up '.nvmrc')"
-  if [ -e "${LOCAL_NVM_DIR}/.nvmrc" ]; then
-    nvm_echo "${LOCAL_NVM_DIR}/.nvmrc"
+  local NVM_LOCAL_DIR
+  NVM_LOCAL_DIR="$(nvm_find_up '.nvmrc')"
+  if [ -e "${NVM_LOCAL_DIR}/.nvmrc" ]; then
+    nvm_echo "${NVM_LOCAL_DIR}/.nvmrc"
   fi
 }
 
 # Obtain nvm version from rc file
 nvm_rc_version() {
   export NVM_RC_VERSION=''
-  local LOCAL_NVM_RC_PATH
-  LOCAL_NVM_RC_PATH="$(nvm_find_nvmrc)"
-  if [ ! -e "${LOCAL_NVM_RC_PATH}" ]; then
-    if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+  local NVM_LOCAL_RC_PATH
+  NVM_LOCAL_RC_PATH="$(nvm_find_nvmrc)"
+  if [ ! -e "${NVM_LOCAL_RC_PATH}" ]; then
+    if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
       nvm_err "No .nvmrc file found"
     fi
     return 1
   fi
-  NVM_RC_VERSION="$(command head -n 1 "${LOCAL_NVM_RC_PATH}" | command tr -d '\r')" || command printf ''
+  NVM_RC_VERSION="$(command head -n 1 "${NVM_LOCAL_RC_PATH}" | command tr -d '\r')" || command printf ''
   if [ -z "${NVM_RC_VERSION}" ]; then
-    if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
-      nvm_err "Warning: empty .nvmrc file found at \"${LOCAL_NVM_RC_PATH}\""
+    if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
+      nvm_err "Warning: empty .nvmrc file found at \"${NVM_LOCAL_RC_PATH}\""
     fi
     return 2
   fi
-  if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
-    nvm_echo "Found '${LOCAL_NVM_RC_PATH}' with version <${NVM_RC_VERSION}>"
+  if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
+    nvm_echo "Found '${NVM_LOCAL_RC_PATH}' with version <${NVM_RC_VERSION}>"
   fi
 }
 
@@ -470,13 +470,13 @@ nvm_version_greater_than_or_equal_to() {
 }
 
 nvm_version_dir() {
-  local LOCAL_NVM_WHICH_DIR
-  LOCAL_NVM_WHICH_DIR="${1-}"
-  if [ -z "${LOCAL_NVM_WHICH_DIR}" ] || [ "${LOCAL_NVM_WHICH_DIR}" = "new" ]; then
+  local NVM_LOCAL_WHICH_DIR
+  NVM_LOCAL_WHICH_DIR="${1-}"
+  if [ -z "${NVM_LOCAL_WHICH_DIR}" ] || [ "${NVM_LOCAL_WHICH_DIR}" = "new" ]; then
     nvm_echo "${NVM_DIR}/versions/node"
-  elif [ "_${LOCAL_NVM_WHICH_DIR}" = "_iojs" ]; then
+  elif [ "_${NVM_LOCAL_WHICH_DIR}" = "_iojs" ]; then
     nvm_echo "${NVM_DIR}/versions/io.js"
-  elif [ "_${LOCAL_NVM_WHICH_DIR}" = "_old" ]; then
+  elif [ "_${NVM_LOCAL_WHICH_DIR}" = "_old" ]; then
     nvm_echo "${NVM_DIR}"
   else
     nvm_err 'unknown version dir'
@@ -489,177 +489,177 @@ nvm_alias_path() {
 }
 
 nvm_version_path() {
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="${1-}"
-  if [ -z "${LOCAL_NVM_VERSION}" ]; then
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="${1-}"
+  if [ -z "${NVM_LOCAL_VERSION}" ]; then
     nvm_err 'version is required'
     return 3
-  elif nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
-    nvm_echo "$(nvm_version_dir iojs)/$(nvm_strip_iojs_prefix "${LOCAL_NVM_VERSION}")"
-  elif nvm_version_greater 0.12.0 "${LOCAL_NVM_VERSION}"; then
-    nvm_echo "$(nvm_version_dir old)/${LOCAL_NVM_VERSION}"
+  elif nvm_is_iojs_version "${NVM_LOCAL_VERSION}"; then
+    nvm_echo "$(nvm_version_dir iojs)/$(nvm_strip_iojs_prefix "${NVM_LOCAL_VERSION}")"
+  elif nvm_version_greater 0.12.0 "${NVM_LOCAL_VERSION}"; then
+    nvm_echo "$(nvm_version_dir old)/${NVM_LOCAL_VERSION}"
   else
-    nvm_echo "$(nvm_version_dir new)/${LOCAL_NVM_VERSION}"
+    nvm_echo "$(nvm_version_dir new)/${NVM_LOCAL_VERSION}"
   fi
 }
 
 nvm_ensure_version_installed() {
-  local LOCAL_NVM_PROVIDED_VERSION
-  LOCAL_NVM_PROVIDED_VERSION="${1-}"
-  if [ "${LOCAL_NVM_PROVIDED_VERSION}" = 'system' ]; then
+  local NVM_LOCAL_PROVIDED_VERSION
+  NVM_LOCAL_PROVIDED_VERSION="${1-}"
+  if [ "${NVM_LOCAL_PROVIDED_VERSION}" = 'system' ]; then
     if nvm_has_system_iojs || nvm_has_system_node; then
       return 0
     fi
     nvm_err "N/A: no system version of node/io.js is installed."
     return 1
   fi
-  local LOCAL_NVM_VERSION
-  local LOCAL_NVM_EXIT_CODE
-  LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")"
-  LOCAL_NVM_EXIT_CODE="$?"
-  if [ "${LOCAL_NVM_EXIT_CODE}" != "0" ] || ! nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
-    if LOCAL_NVM_ALIAS_VERSION="$(nvm_resolve_alias "${LOCAL_NVM_PROVIDED_VERSION}")"; then
-      nvm_err "N/A: version \"${LOCAL_NVM_PROVIDED_VERSION} -> ${LOCAL_NVM_ALIAS_VERSION}\" is not yet installed."
+  local NVM_LOCAL_VERSION
+  local NVM_LOCAL_EXIT_CODE
+  NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_PROVIDED_VERSION}")"
+  NVM_LOCAL_EXIT_CODE="$?"
+  if [ "${NVM_LOCAL_EXIT_CODE}" != "0" ] || ! nvm_is_version_installed "${NVM_LOCAL_VERSION}"; then
+    if NVM_LOCAL_ALIAS_VERSION="$(nvm_resolve_alias "${NVM_LOCAL_PROVIDED_VERSION}")"; then
+      nvm_err "N/A: version \"${NVM_LOCAL_PROVIDED_VERSION} -> ${NVM_LOCAL_ALIAS_VERSION}\" is not yet installed."
     else
-      local LOCAL_NVM_PREFIXED_VERSION
-      LOCAL_NVM_PREFIXED_VERSION="$(nvm_ensure_version_prefix "${LOCAL_NVM_PROVIDED_VERSION}")"
-      nvm_err "N/A: version \"${LOCAL_NVM_PREFIXED_VERSION:-${LOCAL_NVM_PROVIDED_VERSION}}\" is not yet installed."
+      local NVM_LOCAL_PREFIXED_VERSION
+      NVM_LOCAL_PREFIXED_VERSION="$(nvm_ensure_version_prefix "${NVM_LOCAL_PROVIDED_VERSION}")"
+      nvm_err "N/A: version \"${NVM_LOCAL_PREFIXED_VERSION:-${NVM_LOCAL_PROVIDED_VERSION}}\" is not yet installed."
     fi
     nvm_err ""
-    nvm_err "You need to run \"nvm install ${LOCAL_NVM_PROVIDED_VERSION}\" to install it before using it."
+    nvm_err "You need to run \"nvm install ${NVM_LOCAL_PROVIDED_VERSION}\" to install it before using it."
     return 1
   fi
 }
 
 # Expand a version using the version cache
 nvm_version() {
-  local LOCAL_NVM_PATTERN
-  LOCAL_NVM_PATTERN="${1-}"
-  local LOCAL_NVM_VERSION
+  local NVM_LOCAL_PATTERN
+  NVM_LOCAL_PATTERN="${1-}"
+  local NVM_LOCAL_VERSION
   # The default version is the current one
-  if [ -z "${LOCAL_NVM_PATTERN}" ]; then
-    LOCAL_NVM_PATTERN='current'
+  if [ -z "${NVM_LOCAL_PATTERN}" ]; then
+    NVM_LOCAL_PATTERN='current'
   fi
 
-  if [ "${LOCAL_NVM_PATTERN}" = "current" ]; then
+  if [ "${NVM_LOCAL_PATTERN}" = "current" ]; then
     nvm_ls_current
     return $?
   fi
 
-  local LOCAL_NVM_NODE_PREFIX
-  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
-  case "_${LOCAL_NVM_PATTERN}" in
-    "_${LOCAL_NVM_NODE_PREFIX}" | "_${LOCAL_NVM_NODE_PREFIX}-")
-      LOCAL_NVM_PATTERN="stable"
+  local NVM_LOCAL_NODE_PREFIX
+  NVM_LOCAL_NODE_PREFIX="$(nvm_node_prefix)"
+  case "_${NVM_LOCAL_PATTERN}" in
+    "_${NVM_LOCAL_NODE_PREFIX}" | "_${NVM_LOCAL_NODE_PREFIX}-")
+      NVM_LOCAL_PATTERN="stable"
     ;;
   esac
-  LOCAL_NVM_VERSION="$(nvm_ls "${LOCAL_NVM_PATTERN}" | command tail -1)"
-  if [ -z "${LOCAL_NVM_VERSION}" ] || [ "_${LOCAL_NVM_VERSION}" = "_N/A" ]; then
+  NVM_LOCAL_VERSION="$(nvm_ls "${NVM_LOCAL_PATTERN}" | command tail -1)"
+  if [ -z "${NVM_LOCAL_VERSION}" ] || [ "_${NVM_LOCAL_VERSION}" = "_N/A" ]; then
     nvm_echo "N/A"
     return 3
   fi
-  nvm_echo "${LOCAL_NVM_VERSION}"
+  nvm_echo "${NVM_LOCAL_VERSION}"
 }
 
 nvm_remote_version() {
-  local LOCAL_NVM_PATTERN
-  LOCAL_NVM_PATTERN="${1-}"
-  local LOCAL_NVM_VERSION
-  if nvm_validate_implicit_alias "${LOCAL_NVM_PATTERN}" 2>/dev/null; then
-    case "${LOCAL_NVM_PATTERN}" in
+  local NVM_LOCAL_PATTERN
+  NVM_LOCAL_PATTERN="${1-}"
+  local NVM_LOCAL_VERSION
+  if nvm_validate_implicit_alias "${NVM_LOCAL_PATTERN}" 2>/dev/null; then
+    case "${NVM_LOCAL_PATTERN}" in
       "$(nvm_iojs_prefix)")
-        LOCAL_NVM_VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote_iojs | command tail -1)" &&:
+        NVM_LOCAL_VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote_iojs | command tail -1)" &&:
       ;;
       *)
-        LOCAL_NVM_VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${LOCAL_NVM_PATTERN}")" &&:
+        NVM_LOCAL_VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${NVM_LOCAL_PATTERN}")" &&:
       ;;
     esac
   else
-    LOCAL_NVM_VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_remote_versions "${LOCAL_NVM_PATTERN}" | command tail -1)"
+    NVM_LOCAL_VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_remote_versions "${NVM_LOCAL_PATTERN}" | command tail -1)"
   fi
   if [ -n "${NVM_VERSION_ONLY-}" ]; then
     command awk 'BEGIN {
       n = split(ARGV[1], a);
       print a[1]
-    }' "${LOCAL_NVM_VERSION}"
+    }' "${NVM_LOCAL_VERSION}"
   else
-    nvm_echo "${LOCAL_NVM_VERSION}"
+    nvm_echo "${NVM_LOCAL_VERSION}"
   fi
-  if [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
+  if [ "${NVM_LOCAL_VERSION}" = 'N/A' ]; then
     return 3
   fi
 }
 
 nvm_remote_versions() {
-  local LOCAL_NVM_IOJS_PREFIX
-  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local LOCAL_NVM_NODE_PREFIX
-  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
+  local NVM_LOCAL_IOJS_PREFIX
+  NVM_LOCAL_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local NVM_LOCAL_NODE_PREFIX
+  NVM_LOCAL_NODE_PREFIX="$(nvm_node_prefix)"
 
-  local LOCAL_NVM_PATTERN
-  LOCAL_NVM_PATTERN="${1-}"
+  local NVM_LOCAL_PATTERN
+  NVM_LOCAL_PATTERN="${1-}"
 
-  local LOCAL_NVM_FLAVOR
+  local NVM_LOCAL_FLAVOR
   if [ -n "${NVM_LTS-}" ]; then
-    LOCAL_NVM_FLAVOR="${LOCAL_NVM_NODE_PREFIX}"
+    NVM_LOCAL_FLAVOR="${NVM_LOCAL_NODE_PREFIX}"
   fi
 
-  case "${LOCAL_NVM_PATTERN}" in
-    "${LOCAL_NVM_IOJS_PREFIX}" | "io.js")
-      LOCAL_NVM_FLAVOR="${LOCAL_NVM_IOJS_PREFIX}"
-      unset LOCAL_NVM_PATTERN
+  case "${NVM_LOCAL_PATTERN}" in
+    "${NVM_LOCAL_IOJS_PREFIX}" | "io.js")
+      NVM_LOCAL_FLAVOR="${NVM_LOCAL_IOJS_PREFIX}"
+      unset NVM_LOCAL_PATTERN
     ;;
-    "${LOCAL_NVM_NODE_PREFIX}")
-      LOCAL_NVM_FLAVOR="${LOCAL_NVM_NODE_PREFIX}"
-      unset LOCAL_NVM_PATTERN
+    "${NVM_LOCAL_NODE_PREFIX}")
+      NVM_LOCAL_FLAVOR="${NVM_LOCAL_NODE_PREFIX}"
+      unset NVM_LOCAL_PATTERN
     ;;
   esac
 
-  if nvm_validate_implicit_alias "${LOCAL_NVM_PATTERN-}" 2>/dev/null; then
+  if nvm_validate_implicit_alias "${NVM_LOCAL_PATTERN-}" 2>/dev/null; then
     nvm_err 'Implicit aliases are not supported in nvm_remote_versions.'
     return 1
   fi
 
-  local LOCAL_NVM_LS_REMOTE_EXIT_CODE
-  LOCAL_NVM_LS_REMOTE_EXIT_CODE=0
-  local LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT
-  LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT=''
-  local LOCAL_NVM_LS_REMOTE_POST_MERGED_OUTPUT
-  LOCAL_NVM_LS_REMOTE_POST_MERGED_OUTPUT=''
-  if [ -z "${LOCAL_NVM_FLAVOR-}" ] || [ "${LOCAL_NVM_FLAVOR-}" = "${LOCAL_NVM_NODE_PREFIX}" ]; then
-    local LOCAL_NVM_LS_REMOTE_OUTPUT
+  local NVM_LOCAL_LS_REMOTE_EXIT_CODE
+  NVM_LOCAL_LS_REMOTE_EXIT_CODE=0
+  local NVM_LOCAL_LS_REMOTE_PRE_MERGED_OUTPUT
+  NVM_LOCAL_LS_REMOTE_PRE_MERGED_OUTPUT=''
+  local NVM_LOCAL_LS_REMOTE_POST_MERGED_OUTPUT
+  NVM_LOCAL_LS_REMOTE_POST_MERGED_OUTPUT=''
+  if [ -z "${NVM_LOCAL_FLAVOR-}" ] || [ "${NVM_LOCAL_FLAVOR-}" = "${NVM_LOCAL_NODE_PREFIX}" ]; then
+    local NVM_LOCAL_LS_REMOTE_OUTPUT
     # extra space is needed here to avoid weird behavior when `nvm_ls_remote` ends in a `*`
-    LOCAL_NVM_LS_REMOTE_OUTPUT="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${LOCAL_NVM_PATTERN-}") " &&:
-    LOCAL_NVM_LS_REMOTE_EXIT_CODE=$?
+    NVM_LOCAL_LS_REMOTE_OUTPUT="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${NVM_LOCAL_PATTERN-}") " &&:
+    NVM_LOCAL_LS_REMOTE_EXIT_CODE=$?
     # split output into two
-    LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT="${LOCAL_NVM_LS_REMOTE_OUTPUT%%v4\.0\.0*}"
-    LOCAL_NVM_LS_REMOTE_POST_MERGED_OUTPUT="${LOCAL_NVM_LS_REMOTE_OUTPUT#"${LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT}"}"
+    NVM_LOCAL_LS_REMOTE_PRE_MERGED_OUTPUT="${NVM_LOCAL_LS_REMOTE_OUTPUT%%v4\.0\.0*}"
+    NVM_LOCAL_LS_REMOTE_POST_MERGED_OUTPUT="${NVM_LOCAL_LS_REMOTE_OUTPUT#"${NVM_LOCAL_LS_REMOTE_PRE_MERGED_OUTPUT}"}"
   fi
 
-  local LOCAL_NVM_LS_REMOTE_IOJS_EXIT_CODE
-  LOCAL_NVM_LS_REMOTE_IOJS_EXIT_CODE=0
-  local LOCAL_NVM_LS_REMOTE_IOJS_OUTPUT
-  LOCAL_NVM_LS_REMOTE_IOJS_OUTPUT=''
+  local NVM_LOCAL_LS_REMOTE_IOJS_EXIT_CODE
+  NVM_LOCAL_LS_REMOTE_IOJS_EXIT_CODE=0
+  local NVM_LOCAL_LS_REMOTE_IOJS_OUTPUT
+  NVM_LOCAL_LS_REMOTE_IOJS_OUTPUT=''
   if [ -z "${NVM_LTS-}" ] && {
-    [ -z "${LOCAL_NVM_FLAVOR-}" ] || [ "${LOCAL_NVM_FLAVOR-}" = "${LOCAL_NVM_IOJS_PREFIX}" ];
+    [ -z "${NVM_LOCAL_FLAVOR-}" ] || [ "${NVM_LOCAL_FLAVOR-}" = "${NVM_LOCAL_IOJS_PREFIX}" ];
   }; then
-    LOCAL_NVM_LS_REMOTE_IOJS_OUTPUT=$(nvm_ls_remote_iojs "${LOCAL_NVM_PATTERN-}") &&:
-    LOCAL_NVM_LS_REMOTE_IOJS_EXIT_CODE=$?
+    NVM_LOCAL_LS_REMOTE_IOJS_OUTPUT=$(nvm_ls_remote_iojs "${NVM_LOCAL_PATTERN-}") &&:
+    NVM_LOCAL_LS_REMOTE_IOJS_EXIT_CODE=$?
   fi
 
   # the `sed` removes both blank lines, and only-whitespace lines (see "weird behavior" ~19 lines up)
-  local LOCAL_NVM_VERSIONS
-  LOCAL_NVM_VERSIONS="$(nvm_echo "${LOCAL_NVM_LS_REMOTE_PRE_MERGED_OUTPUT}
-${LOCAL_NVM_LS_REMOTE_IOJS_OUTPUT}
-${LOCAL_NVM_LS_REMOTE_POST_MERGED_OUTPUT}" | nvm_grep -v "N/A" | command sed '/^ *$/d')"
+  local NVM_LOCAL_VERSIONS
+  NVM_LOCAL_VERSIONS="$(nvm_echo "${NVM_LOCAL_LS_REMOTE_PRE_MERGED_OUTPUT}
+${NVM_LOCAL_LS_REMOTE_IOJS_OUTPUT}
+${NVM_LOCAL_LS_REMOTE_POST_MERGED_OUTPUT}" | nvm_grep -v "N/A" | command sed '/^ *$/d')"
 
-  if [ -z "${LOCAL_NVM_VERSIONS}" ]; then
+  if [ -z "${NVM_LOCAL_VERSIONS}" ]; then
     nvm_echo 'N/A'
     return 3
   fi
   # the `sed` is to remove trailing whitespaces (see "weird behavior" ~25 lines up)
-  nvm_echo "${LOCAL_NVM_VERSIONS}" | command sed 's/ *$//g'
-  return ${LOCAL_NVM_LS_REMOTE_EXIT_CODE} || ${LOCAL_NVM_LS_REMOTE_IOJS_EXIT_CODE}
+  nvm_echo "${NVM_LOCAL_VERSIONS}" | command sed 's/ *$//g'
+  return ${NVM_LOCAL_LS_REMOTE_EXIT_CODE} || ${NVM_LOCAL_LS_REMOTE_IOJS_EXIT_CODE}
 }
 
 nvm_is_valid_version() {
@@ -672,9 +672,9 @@ nvm_is_valid_version() {
       return 0
     ;;
     *)
-      local LOCAL_NVM_VERSION
-      LOCAL_NVM_VERSION="$(nvm_strip_iojs_prefix "${1-}")"
-      nvm_version_greater_than_or_equal_to "${LOCAL_NVM_VERSION}" 0
+      local NVM_LOCAL_VERSION
+      NVM_LOCAL_VERSION="$(nvm_strip_iojs_prefix "${1-}")"
+      nvm_version_greater_than_or_equal_to "${NVM_LOCAL_VERSION}" 0
     ;;
   esac
 }
@@ -688,64 +688,64 @@ nvm_normalize_version() {
 }
 
 nvm_normalize_lts() {
-  local LOCAL_NVM_LTS
-  LOCAL_NVM_LTS="${1-}"
+  local NVM_LOCAL_LTS
+  NVM_LOCAL_LTS="${1-}"
 
-  if [ "$(expr "${LOCAL_NVM_LTS}" : '^lts/-[1-9][0-9]*$')" -gt 0 ]; then
-    local LOCAL_NVM_N
-    LOCAL_NVM_N="$(echo "${LOCAL_NVM_LTS}" | cut -d '-' -f 2)"
-    LOCAL_NVM_N=$((LOCAL_NVM_N+1))
-    local LOCAL_NVM_ALIAS_DIR
-    LOCAL_NVM_ALIAS_DIR="$(nvm_alias_path)"
-    local LOCAL_NVM_RESULT
-    LOCAL_NVM_RESULT="$(command ls "${LOCAL_NVM_ALIAS_DIR}/lts" | command tail -n "${LOCAL_NVM_N}" | command head -n 1)"
-    if [ "${LOCAL_NVM_RESULT}" != '*' ]; then
-      nvm_echo "lts/${LOCAL_NVM_RESULT}"
+  if [ "$(expr "${NVM_LOCAL_LTS}" : '^lts/-[1-9][0-9]*$')" -gt 0 ]; then
+    local NVM_LOCAL_N
+    NVM_LOCAL_N="$(echo "${NVM_LOCAL_LTS}" | cut -d '-' -f 2)"
+    NVM_LOCAL_N=$((NVM_LOCAL_N+1))
+    local NVM_LOCAL_ALIAS_DIR
+    NVM_LOCAL_ALIAS_DIR="$(nvm_alias_path)"
+    local NVM_LOCAL_RESULT
+    NVM_LOCAL_RESULT="$(command ls "${NVM_LOCAL_ALIAS_DIR}/lts" | command tail -n "${NVM_LOCAL_N}" | command head -n 1)"
+    if [ "${NVM_LOCAL_RESULT}" != '*' ]; then
+      nvm_echo "lts/${NVM_LOCAL_RESULT}"
     else
       nvm_err 'That many LTS releases do not exist yet.'
       return 2
     fi
   else
-    nvm_echo "${LOCAL_NVM_LTS}"
+    nvm_echo "${NVM_LOCAL_LTS}"
   fi
 }
 
 nvm_ensure_version_prefix() {
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="$(nvm_strip_iojs_prefix "${1-}" | command sed -e 's/^\([0-9]\)/v\1/g')"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="$(nvm_strip_iojs_prefix "${1-}" | command sed -e 's/^\([0-9]\)/v\1/g')"
   if nvm_is_iojs_version "${1-}"; then
-    nvm_add_iojs_prefix "${LOCAL_NVM_VERSION}"
+    nvm_add_iojs_prefix "${NVM_LOCAL_VERSION}"
   else
-    nvm_echo "${LOCAL_NVM_VERSION}"
+    nvm_echo "${NVM_LOCAL_VERSION}"
   fi
 }
 
 nvm_format_version() {
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="$(nvm_ensure_version_prefix "${1-}")"
-  local LOCAL_NVM_NUM_GROUPS
-  LOCAL_NVM_NUM_GROUPS="$(nvm_num_version_groups "${LOCAL_NVM_VERSION}")"
-  if [ "${LOCAL_NVM_NUM_GROUPS}" -lt 3 ]; then
-    nvm_format_version "${LOCAL_NVM_VERSION%.}.0"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="$(nvm_ensure_version_prefix "${1-}")"
+  local NVM_LOCAL_NUM_GROUPS
+  NVM_LOCAL_NUM_GROUPS="$(nvm_num_version_groups "${NVM_LOCAL_VERSION}")"
+  if [ "${NVM_LOCAL_NUM_GROUPS}" -lt 3 ]; then
+    nvm_format_version "${NVM_LOCAL_VERSION%.}.0"
   else
-    nvm_echo "${LOCAL_NVM_VERSION}" | command cut -f1-3 -d.
+    nvm_echo "${NVM_LOCAL_VERSION}" | command cut -f1-3 -d.
   fi
 }
 
 nvm_num_version_groups() {
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="${1-}"
-  LOCAL_NVM_VERSION="${LOCAL_NVM_VERSION#v}"
-  LOCAL_NVM_VERSION="${LOCAL_NVM_VERSION%.}"
-  if [ -z "${LOCAL_NVM_VERSION}" ]; then
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="${1-}"
+  NVM_LOCAL_VERSION="${NVM_LOCAL_VERSION#v}"
+  NVM_LOCAL_VERSION="${NVM_LOCAL_VERSION%.}"
+  if [ -z "${NVM_LOCAL_VERSION}" ]; then
     nvm_echo "0"
     return
   fi
-  local LOCAL_NVM_NUM_DOTS
-  LOCAL_NVM_NUM_DOTS=$(nvm_echo "${LOCAL_NVM_VERSION}" | command sed -e 's/[^\.]//g')
-  local LOCAL_NVM_NUM_GROUPS
-  LOCAL_NVM_NUM_GROUPS=".${LOCAL_NVM_NUM_DOTS}" # add extra dot, since it's (n - 1) dots at this point
-  nvm_echo "${#LOCAL_NVM_NUM_GROUPS}"
+  local NVM_LOCAL_NUM_DOTS
+  NVM_LOCAL_NUM_DOTS=$(nvm_echo "${NVM_LOCAL_VERSION}" | command sed -e 's/[^\.]//g')
+  local NVM_LOCAL_NUM_GROUPS
+  NVM_LOCAL_NUM_GROUPS=".${NVM_LOCAL_NUM_DOTS}" # add extra dot, since it's (n - 1) dots at this point
+  nvm_echo "${#NVM_LOCAL_NUM_GROUPS}"
 }
 
 nvm_strip_path() {
@@ -793,22 +793,22 @@ nvm_binary_available() {
 
 nvm_set_colors() {
   if [ "${#1}" -eq 5 ] && nvm_echo "$1" | nvm_grep -E "^[rRgGbBcCyYmMkKeW]{1,}$" 1>/dev/null; then
-    local LOCAL_NVM_INSTALLED_COLOR
-    local LOCAL_NVM_LTS_AND_SYSTEM_COLOR
-    local LOCAL_NVM_CURRENT_COLOR
-    local LOCAL_NVM_NOT_INSTALLED_COLOR
-    local LOCAL_NVM_DEFAULT_COLOR
+    local NVM_LOCAL_INSTALLED_COLOR
+    local NVM_LOCAL_LTS_AND_SYSTEM_COLOR
+    local NVM_LOCAL_CURRENT_COLOR
+    local NVM_LOCAL_NOT_INSTALLED_COLOR
+    local NVM_LOCAL_DEFAULT_COLOR
 
-    LOCAL_NVM_INSTALLED_COLOR="$(echo "$1" | awk '{ print substr($0, 1, 1); }')"
-    LOCAL_NVM_LTS_AND_SYSTEM_COLOR="$(echo "$1" | awk '{ print substr($0, 2, 1); }')"
-    LOCAL_NVM_CURRENT_COLOR="$(echo "$1" | awk '{ print substr($0, 3, 1); }')"
-    LOCAL_NVM_NOT_INSTALLED_COLOR="$(echo "$1" | awk '{ print substr($0, 4, 1); }')"
-    LOCAL_NVM_DEFAULT_COLOR="$(echo "$1" | awk '{ print substr($0, 5, 1); }')"
+    NVM_LOCAL_INSTALLED_COLOR="$(echo "$1" | awk '{ print substr($0, 1, 1); }')"
+    NVM_LOCAL_LTS_AND_SYSTEM_COLOR="$(echo "$1" | awk '{ print substr($0, 2, 1); }')"
+    NVM_LOCAL_CURRENT_COLOR="$(echo "$1" | awk '{ print substr($0, 3, 1); }')"
+    NVM_LOCAL_NOT_INSTALLED_COLOR="$(echo "$1" | awk '{ print substr($0, 4, 1); }')"
+    NVM_LOCAL_DEFAULT_COLOR="$(echo "$1" | awk '{ print substr($0, 5, 1); }')"
     if ! nvm_has_colors; then
-      nvm_echo "Setting colors to: ${LOCAL_NVM_INSTALLED_COLOR} ${LOCAL_NVM_LTS_AND_SYSTEM_COLOR} ${LOCAL_NVM_CURRENT_COLOR} ${LOCAL_NVM_NOT_INSTALLED_COLOR} ${LOCAL_NVM_DEFAULT_COLOR}"
+      nvm_echo "Setting colors to: ${NVM_LOCAL_INSTALLED_COLOR} ${NVM_LOCAL_LTS_AND_SYSTEM_COLOR} ${NVM_LOCAL_CURRENT_COLOR} ${NVM_LOCAL_NOT_INSTALLED_COLOR} ${NVM_LOCAL_DEFAULT_COLOR}"
       nvm_echo "WARNING: Colors may not display because they are not supported in this shell."
     else
-      nvm_echo_with_colors "Setting colors to: \033[$(nvm_print_color_code "${LOCAL_NVM_INSTALLED_COLOR}") ${LOCAL_NVM_INSTALLED_COLOR}\033[$(nvm_print_color_code "${LOCAL_NVM_LTS_AND_SYSTEM_COLOR}") ${LOCAL_NVM_LTS_AND_SYSTEM_COLOR}\033[$(nvm_print_color_code "${LOCAL_NVM_CURRENT_COLOR}") ${LOCAL_NVM_CURRENT_COLOR}\033[$(nvm_print_color_code "${LOCAL_NVM_NOT_INSTALLED_COLOR}") ${LOCAL_NVM_NOT_INSTALLED_COLOR}\033[$(nvm_print_color_code "${LOCAL_NVM_DEFAULT_COLOR}") ${LOCAL_NVM_DEFAULT_COLOR}\033[0m"
+      nvm_echo_with_colors "Setting colors to: \033[$(nvm_print_color_code "${NVM_LOCAL_INSTALLED_COLOR}") ${NVM_LOCAL_INSTALLED_COLOR}\033[$(nvm_print_color_code "${NVM_LOCAL_LTS_AND_SYSTEM_COLOR}") ${NVM_LOCAL_LTS_AND_SYSTEM_COLOR}\033[$(nvm_print_color_code "${NVM_LOCAL_CURRENT_COLOR}") ${NVM_LOCAL_CURRENT_COLOR}\033[$(nvm_print_color_code "${NVM_LOCAL_NOT_INSTALLED_COLOR}") ${NVM_LOCAL_NOT_INSTALLED_COLOR}\033[$(nvm_print_color_code "${NVM_LOCAL_DEFAULT_COLOR}") ${NVM_LOCAL_DEFAULT_COLOR}\033[0m"
     fi
     export NVM_COLORS="$1"
   else
@@ -817,18 +817,18 @@ nvm_set_colors() {
 }
 
 nvm_get_colors() {
-  local LOCAL_NVM_COLOR
-  local LOCAL_NVM_SYS_COLOR
+  local NVM_LOCAL_COLOR
+  local NVM_LOCAL_SYS_COLOR
   if [ -n "${NVM_COLORS-}" ]; then
     case $1 in
-      1) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 1, 1); }')");;
-      2) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 2, 1); }')");;
-      3) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 3, 1); }')");;
-      4) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 4, 1); }')");;
-      5) LOCAL_NVM_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 5, 1); }')");;
+      1) NVM_LOCAL_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 1, 1); }')");;
+      2) NVM_LOCAL_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 2, 1); }')");;
+      3) NVM_LOCAL_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 3, 1); }')");;
+      4) NVM_LOCAL_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 4, 1); }')");;
+      5) NVM_LOCAL_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 5, 1); }')");;
       6)
-        LOCAL_NVM_SYS_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 2, 1); }')")
-        LOCAL_NVM_COLOR=$(nvm_echo "${LOCAL_NVM_SYS_COLOR}" | command tr '0;' '1;')
+        NVM_LOCAL_SYS_COLOR=$(nvm_print_color_code "$(echo "${NVM_COLORS}" | awk '{ print substr($0, 2, 1); }')")
+        NVM_LOCAL_COLOR=$(nvm_echo "${NVM_LOCAL_SYS_COLOR}" | command tr '0;' '1;')
         ;;
       *)
         nvm_err "Invalid color index, ${1-}"
@@ -837,12 +837,12 @@ nvm_get_colors() {
     esac
   else
     case $1 in
-      1) LOCAL_NVM_COLOR='0;34m';;
-      2) LOCAL_NVM_COLOR='0;33m';;
-      3) LOCAL_NVM_COLOR='0;32m';;
-      4) LOCAL_NVM_COLOR='0;31m';;
-      5) LOCAL_NVM_COLOR='0;37m';;
-      6) LOCAL_NVM_COLOR='1;33m';;
+      1) NVM_LOCAL_COLOR='0;34m';;
+      2) NVM_LOCAL_COLOR='0;33m';;
+      3) NVM_LOCAL_COLOR='0;32m';;
+      4) NVM_LOCAL_COLOR='0;31m';;
+      5) NVM_LOCAL_COLOR='0;37m';;
+      6) NVM_LOCAL_COLOR='1;33m';;
       *)
         nvm_err "Invalid color index, ${1-}"
         return 1
@@ -850,7 +850,7 @@ nvm_get_colors() {
     esac
   fi
 
-  echo "${LOCAL_NVM_COLOR}"
+  echo "${NVM_LOCAL_COLOR}"
 }
 
 nvm_print_color_code() {
@@ -878,181 +878,181 @@ nvm_print_color_code() {
 }
 
 nvm_print_formatted_alias() {
-  local LOCAL_NVM_ALIAS
-  LOCAL_NVM_ALIAS="${1-}"
-  local LOCAL_NVM_DEST
-  LOCAL_NVM_DEST="${2-}"
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="${3-}"
-  if [ -z "${LOCAL_NVM_VERSION}" ]; then
-    LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_DEST}")" ||:
+  local NVM_LOCAL_ALIAS
+  NVM_LOCAL_ALIAS="${1-}"
+  local NVM_LOCAL_DEST
+  NVM_LOCAL_DEST="${2-}"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="${3-}"
+  if [ -z "${NVM_LOCAL_VERSION}" ]; then
+    NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_DEST}")" ||:
   fi
 
-  local LOCAL_NVM_INSTALLED_COLOR
-  local LOCAL_NVM_SYSTEM_COLOR
-  local LOCAL_NVM_CURRENT_COLOR
-  local LOCAL_NVM_NOT_INSTALLED_COLOR
-  local LOCAL_NVM_DEFAULT_COLOR
-  local LOCAL_NVM_LTS_COLOR
-  LOCAL_NVM_INSTALLED_COLOR=$(nvm_get_colors 1)
-  LOCAL_NVM_SYSTEM_COLOR=$(nvm_get_colors 2)
-  LOCAL_NVM_CURRENT_COLOR=$(nvm_get_colors 3)
-  LOCAL_NVM_NOT_INSTALLED_COLOR=$(nvm_get_colors 4)
-  LOCAL_NVM_DEFAULT_COLOR=$(nvm_get_colors 5)
-  LOCAL_NVM_LTS_COLOR=$(nvm_get_colors 6)
+  local NVM_LOCAL_INSTALLED_COLOR
+  local NVM_LOCAL_SYSTEM_COLOR
+  local NVM_LOCAL_CURRENT_COLOR
+  local NVM_LOCAL_NOT_INSTALLED_COLOR
+  local NVM_LOCAL_DEFAULT_COLOR
+  local NVM_LOCAL_LTS_COLOR
+  NVM_LOCAL_INSTALLED_COLOR=$(nvm_get_colors 1)
+  NVM_LOCAL_SYSTEM_COLOR=$(nvm_get_colors 2)
+  NVM_LOCAL_CURRENT_COLOR=$(nvm_get_colors 3)
+  NVM_LOCAL_NOT_INSTALLED_COLOR=$(nvm_get_colors 4)
+  NVM_LOCAL_DEFAULT_COLOR=$(nvm_get_colors 5)
+  NVM_LOCAL_LTS_COLOR=$(nvm_get_colors 6)
 
-  local LOCAL_NVM_DEST_FORMAT
-  local LOCAL_NVM_ALIAS_FORMAT
-  local LOCAL_NVM_VERSION_FORMAT
-  LOCAL_NVM_DEST_FORMAT='%s'
-  LOCAL_NVM_ALIAS_FORMAT='%s'
-  LOCAL_NVM_VERSION_FORMAT='%s'
+  local NVM_LOCAL_DEST_FORMAT
+  local NVM_LOCAL_ALIAS_FORMAT
+  local NVM_LOCAL_VERSION_FORMAT
+  NVM_LOCAL_DEST_FORMAT='%s'
+  NVM_LOCAL_ALIAS_FORMAT='%s'
+  NVM_LOCAL_VERSION_FORMAT='%s'
 
-  local LOCAL_NVM_NEWLINE
-  LOCAL_NVM_NEWLINE='\n'
+  local NVM_LOCAL_NEWLINE
+  NVM_LOCAL_NEWLINE='\n'
   if [ "_${NVM_DEFAULT}" = '_true' ]; then
-    LOCAL_NVM_NEWLINE=' (default)\n'
+    NVM_LOCAL_NEWLINE=' (default)\n'
   fi
 
-  local LOCAL_NVM_ARROW
-  LOCAL_NVM_ARROW='->'
+  local NVM_LOCAL_ARROW
+  NVM_LOCAL_ARROW='->'
   if [ -z "${NVM_NO_COLORS}" ] && nvm_has_colors; then
-    LOCAL_NVM_ARROW='\033[0;90m->\033[0m'
+    NVM_LOCAL_ARROW='\033[0;90m->\033[0m'
     if [ "_${NVM_DEFAULT}" = '_true' ]; then
-      LOCAL_NVM_NEWLINE=" \033[${LOCAL_NVM_DEFAULT_COLOR}(default)\033[0m\n"
+      NVM_LOCAL_NEWLINE=" \033[${NVM_LOCAL_DEFAULT_COLOR}(default)\033[0m\n"
     fi
-    if [ "_${LOCAL_NVM_VERSION}" = "_${LOCAL_NVM_CURRENT-}" ]; then
-      LOCAL_NVM_ALIAS_FORMAT="\033[${LOCAL_NVM_CURRENT_COLOR}%s\033[0m"
-      LOCAL_NVM_DEST_FORMAT="\033[${LOCAL_NVM_CURRENT_COLOR}%s\033[0m"
-      LOCAL_NVM_VERSION_FORMAT="\033[${LOCAL_NVM_CURRENT_COLOR}%s\033[0m"
-    elif nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
-      LOCAL_NVM_ALIAS_FORMAT="\033[${LOCAL_NVM_INSTALLED_COLOR}%s\033[0m"
-      LOCAL_NVM_DEST_FORMAT="\033[${LOCAL_NVM_INSTALLED_COLOR}%s\033[0m"
-      LOCAL_NVM_VERSION_FORMAT="\033[${LOCAL_NVM_INSTALLED_COLOR}%s\033[0m"
-    elif [ "${LOCAL_NVM_VERSION}" = '∞' ] || [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
-      LOCAL_NVM_ALIAS_FORMAT="\033[${LOCAL_NVM_NOT_INSTALLED_COLOR}%s\033[0m"
-      LOCAL_NVM_DEST_FORMAT="\033[${LOCAL_NVM_NOT_INSTALLED_COLOR}%s\033[0m"
-      LOCAL_NVM_VERSION_FORMAT="\033[${LOCAL_NVM_NOT_INSTALLED_COLOR}%s\033[0m"
+    if [ "_${NVM_LOCAL_VERSION}" = "_${NVM_LOCAL_CURRENT-}" ]; then
+      NVM_LOCAL_ALIAS_FORMAT="\033[${NVM_LOCAL_CURRENT_COLOR}%s\033[0m"
+      NVM_LOCAL_DEST_FORMAT="\033[${NVM_LOCAL_CURRENT_COLOR}%s\033[0m"
+      NVM_LOCAL_VERSION_FORMAT="\033[${NVM_LOCAL_CURRENT_COLOR}%s\033[0m"
+    elif nvm_is_version_installed "${NVM_LOCAL_VERSION}"; then
+      NVM_LOCAL_ALIAS_FORMAT="\033[${NVM_LOCAL_INSTALLED_COLOR}%s\033[0m"
+      NVM_LOCAL_DEST_FORMAT="\033[${NVM_LOCAL_INSTALLED_COLOR}%s\033[0m"
+      NVM_LOCAL_VERSION_FORMAT="\033[${NVM_LOCAL_INSTALLED_COLOR}%s\033[0m"
+    elif [ "${NVM_LOCAL_VERSION}" = '∞' ] || [ "${NVM_LOCAL_VERSION}" = 'N/A' ]; then
+      NVM_LOCAL_ALIAS_FORMAT="\033[${NVM_LOCAL_NOT_INSTALLED_COLOR}%s\033[0m"
+      NVM_LOCAL_DEST_FORMAT="\033[${NVM_LOCAL_NOT_INSTALLED_COLOR}%s\033[0m"
+      NVM_LOCAL_VERSION_FORMAT="\033[${NVM_LOCAL_NOT_INSTALLED_COLOR}%s\033[0m"
     fi
     if [ "_${NVM_LTS-}" = '_true' ]; then
-      LOCAL_NVM_ALIAS_FORMAT="\033[${LOCAL_NVM_LTS_COLOR}%s\033[0m"
+      NVM_LOCAL_ALIAS_FORMAT="\033[${NVM_LOCAL_LTS_COLOR}%s\033[0m"
     fi
-    if [ "_${LOCAL_NVM_DEST%/*}" = "_lts" ]; then
-      LOCAL_NVM_DEST_FORMAT="\033[${LOCAL_NVM_LTS_COLOR}%s\033[0m"
+    if [ "_${NVM_LOCAL_DEST%/*}" = "_lts" ]; then
+      NVM_LOCAL_DEST_FORMAT="\033[${NVM_LOCAL_LTS_COLOR}%s\033[0m"
     fi
-  elif [ "_${LOCAL_NVM_VERSION}" != '_∞' ] && [ "_${LOCAL_NVM_VERSION}" != '_N/A' ]; then
-    LOCAL_NVM_VERSION_FORMAT='%s *'
+  elif [ "_${NVM_LOCAL_VERSION}" != '_∞' ] && [ "_${NVM_LOCAL_VERSION}" != '_N/A' ]; then
+    NVM_LOCAL_VERSION_FORMAT='%s *'
   fi
-  if [ "${LOCAL_NVM_DEST}" = "${LOCAL_NVM_VERSION}" ]; then
-    command printf -- "${LOCAL_NVM_ALIAS_FORMAT} ${LOCAL_NVM_ARROW} ${LOCAL_NVM_VERSION_FORMAT}${LOCAL_NVM_NEWLINE}" "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_DEST}"
+  if [ "${NVM_LOCAL_DEST}" = "${NVM_LOCAL_VERSION}" ]; then
+    command printf -- "${NVM_LOCAL_ALIAS_FORMAT} ${NVM_LOCAL_ARROW} ${NVM_LOCAL_VERSION_FORMAT}${NVM_LOCAL_NEWLINE}" "${NVM_LOCAL_ALIAS}" "${NVM_LOCAL_DEST}"
   else
-    command printf -- "${LOCAL_NVM_ALIAS_FORMAT} ${LOCAL_NVM_ARROW} ${LOCAL_NVM_DEST_FORMAT} (${LOCAL_NVM_ARROW} ${LOCAL_NVM_VERSION_FORMAT})${LOCAL_NVM_NEWLINE}" "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_DEST}" "${LOCAL_NVM_VERSION}"
+    command printf -- "${NVM_LOCAL_ALIAS_FORMAT} ${NVM_LOCAL_ARROW} ${NVM_LOCAL_DEST_FORMAT} (${NVM_LOCAL_ARROW} ${NVM_LOCAL_VERSION_FORMAT})${NVM_LOCAL_NEWLINE}" "${NVM_LOCAL_ALIAS}" "${NVM_LOCAL_DEST}" "${NVM_LOCAL_VERSION}"
   fi
 }
 
 nvm_print_alias_path() {
-  local LOCAL_NVM_ALIAS_DIR
-  LOCAL_NVM_ALIAS_DIR="${1-}"
-  if [ -z "${LOCAL_NVM_ALIAS_DIR}" ]; then
+  local NVM_LOCAL_ALIAS_DIR
+  NVM_LOCAL_ALIAS_DIR="${1-}"
+  if [ -z "${NVM_LOCAL_ALIAS_DIR}" ]; then
     nvm_err 'An alias dir is required.'
     return 1
   fi
-  local LOCAL_NVM_ALIAS_PATH
-  LOCAL_NVM_ALIAS_PATH="${2-}"
-  if [ -z "${LOCAL_NVM_ALIAS_PATH}" ]; then
+  local NVM_LOCAL_ALIAS_PATH
+  NVM_LOCAL_ALIAS_PATH="${2-}"
+  if [ -z "${NVM_LOCAL_ALIAS_PATH}" ]; then
     nvm_err 'An alias path is required.'
     return 2
   fi
-  local LOCAL_NVM_ALIAS
-  LOCAL_NVM_ALIAS="${LOCAL_NVM_ALIAS_PATH##"${LOCAL_NVM_ALIAS_DIR}"\/}"
-  local LOCAL_NVM_DEST
-  LOCAL_NVM_DEST="$(nvm_alias "${LOCAL_NVM_ALIAS}" 2>/dev/null)" ||:
-  if [ -n "${LOCAL_NVM_DEST}" ]; then
-    NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LTS="${NVM_LTS-}" NVM_DEFAULT=false nvm_print_formatted_alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_DEST}"
+  local NVM_LOCAL_ALIAS
+  NVM_LOCAL_ALIAS="${NVM_LOCAL_ALIAS_PATH##"${NVM_LOCAL_ALIAS_DIR}"\/}"
+  local NVM_LOCAL_DEST
+  NVM_LOCAL_DEST="$(nvm_alias "${NVM_LOCAL_ALIAS}" 2>/dev/null)" ||:
+  if [ -n "${NVM_LOCAL_DEST}" ]; then
+    NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LTS="${NVM_LTS-}" NVM_DEFAULT=false nvm_print_formatted_alias "${NVM_LOCAL_ALIAS}" "${NVM_LOCAL_DEST}"
   fi
 }
 
 nvm_print_default_alias() {
-  local LOCAL_NVM_ALIAS
-  LOCAL_NVM_ALIAS="${1-}"
-  if [ -z "${LOCAL_NVM_ALIAS}" ]; then
+  local NVM_LOCAL_ALIAS
+  NVM_LOCAL_ALIAS="${1-}"
+  if [ -z "${NVM_LOCAL_ALIAS}" ]; then
     nvm_err 'A default alias is required.'
     return 1
   fi
-  local LOCAL_NVM_DEST
-  LOCAL_NVM_DEST="$(nvm_print_implicit_alias local "${LOCAL_NVM_ALIAS}")"
-  if [ -n "${LOCAL_NVM_DEST}" ]; then
-    NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_DEFAULT=true nvm_print_formatted_alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_DEST}"
+  local NVM_LOCAL_DEST
+  NVM_LOCAL_DEST="$(nvm_print_implicit_alias local "${NVM_LOCAL_ALIAS}")"
+  if [ -n "${NVM_LOCAL_DEST}" ]; then
+    NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_DEFAULT=true nvm_print_formatted_alias "${NVM_LOCAL_ALIAS}" "${NVM_LOCAL_DEST}"
   fi
 }
 
 nvm_make_alias() {
-  local LOCAL_NVM_ALIAS
-  LOCAL_NVM_ALIAS="${1-}"
-  if [ -z "${LOCAL_NVM_ALIAS}" ]; then
+  local NVM_LOCAL_ALIAS
+  NVM_LOCAL_ALIAS="${1-}"
+  if [ -z "${NVM_LOCAL_ALIAS}" ]; then
     nvm_err "an alias name is required"
     return 1
   fi
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="${2-}"
-  if [ -z "${LOCAL_NVM_VERSION}" ]; then
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="${2-}"
+  if [ -z "${NVM_LOCAL_VERSION}" ]; then
     nvm_err "an alias target version is required"
     return 2
   fi
-  nvm_echo "${LOCAL_NVM_VERSION}" | tee "$(nvm_alias_path)/${LOCAL_NVM_ALIAS}" >/dev/null
+  nvm_echo "${NVM_LOCAL_VERSION}" | tee "$(nvm_alias_path)/${NVM_LOCAL_ALIAS}" >/dev/null
 }
 
 nvm_list_aliases() {
-  local LOCAL_NVM_ALIAS
-  LOCAL_NVM_ALIAS="${1-}"
+  local NVM_LOCAL_ALIAS
+  NVM_LOCAL_ALIAS="${1-}"
 
-  local LOCAL_NVM_CURRENT
-  LOCAL_NVM_CURRENT="$(nvm_ls_current)"
-  local LOCAL_NVM_ALIAS_DIR
-  LOCAL_NVM_ALIAS_DIR="$(nvm_alias_path)"
-  command mkdir -p "${LOCAL_NVM_ALIAS_DIR}/lts"
+  local NVM_LOCAL_CURRENT
+  NVM_LOCAL_CURRENT="$(nvm_ls_current)"
+  local NVM_LOCAL_ALIAS_DIR
+  NVM_LOCAL_ALIAS_DIR="$(nvm_alias_path)"
+  command mkdir -p "${NVM_LOCAL_ALIAS_DIR}/lts"
 
-  if [ "${LOCAL_NVM_ALIAS}" != "${LOCAL_NVM_ALIAS#lts/}" ]; then
-    nvm_alias "${LOCAL_NVM_ALIAS}"
+  if [ "${NVM_LOCAL_ALIAS}" != "${NVM_LOCAL_ALIAS#lts/}" ]; then
+    nvm_alias "${NVM_LOCAL_ALIAS}"
     return $?
   fi
 
   nvm_is_zsh && unsetopt local_options nomatch
   (
-    local LOCAL_NVM_ALIAS_PATH
-    for LOCAL_NVM_ALIAS_PATH in "${LOCAL_NVM_ALIAS_DIR}/${LOCAL_NVM_ALIAS}"*; do
-      NVM_NO_COLORS="${NVM_NO_COLORS-}" LOCAL_NVM_CURRENT="${LOCAL_NVM_CURRENT}" nvm_print_alias_path "${LOCAL_NVM_ALIAS_DIR}" "${LOCAL_NVM_ALIAS_PATH}" &
+    local NVM_LOCAL_ALIAS_PATH
+    for NVM_LOCAL_ALIAS_PATH in "${NVM_LOCAL_ALIAS_DIR}/${NVM_LOCAL_ALIAS}"*; do
+      NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LOCAL_CURRENT="${NVM_LOCAL_CURRENT}" nvm_print_alias_path "${NVM_LOCAL_ALIAS_DIR}" "${NVM_LOCAL_ALIAS_PATH}" &
     done
     wait
   ) | sort
 
   (
-    local LOCAL_NVM_ALIAS_NAME
-    for LOCAL_NVM_ALIAS_NAME in "$(nvm_node_prefix)" "stable" "unstable"; do
+    local NVM_LOCAL_ALIAS_NAME
+    for NVM_LOCAL_ALIAS_NAME in "$(nvm_node_prefix)" "stable" "unstable"; do
       {
         # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
-        if [ ! -f "${LOCAL_NVM_ALIAS_DIR}/${LOCAL_NVM_ALIAS_NAME}" ] && { [ -z "${LOCAL_NVM_ALIAS}" ] || [ "${LOCAL_NVM_ALIAS_NAME}" = "${LOCAL_NVM_ALIAS}" ]; }; then
-          NVM_NO_COLORS="${NVM_NO_COLORS-}" LOCAL_NVM_CURRENT="${LOCAL_NVM_CURRENT}" nvm_print_default_alias "${LOCAL_NVM_ALIAS_NAME}"
+        if [ ! -f "${NVM_LOCAL_ALIAS_DIR}/${NVM_LOCAL_ALIAS_NAME}" ] && { [ -z "${NVM_LOCAL_ALIAS}" ] || [ "${NVM_LOCAL_ALIAS_NAME}" = "${NVM_LOCAL_ALIAS}" ]; }; then
+          NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LOCAL_CURRENT="${NVM_LOCAL_CURRENT}" nvm_print_default_alias "${NVM_LOCAL_ALIAS_NAME}"
         fi
       } &
     done
     wait
-    LOCAL_NVM_ALIAS_NAME="$(nvm_iojs_prefix)"
+    NVM_LOCAL_ALIAS_NAME="$(nvm_iojs_prefix)"
     # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
-    if [ ! -f "${LOCAL_NVM_ALIAS_DIR}/${LOCAL_NVM_ALIAS_NAME}" ] && { [ -z "${LOCAL_NVM_ALIAS}" ] || [ "${LOCAL_NVM_ALIAS_NAME}" = "${LOCAL_NVM_ALIAS}" ]; }; then
-      NVM_NO_COLORS="${NVM_NO_COLORS-}" LOCAL_NVM_CURRENT="${LOCAL_NVM_CURRENT}" nvm_print_default_alias "${LOCAL_NVM_ALIAS_NAME}"
+    if [ ! -f "${NVM_LOCAL_ALIAS_DIR}/${NVM_LOCAL_ALIAS_NAME}" ] && { [ -z "${NVM_LOCAL_ALIAS}" ] || [ "${NVM_LOCAL_ALIAS_NAME}" = "${NVM_LOCAL_ALIAS}" ]; }; then
+      NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LOCAL_CURRENT="${NVM_LOCAL_CURRENT}" nvm_print_default_alias "${NVM_LOCAL_ALIAS_NAME}"
     fi
   ) | sort
 
   (
-    local LOCAL_NVM_LTS_ALIAS
-    local LOCAL_NVM_ALIAS_PATH
+    local NVM_LOCAL_LTS_ALIAS
+    local NVM_LOCAL_ALIAS_PATH
     # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
-    for LOCAL_NVM_ALIAS_PATH in "${LOCAL_NVM_ALIAS_DIR}/lts/${LOCAL_NVM_ALIAS}"*; do
+    for NVM_LOCAL_ALIAS_PATH in "${NVM_LOCAL_ALIAS_DIR}/lts/${NVM_LOCAL_ALIAS}"*; do
       {
-        LOCAL_NVM_LTS_ALIAS="$(NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LTS=true nvm_print_alias_path "${LOCAL_NVM_ALIAS_DIR}" "${LOCAL_NVM_ALIAS_PATH}")"
-        if [ -n "${LOCAL_NVM_LTS_ALIAS}" ]; then
-          nvm_echo "${LOCAL_NVM_LTS_ALIAS}"
+        NVM_LOCAL_LTS_ALIAS="$(NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LTS=true nvm_print_alias_path "${NVM_LOCAL_ALIAS_DIR}" "${NVM_LOCAL_ALIAS_PATH}")"
+        if [ -n "${NVM_LOCAL_LTS_ALIAS}" ]; then
+          nvm_echo "${NVM_LOCAL_LTS_ALIAS}"
         fi
       } &
     done
@@ -1062,41 +1062,41 @@ nvm_list_aliases() {
 }
 
 nvm_alias() {
-  local LOCAL_NVM_ALIAS
-  LOCAL_NVM_ALIAS="${1-}"
-  if [ -z "${LOCAL_NVM_ALIAS}" ]; then
+  local NVM_LOCAL_ALIAS
+  NVM_LOCAL_ALIAS="${1-}"
+  if [ -z "${NVM_LOCAL_ALIAS}" ]; then
     nvm_err 'An alias is required.'
     return 1
   fi
-  LOCAL_NVM_ALIAS="$(nvm_normalize_lts "${LOCAL_NVM_ALIAS}")"
+  NVM_LOCAL_ALIAS="$(nvm_normalize_lts "${NVM_LOCAL_ALIAS}")"
 
-  if [ -z "${LOCAL_NVM_ALIAS}" ]; then
+  if [ -z "${NVM_LOCAL_ALIAS}" ]; then
     return 2
   fi
 
-  local LOCAL_NVM_ALIAS_PATH
-  LOCAL_NVM_ALIAS_PATH="$(nvm_alias_path)/${LOCAL_NVM_ALIAS}"
-  if [ ! -f "${LOCAL_NVM_ALIAS_PATH}" ]; then
+  local NVM_LOCAL_ALIAS_PATH
+  NVM_LOCAL_ALIAS_PATH="$(nvm_alias_path)/${NVM_LOCAL_ALIAS}"
+  if [ ! -f "${NVM_LOCAL_ALIAS_PATH}" ]; then
     nvm_err 'Alias does not exist.'
     return 2
   fi
 
-  command cat "${LOCAL_NVM_ALIAS_PATH}"
+  command cat "${NVM_LOCAL_ALIAS_PATH}"
 }
 
 nvm_ls_current() {
-  local LOCAL_NVM_LS_CURRENT_NODE_PATH
-  if ! LOCAL_NVM_LS_CURRENT_NODE_PATH="$(command which node 2>/dev/null)"; then
+  local NVM_LOCAL_LS_CURRENT_NODE_PATH
+  if ! NVM_LOCAL_LS_CURRENT_NODE_PATH="$(command which node 2>/dev/null)"; then
     nvm_echo 'none'
-  elif nvm_tree_contains_path "$(nvm_version_dir iojs)" "${LOCAL_NVM_LS_CURRENT_NODE_PATH}"; then
+  elif nvm_tree_contains_path "$(nvm_version_dir iojs)" "${NVM_LOCAL_LS_CURRENT_NODE_PATH}"; then
     nvm_add_iojs_prefix "$(iojs --version 2>/dev/null)"
-  elif nvm_tree_contains_path "${NVM_DIR}" "${LOCAL_NVM_LS_CURRENT_NODE_PATH}"; then
-    local LOCAL_NVM_VERSION
-    LOCAL_NVM_VERSION="$(node --version 2>/dev/null)"
-    if [ "${LOCAL_NVM_VERSION}" = "v0.6.21-pre" ]; then
+  elif nvm_tree_contains_path "${NVM_DIR}" "${NVM_LOCAL_LS_CURRENT_NODE_PATH}"; then
+    local NVM_LOCAL_VERSION
+    NVM_LOCAL_VERSION="$(node --version 2>/dev/null)"
+    if [ "${NVM_LOCAL_VERSION}" = "v0.6.21-pre" ]; then
       nvm_echo 'v0.6.21'
     else
-      nvm_echo "${LOCAL_NVM_VERSION}"
+      nvm_echo "${NVM_LOCAL_VERSION}"
     fi
   else
     nvm_echo 'system'
@@ -1108,54 +1108,54 @@ nvm_resolve_alias() {
     return 1
   fi
 
-  local LOCAL_NVM_PATTERN
-  LOCAL_NVM_PATTERN="${1-}"
+  local NVM_LOCAL_PATTERN
+  NVM_LOCAL_PATTERN="${1-}"
 
-  local LOCAL_NVM_ALIAS
-  LOCAL_NVM_ALIAS="${LOCAL_NVM_PATTERN}"
-  local LOCAL_NVM_ALIAS_TEMP
+  local NVM_LOCAL_ALIAS
+  NVM_LOCAL_ALIAS="${NVM_LOCAL_PATTERN}"
+  local NVM_LOCAL_ALIAS_TEMP
 
-  local LOCAL_NVM_SEEN_ALIASES
-  LOCAL_NVM_SEEN_ALIASES="${LOCAL_NVM_ALIAS}"
+  local NVM_LOCAL_SEEN_ALIASES
+  NVM_LOCAL_SEEN_ALIASES="${NVM_LOCAL_ALIAS}"
   while true; do
-    LOCAL_NVM_ALIAS_TEMP="$(nvm_alias "${LOCAL_NVM_ALIAS}" 2>/dev/null || nvm_echo)"
+    NVM_LOCAL_ALIAS_TEMP="$(nvm_alias "${NVM_LOCAL_ALIAS}" 2>/dev/null || nvm_echo)"
 
-    if [ -z "${LOCAL_NVM_ALIAS_TEMP}" ]; then
+    if [ -z "${NVM_LOCAL_ALIAS_TEMP}" ]; then
       break
     fi
 
-    if command printf "${LOCAL_NVM_SEEN_ALIASES}" | nvm_grep -q -e "^${LOCAL_NVM_ALIAS_TEMP}$"; then
-      LOCAL_NVM_ALIAS="∞"
+    if command printf "${NVM_LOCAL_SEEN_ALIASES}" | nvm_grep -q -e "^${NVM_LOCAL_ALIAS_TEMP}$"; then
+      NVM_LOCAL_ALIAS="∞"
       break
     fi
 
-    LOCAL_NVM_SEEN_ALIASES="${LOCAL_NVM_SEEN_ALIASES}\\n${LOCAL_NVM_ALIAS_TEMP}"
-    LOCAL_NVM_ALIAS="${LOCAL_NVM_ALIAS_TEMP}"
+    NVM_LOCAL_SEEN_ALIASES="${NVM_LOCAL_SEEN_ALIASES}\\n${NVM_LOCAL_ALIAS_TEMP}"
+    NVM_LOCAL_ALIAS="${NVM_LOCAL_ALIAS_TEMP}"
   done
 
-  if [ -n "${LOCAL_NVM_ALIAS}" ] && [ "_${LOCAL_NVM_ALIAS}" != "_${LOCAL_NVM_PATTERN}" ]; then
-    local LOCAL_NVM_IOJS_PREFIX
-    LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-    local LOCAL_NVM_NODE_PREFIX
-    LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
-    case "${LOCAL_NVM_ALIAS}" in
+  if [ -n "${NVM_LOCAL_ALIAS}" ] && [ "_${NVM_LOCAL_ALIAS}" != "_${NVM_LOCAL_PATTERN}" ]; then
+    local NVM_LOCAL_IOJS_PREFIX
+    NVM_LOCAL_IOJS_PREFIX="$(nvm_iojs_prefix)"
+    local NVM_LOCAL_NODE_PREFIX
+    NVM_LOCAL_NODE_PREFIX="$(nvm_node_prefix)"
+    case "${NVM_LOCAL_ALIAS}" in
       '∞' | \
-      "${LOCAL_NVM_IOJS_PREFIX}" | "${LOCAL_NVM_IOJS_PREFIX}-" | \
-      "${LOCAL_NVM_NODE_PREFIX}")
-        nvm_echo "${LOCAL_NVM_ALIAS}"
+      "${NVM_LOCAL_IOJS_PREFIX}" | "${NVM_LOCAL_IOJS_PREFIX}-" | \
+      "${NVM_LOCAL_NODE_PREFIX}")
+        nvm_echo "${NVM_LOCAL_ALIAS}"
       ;;
       *)
-        nvm_ensure_version_prefix "${LOCAL_NVM_ALIAS}"
+        nvm_ensure_version_prefix "${NVM_LOCAL_ALIAS}"
       ;;
     esac
     return 0
   fi
 
-  if nvm_validate_implicit_alias "${LOCAL_NVM_PATTERN}" 2>/dev/null; then
-    local LOCAL_NVM_IMPLICIT
-    LOCAL_NVM_IMPLICIT="$(nvm_print_implicit_alias local "${LOCAL_NVM_PATTERN}" 2>/dev/null)"
-    if [ -n "${LOCAL_NVM_IMPLICIT}" ]; then
-      nvm_ensure_version_prefix "${LOCAL_NVM_IMPLICIT}"
+  if nvm_validate_implicit_alias "${NVM_LOCAL_PATTERN}" 2>/dev/null; then
+    local NVM_LOCAL_IMPLICIT
+    NVM_LOCAL_IMPLICIT="$(nvm_print_implicit_alias local "${NVM_LOCAL_PATTERN}" 2>/dev/null)"
+    if [ -n "${NVM_LOCAL_IMPLICIT}" ]; then
+      nvm_ensure_version_prefix "${NVM_LOCAL_IMPLICIT}"
     fi
   fi
 
@@ -1167,17 +1167,17 @@ nvm_resolve_local_alias() {
     return 1
   fi
 
-  local LOCAL_NVM_VERSION
-  local LOCAL_NVM_EXIT_CODE
-  LOCAL_NVM_VERSION="$(nvm_resolve_alias "${1-}")"
-  LOCAL_NVM_EXIT_CODE=$?
-  if [ -z "${LOCAL_NVM_VERSION}" ]; then
-    return ${LOCAL_NVM_EXIT_CODE}
+  local NVM_LOCAL_VERSION
+  local NVM_LOCAL_EXIT_CODE
+  NVM_LOCAL_VERSION="$(nvm_resolve_alias "${1-}")"
+  NVM_LOCAL_EXIT_CODE=$?
+  if [ -z "${NVM_LOCAL_VERSION}" ]; then
+    return ${NVM_LOCAL_EXIT_CODE}
   fi
-  if [ "_${LOCAL_NVM_VERSION}" != '_∞' ]; then
-    nvm_version "${LOCAL_NVM_VERSION}"
+  if [ "_${NVM_LOCAL_VERSION}" != '_∞' ]; then
+    nvm_version "${NVM_LOCAL_VERSION}"
   else
-    nvm_echo "${LOCAL_NVM_VERSION}"
+    nvm_echo "${NVM_LOCAL_VERSION}"
   fi
 }
 
@@ -1198,70 +1198,70 @@ nvm_add_iojs_prefix() {
 }
 
 nvm_strip_iojs_prefix() {
-  local LOCAL_NVM_IOJS_PREFIX
-  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  if [ "${1-}" = "${LOCAL_NVM_IOJS_PREFIX}" ]; then
+  local NVM_LOCAL_IOJS_PREFIX
+  NVM_LOCAL_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  if [ "${1-}" = "${NVM_LOCAL_IOJS_PREFIX}" ]; then
     nvm_echo
   else
-    nvm_echo "${1#"${LOCAL_NVM_IOJS_PREFIX}"-}"
+    nvm_echo "${1#"${NVM_LOCAL_IOJS_PREFIX}"-}"
   fi
 }
 
 nvm_ls() {
-  local LOCAL_NVM_PATTERN
-  LOCAL_NVM_PATTERN="${1-}"
-  local LOCAL_NVM_VERSIONS
-  LOCAL_NVM_VERSIONS=''
-  if [ "${LOCAL_NVM_PATTERN}" = 'current' ]; then
+  local NVM_LOCAL_PATTERN
+  NVM_LOCAL_PATTERN="${1-}"
+  local NVM_LOCAL_VERSIONS
+  NVM_LOCAL_VERSIONS=''
+  if [ "${NVM_LOCAL_PATTERN}" = 'current' ]; then
     nvm_ls_current
     return
   fi
 
-  local LOCAL_NVM_IOJS_PREFIX
-  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local LOCAL_NVM_NODE_PREFIX
-  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
-  local LOCAL_NVM_VERSION_DIR_IOJS
-  LOCAL_NVM_VERSION_DIR_IOJS="$(nvm_version_dir "${LOCAL_NVM_IOJS_PREFIX}")"
-  local LOCAL_NVM_VERSION_DIR_NEW
-  LOCAL_NVM_VERSION_DIR_NEW="$(nvm_version_dir new)"
-  local LOCAL_NVM_VERSION_DIR_OLD
-  LOCAL_NVM_VERSION_DIR_OLD="$(nvm_version_dir old)"
+  local NVM_LOCAL_IOJS_PREFIX
+  NVM_LOCAL_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local NVM_LOCAL_NODE_PREFIX
+  NVM_LOCAL_NODE_PREFIX="$(nvm_node_prefix)"
+  local NVM_LOCAL_VERSION_DIR_IOJS
+  NVM_LOCAL_VERSION_DIR_IOJS="$(nvm_version_dir "${NVM_LOCAL_IOJS_PREFIX}")"
+  local NVM_LOCAL_VERSION_DIR_NEW
+  NVM_LOCAL_VERSION_DIR_NEW="$(nvm_version_dir new)"
+  local NVM_LOCAL_VERSION_DIR_OLD
+  NVM_LOCAL_VERSION_DIR_OLD="$(nvm_version_dir old)"
 
-  case "${LOCAL_NVM_PATTERN}" in
-    "${LOCAL_NVM_IOJS_PREFIX}" | "${LOCAL_NVM_NODE_PREFIX}")
-      LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN}-"
+  case "${NVM_LOCAL_PATTERN}" in
+    "${NVM_LOCAL_IOJS_PREFIX}" | "${NVM_LOCAL_NODE_PREFIX}")
+      NVM_LOCAL_PATTERN="${NVM_LOCAL_PATTERN}-"
     ;;
     *)
-      if nvm_resolve_local_alias "${LOCAL_NVM_PATTERN}"; then
+      if nvm_resolve_local_alias "${NVM_LOCAL_PATTERN}"; then
         return
       fi
-      LOCAL_NVM_PATTERN="$(nvm_ensure_version_prefix "${LOCAL_NVM_PATTERN}")"
+      NVM_LOCAL_PATTERN="$(nvm_ensure_version_prefix "${NVM_LOCAL_PATTERN}")"
     ;;
   esac
-  if [ "${LOCAL_NVM_PATTERN}" = 'N/A' ]; then
+  if [ "${NVM_LOCAL_PATTERN}" = 'N/A' ]; then
     return
   fi
   # If it looks like an explicit version, don't do anything funny
-  local LOCAL_NVM_PATTERN_STARTS_WITH_V
-  case ${LOCAL_NVM_PATTERN} in
-    v*) LOCAL_NVM_PATTERN_STARTS_WITH_V=true ;;
-    *) LOCAL_NVM_PATTERN_STARTS_WITH_V=false ;;
+  local NVM_LOCAL_PATTERN_STARTS_WITH_V
+  case ${NVM_LOCAL_PATTERN} in
+    v*) NVM_LOCAL_PATTERN_STARTS_WITH_V=true ;;
+    *) NVM_LOCAL_PATTERN_STARTS_WITH_V=false ;;
   esac
-  if [ ${LOCAL_NVM_PATTERN_STARTS_WITH_V} = true ] && [ "_$(nvm_num_version_groups "${LOCAL_NVM_PATTERN}")" = "_3" ]; then
-    if nvm_is_version_installed "${LOCAL_NVM_PATTERN}"; then
-      LOCAL_NVM_VERSIONS="${LOCAL_NVM_PATTERN}"
-    elif nvm_is_version_installed "$(nvm_add_iojs_prefix "${LOCAL_NVM_PATTERN}")"; then
-      LOCAL_NVM_VERSIONS="$(nvm_add_iojs_prefix "${LOCAL_NVM_PATTERN}")"
+  if [ ${NVM_LOCAL_PATTERN_STARTS_WITH_V} = true ] && [ "_$(nvm_num_version_groups "${NVM_LOCAL_PATTERN}")" = "_3" ]; then
+    if nvm_is_version_installed "${NVM_LOCAL_PATTERN}"; then
+      NVM_LOCAL_VERSIONS="${NVM_LOCAL_PATTERN}"
+    elif nvm_is_version_installed "$(nvm_add_iojs_prefix "${NVM_LOCAL_PATTERN}")"; then
+      NVM_LOCAL_VERSIONS="$(nvm_add_iojs_prefix "${NVM_LOCAL_PATTERN}")"
     fi
   else
-    case "${LOCAL_NVM_PATTERN}" in
-      "${LOCAL_NVM_IOJS_PREFIX}-" | "${LOCAL_NVM_NODE_PREFIX}-" | "system") ;;
+    case "${NVM_LOCAL_PATTERN}" in
+      "${NVM_LOCAL_IOJS_PREFIX}-" | "${NVM_LOCAL_NODE_PREFIX}-" | "system") ;;
       *)
-        local LOCAL_NVM_NUM_VERSION_GROUPS
-        LOCAL_NVM_NUM_VERSION_GROUPS="$(nvm_num_version_groups "${LOCAL_NVM_PATTERN}")"
-        if [ "${LOCAL_NVM_NUM_VERSION_GROUPS}" = "2" ] || [ "${LOCAL_NVM_NUM_VERSION_GROUPS}" = "1" ]; then
-          LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN%.}."
+        local NVM_LOCAL_NUM_VERSION_GROUPS
+        NVM_LOCAL_NUM_VERSION_GROUPS="$(nvm_num_version_groups "${NVM_LOCAL_PATTERN}")"
+        if [ "${NVM_LOCAL_NUM_VERSION_GROUPS}" = "2" ] || [ "${NVM_LOCAL_NUM_VERSION_GROUPS}" = "1" ]; then
+          NVM_LOCAL_PATTERN="${NVM_LOCAL_PATTERN%.}."
         fi
       ;;
     esac
@@ -1269,105 +1269,105 @@ nvm_ls() {
     nvm_is_zsh && setopt local_options shwordsplit
     nvm_is_zsh && unsetopt local_options markdirs
 
-    local LOCAL_NVM_DIRS_TO_SEARCH1
-    LOCAL_NVM_DIRS_TO_SEARCH1=''
-    local LOCAL_NVM_DIRS_TO_SEARCH2
-    LOCAL_NVM_DIRS_TO_SEARCH2=''
-    local LOCAL_NVM_DIRS_TO_SEARCH3
-    LOCAL_NVM_DIRS_TO_SEARCH3=''
-    local LOCAL_NVM_ADD_SYSTEM
-    LOCAL_NVM_ADD_SYSTEM=false
-    if nvm_is_iojs_version "${LOCAL_NVM_PATTERN}"; then
-      LOCAL_NVM_DIRS_TO_SEARCH1="${LOCAL_NVM_VERSION_DIR_IOJS}"
-      LOCAL_NVM_PATTERN="$(nvm_strip_iojs_prefix "${LOCAL_NVM_PATTERN}")"
+    local NVM_LOCAL_DIRS_TO_SEARCH1
+    NVM_LOCAL_DIRS_TO_SEARCH1=''
+    local NVM_LOCAL_DIRS_TO_SEARCH2
+    NVM_LOCAL_DIRS_TO_SEARCH2=''
+    local NVM_LOCAL_DIRS_TO_SEARCH3
+    NVM_LOCAL_DIRS_TO_SEARCH3=''
+    local NVM_LOCAL_ADD_SYSTEM
+    NVM_LOCAL_ADD_SYSTEM=false
+    if nvm_is_iojs_version "${NVM_LOCAL_PATTERN}"; then
+      NVM_LOCAL_DIRS_TO_SEARCH1="${NVM_LOCAL_VERSION_DIR_IOJS}"
+      NVM_LOCAL_PATTERN="$(nvm_strip_iojs_prefix "${NVM_LOCAL_PATTERN}")"
       if nvm_has_system_iojs; then
-        LOCAL_NVM_ADD_SYSTEM=true
+        NVM_LOCAL_ADD_SYSTEM=true
       fi
-    elif [ "${LOCAL_NVM_PATTERN}" = "${LOCAL_NVM_NODE_PREFIX}-" ]; then
-      LOCAL_NVM_DIRS_TO_SEARCH1="${LOCAL_NVM_VERSION_DIR_OLD}"
-      LOCAL_NVM_DIRS_TO_SEARCH2="${LOCAL_NVM_VERSION_DIR_NEW}"
-      LOCAL_NVM_PATTERN=''
+    elif [ "${NVM_LOCAL_PATTERN}" = "${NVM_LOCAL_NODE_PREFIX}-" ]; then
+      NVM_LOCAL_DIRS_TO_SEARCH1="${NVM_LOCAL_VERSION_DIR_OLD}"
+      NVM_LOCAL_DIRS_TO_SEARCH2="${NVM_LOCAL_VERSION_DIR_NEW}"
+      NVM_LOCAL_PATTERN=''
       if nvm_has_system_node; then
-        LOCAL_NVM_ADD_SYSTEM=true
+        NVM_LOCAL_ADD_SYSTEM=true
       fi
     else
-      LOCAL_NVM_DIRS_TO_SEARCH1="${LOCAL_NVM_VERSION_DIR_OLD}"
-      LOCAL_NVM_DIRS_TO_SEARCH2="${LOCAL_NVM_VERSION_DIR_NEW}"
-      LOCAL_NVM_DIRS_TO_SEARCH3="${LOCAL_NVM_VERSION_DIR_IOJS}"
+      NVM_LOCAL_DIRS_TO_SEARCH1="${NVM_LOCAL_VERSION_DIR_OLD}"
+      NVM_LOCAL_DIRS_TO_SEARCH2="${NVM_LOCAL_VERSION_DIR_NEW}"
+      NVM_LOCAL_DIRS_TO_SEARCH3="${NVM_LOCAL_VERSION_DIR_IOJS}"
       if nvm_has_system_iojs || nvm_has_system_node; then
-        LOCAL_NVM_ADD_SYSTEM=true
+        NVM_LOCAL_ADD_SYSTEM=true
       fi
     fi
 
-    if ! [ -d "${LOCAL_NVM_DIRS_TO_SEARCH1}" ] || ! (command ls -1qA "${LOCAL_NVM_DIRS_TO_SEARCH1}" | nvm_grep -q .); then
-      LOCAL_NVM_DIRS_TO_SEARCH1=''
+    if ! [ -d "${NVM_LOCAL_DIRS_TO_SEARCH1}" ] || ! (command ls -1qA "${NVM_LOCAL_DIRS_TO_SEARCH1}" | nvm_grep -q .); then
+      NVM_LOCAL_DIRS_TO_SEARCH1=''
     fi
-    if ! [ -d "${LOCAL_NVM_DIRS_TO_SEARCH2}" ] || ! (command ls -1qA "${LOCAL_NVM_DIRS_TO_SEARCH2}" | nvm_grep -q .); then
-      LOCAL_NVM_DIRS_TO_SEARCH2="${LOCAL_NVM_DIRS_TO_SEARCH1}"
+    if ! [ -d "${NVM_LOCAL_DIRS_TO_SEARCH2}" ] || ! (command ls -1qA "${NVM_LOCAL_DIRS_TO_SEARCH2}" | nvm_grep -q .); then
+      NVM_LOCAL_DIRS_TO_SEARCH2="${NVM_LOCAL_DIRS_TO_SEARCH1}"
     fi
-    if ! [ -d "${LOCAL_NVM_DIRS_TO_SEARCH3}" ] || ! (command ls -1qA "${LOCAL_NVM_DIRS_TO_SEARCH3}" | nvm_grep -q .); then
-      LOCAL_NVM_DIRS_TO_SEARCH3="${LOCAL_NVM_DIRS_TO_SEARCH2}"
+    if ! [ -d "${NVM_LOCAL_DIRS_TO_SEARCH3}" ] || ! (command ls -1qA "${NVM_LOCAL_DIRS_TO_SEARCH3}" | nvm_grep -q .); then
+      NVM_LOCAL_DIRS_TO_SEARCH3="${NVM_LOCAL_DIRS_TO_SEARCH2}"
     fi
 
-    local LOCAL_NVM_SEARCH_PATTERN
-    if [ -z "${LOCAL_NVM_PATTERN}" ]; then
-      LOCAL_NVM_PATTERN='v'
-      LOCAL_NVM_SEARCH_PATTERN='.*'
+    local NVM_LOCAL_SEARCH_PATTERN
+    if [ -z "${NVM_LOCAL_PATTERN}" ]; then
+      NVM_LOCAL_PATTERN='v'
+      NVM_LOCAL_SEARCH_PATTERN='.*'
     else
-      LOCAL_NVM_SEARCH_PATTERN="$(nvm_echo "${LOCAL_NVM_PATTERN}" | command sed 's#\.#\\\.#g;')"
+      NVM_LOCAL_SEARCH_PATTERN="$(nvm_echo "${NVM_LOCAL_PATTERN}" | command sed 's#\.#\\\.#g;')"
     fi
-    if [ -n "${LOCAL_NVM_DIRS_TO_SEARCH1}${LOCAL_NVM_DIRS_TO_SEARCH2}${LOCAL_NVM_DIRS_TO_SEARCH3}" ]; then
-      LOCAL_NVM_VERSIONS="$(command find "${LOCAL_NVM_DIRS_TO_SEARCH1}"/* "${LOCAL_NVM_DIRS_TO_SEARCH2}"/* "${LOCAL_NVM_DIRS_TO_SEARCH3}"/* -name . -o -type d -prune -o -path "${LOCAL_NVM_PATTERN}*" \
+    if [ -n "${NVM_LOCAL_DIRS_TO_SEARCH1}${NVM_LOCAL_DIRS_TO_SEARCH2}${NVM_LOCAL_DIRS_TO_SEARCH3}" ]; then
+      NVM_LOCAL_VERSIONS="$(command find "${NVM_LOCAL_DIRS_TO_SEARCH1}"/* "${NVM_LOCAL_DIRS_TO_SEARCH2}"/* "${NVM_LOCAL_DIRS_TO_SEARCH3}"/* -name . -o -type d -prune -o -path "${NVM_LOCAL_PATTERN}*" \
         | command sed -e "
-            s#${LOCAL_NVM_VERSION_DIR_IOJS}/#versions/${LOCAL_NVM_IOJS_PREFIX}/#;
+            s#${NVM_LOCAL_VERSION_DIR_IOJS}/#versions/${NVM_LOCAL_IOJS_PREFIX}/#;
             s#^${NVM_DIR}/##;
             \\#^[^v]# d;
             \\#^versions\$# d;
             s#^versions/##;
-            s#^v#${LOCAL_NVM_NODE_PREFIX}/v#;
-            \\#${LOCAL_NVM_SEARCH_PATTERN}# !d;
+            s#^v#${NVM_LOCAL_NODE_PREFIX}/v#;
+            \\#${NVM_LOCAL_SEARCH_PATTERN}# !d;
           " \
           -e 's#^\([^/]\{1,\}\)/\(.*\)$#\2.\1#;' \
         | command sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n \
         | command sed -e 's#\(.*\)\.\([^\.]\{1,\}\)$#\2-\1#;' \
-                      -e "s#^${LOCAL_NVM_NODE_PREFIX}-##;" \
+                      -e "s#^${NVM_LOCAL_NODE_PREFIX}-##;" \
       )"
     fi
   fi
 
-  if [ "${LOCAL_NVM_ADD_SYSTEM-}" = true ]; then
-    if [ -z "${LOCAL_NVM_PATTERN}" ] || [ "${LOCAL_NVM_PATTERN}" = 'v' ]; then
-      LOCAL_NVM_VERSIONS="${LOCAL_NVM_VERSIONS}$(command printf '\n%s' 'system')"
-    elif [ "${LOCAL_NVM_PATTERN}" = 'system' ]; then
-      LOCAL_NVM_VERSIONS="$(command printf '%s' 'system')"
+  if [ "${NVM_LOCAL_ADD_SYSTEM-}" = true ]; then
+    if [ -z "${NVM_LOCAL_PATTERN}" ] || [ "${NVM_LOCAL_PATTERN}" = 'v' ]; then
+      NVM_LOCAL_VERSIONS="${NVM_LOCAL_VERSIONS}$(command printf '\n%s' 'system')"
+    elif [ "${NVM_LOCAL_PATTERN}" = 'system' ]; then
+      NVM_LOCAL_VERSIONS="$(command printf '%s' 'system')"
     fi
   fi
 
-  if [ -z "${LOCAL_NVM_VERSIONS}" ]; then
+  if [ -z "${NVM_LOCAL_VERSIONS}" ]; then
     nvm_echo 'N/A'
     return 3
   fi
 
-  nvm_echo "${LOCAL_NVM_VERSIONS}"
+  nvm_echo "${NVM_LOCAL_VERSIONS}"
 }
 
 nvm_ls_remote() {
-  local LOCAL_NVM_PATTERN
-  LOCAL_NVM_PATTERN="${1-}"
-  if nvm_validate_implicit_alias "${LOCAL_NVM_PATTERN}" 2>/dev/null ; then
-    local LOCAL_NVM_IMPLICIT
-    LOCAL_NVM_IMPLICIT="$(nvm_print_implicit_alias remote "${LOCAL_NVM_PATTERN}")"
-    if [ -z "${LOCAL_NVM_IMPLICIT-}" ] || [ "${LOCAL_NVM_IMPLICIT}" = 'N/A' ]; then
+  local NVM_LOCAL_PATTERN
+  NVM_LOCAL_PATTERN="${1-}"
+  if nvm_validate_implicit_alias "${NVM_LOCAL_PATTERN}" 2>/dev/null ; then
+    local NVM_LOCAL_IMPLICIT
+    NVM_LOCAL_IMPLICIT="$(nvm_print_implicit_alias remote "${NVM_LOCAL_PATTERN}")"
+    if [ -z "${NVM_LOCAL_IMPLICIT-}" ] || [ "${NVM_LOCAL_IMPLICIT}" = 'N/A' ]; then
       nvm_echo "N/A"
       return 3
     fi
-    LOCAL_NVM_PATTERN="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${LOCAL_NVM_IMPLICIT}" | command tail -1 | command awk '{ print $1 }')"
-  elif [ -n "${LOCAL_NVM_PATTERN}" ]; then
-    LOCAL_NVM_PATTERN="$(nvm_ensure_version_prefix "${LOCAL_NVM_PATTERN}")"
+    NVM_LOCAL_PATTERN="$(NVM_LTS="${NVM_LTS-}" nvm_ls_remote "${NVM_LOCAL_IMPLICIT}" | command tail -1 | command awk '{ print $1 }')"
+  elif [ -n "${NVM_LOCAL_PATTERN}" ]; then
+    NVM_LOCAL_PATTERN="$(nvm_ensure_version_prefix "${NVM_LOCAL_PATTERN}")"
   else
-    LOCAL_NVM_PATTERN=".*"
+    NVM_LOCAL_PATTERN=".*"
   fi
-  NVM_LTS="${NVM_LTS-}" nvm_ls_remote_index_tab node std "${LOCAL_NVM_PATTERN}"
+  NVM_LTS="${NVM_LTS-}" nvm_ls_remote_index_tab node std "${NVM_LOCAL_PATTERN}"
 }
 
 nvm_ls_remote_iojs() {
@@ -1376,30 +1376,30 @@ nvm_ls_remote_iojs() {
 
 # args flavor, type, version
 nvm_ls_remote_index_tab() {
-  local LOCAL_NVM_LTS
-  LOCAL_NVM_LTS="${NVM_LTS-}"
+  local NVM_LOCAL_LTS
+  NVM_LOCAL_LTS="${NVM_LTS-}"
   if [ "$#" -lt 3 ]; then
     nvm_err 'not enough arguments'
     return 5
   fi
 
-  local LOCAL_NVM_FLAVOR
-  LOCAL_NVM_FLAVOR="${1-}"
+  local NVM_LOCAL_FLAVOR
+  NVM_LOCAL_FLAVOR="${1-}"
 
-  local LOCAL_NVM_TYPE
-  LOCAL_NVM_TYPE="${2-}"
+  local NVM_LOCAL_TYPE
+  NVM_LOCAL_TYPE="${2-}"
 
-  local LOCAL_NVM_MIRROR
-  LOCAL_NVM_MIRROR="$(nvm_get_mirror "${LOCAL_NVM_FLAVOR}" "${LOCAL_NVM_TYPE}")"
-  if [ -z "${LOCAL_NVM_MIRROR}" ]; then
+  local NVM_LOCAL_MIRROR
+  NVM_LOCAL_MIRROR="$(nvm_get_mirror "${NVM_LOCAL_FLAVOR}" "${NVM_LOCAL_TYPE}")"
+  if [ -z "${NVM_LOCAL_MIRROR}" ]; then
     return 3
   fi
 
-  local LOCAL_NVM_PREFIX
-  LOCAL_NVM_PREFIX=''
-  case "${LOCAL_NVM_FLAVOR}-${LOCAL_NVM_TYPE}" in
-    iojs-std) LOCAL_NVM_PREFIX="$(nvm_iojs_prefix)-" ;;
-    node-std) LOCAL_NVM_PREFIX='' ;;
+  local NVM_LOCAL_PREFIX
+  NVM_LOCAL_PREFIX=''
+  case "${NVM_LOCAL_FLAVOR}-${NVM_LOCAL_TYPE}" in
+    iojs-std) NVM_LOCAL_PREFIX="$(nvm_iojs_prefix)-" ;;
+    node-std) NVM_LOCAL_PREFIX='' ;;
     iojs-*)
       nvm_err 'unknown type of io.js release'
       return 4
@@ -1409,40 +1409,40 @@ nvm_ls_remote_index_tab() {
       return 4
     ;;
   esac
-  local LOCAL_NVM_SORT_COMMAND
-  LOCAL_NVM_SORT_COMMAND='command sort'
-  case "${LOCAL_NVM_FLAVOR}" in
-    node) LOCAL_NVM_SORT_COMMAND='command sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n' ;;
+  local NVM_LOCAL_SORT_COMMAND
+  NVM_LOCAL_SORT_COMMAND='command sort'
+  case "${NVM_LOCAL_FLAVOR}" in
+    node) NVM_LOCAL_SORT_COMMAND='command sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n' ;;
   esac
 
-  local LOCAL_NVM_PATTERN
-  LOCAL_NVM_PATTERN="${3-}"
+  local NVM_LOCAL_PATTERN
+  NVM_LOCAL_PATTERN="${3-}"
 
-  if [ "${LOCAL_NVM_PATTERN#"${LOCAL_NVM_PATTERN%?}"}" = '.' ]; then
-    LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN%.}"
+  if [ "${NVM_LOCAL_PATTERN#"${NVM_LOCAL_PATTERN%?}"}" = '.' ]; then
+    NVM_LOCAL_PATTERN="${NVM_LOCAL_PATTERN%.}"
   fi
 
-  local LOCAL_NVM_VERSIONS
-  if [ -n "${LOCAL_NVM_PATTERN}" ] && [ "${LOCAL_NVM_PATTERN}" != '*' ]; then
-    if [ "${LOCAL_NVM_FLAVOR}" = 'iojs' ]; then
-      LOCAL_NVM_PATTERN="$(nvm_ensure_version_prefix "$(nvm_strip_iojs_prefix "${LOCAL_NVM_PATTERN}")")"
+  local NVM_LOCAL_VERSIONS
+  if [ -n "${NVM_LOCAL_PATTERN}" ] && [ "${NVM_LOCAL_PATTERN}" != '*' ]; then
+    if [ "${NVM_LOCAL_FLAVOR}" = 'iojs' ]; then
+      NVM_LOCAL_PATTERN="$(nvm_ensure_version_prefix "$(nvm_strip_iojs_prefix "${NVM_LOCAL_PATTERN}")")"
     else
-      LOCAL_NVM_PATTERN="$(nvm_ensure_version_prefix "${LOCAL_NVM_PATTERN}")"
+      NVM_LOCAL_PATTERN="$(nvm_ensure_version_prefix "${NVM_LOCAL_PATTERN}")"
     fi
   else
-    unset LOCAL_NVM_PATTERN
+    unset NVM_LOCAL_PATTERN
   fi
 
   nvm_is_zsh && setopt local_options shwordsplit
-  local LOCAL_NVM_VERSION_LIST
-  LOCAL_NVM_VERSION_LIST="$(nvm_download -L -s "${LOCAL_NVM_MIRROR}/index.tab" -o - \
+  local NVM_LOCAL_VERSION_LIST
+  NVM_LOCAL_VERSION_LIST="$(nvm_download -L -s "${NVM_LOCAL_MIRROR}/index.tab" -o - \
     | command sed "
         1d;
-        s/^/${LOCAL_NVM_PREFIX}/;
+        s/^/${NVM_LOCAL_PREFIX}/;
       " \
   )"
-  local LOCAL_NVM_LTS_ALIAS
-  local LOCAL_NVM_LTS_VERSION
+  local NVM_LOCAL_LTS_ALIAS
+  local NVM_LOCAL_LTS_VERSION
   command mkdir -p "$(nvm_alias_path)/lts"
   { command awk '{
         if ($10 ~ /^\-?$/) { next }
@@ -1459,20 +1459,20 @@ nvm_ls_remote_index_tab() {
           print alias, version
         }
       }' \
-    | while read -r LOCAL_NVM_LTS_ALIAS_LINE; do
-      LOCAL_NVM_LTS_ALIAS="${LOCAL_NVM_LTS_ALIAS_LINE%% *}"
-      LOCAL_NVM_LTS_VERSION="${LOCAL_NVM_LTS_ALIAS_LINE#* }"
-      nvm_make_alias "${LOCAL_NVM_LTS_ALIAS}" "${LOCAL_NVM_LTS_VERSION}" >/dev/null 2>&1
+    | while read -r NVM_LOCAL_LTS_ALIAS_LINE; do
+      NVM_LOCAL_LTS_ALIAS="${NVM_LOCAL_LTS_ALIAS_LINE%% *}"
+      NVM_LOCAL_LTS_VERSION="${NVM_LOCAL_LTS_ALIAS_LINE#* }"
+      nvm_make_alias "${NVM_LOCAL_LTS_ALIAS}" "${NVM_LOCAL_LTS_VERSION}" >/dev/null 2>&1
     done; } << EOF
-${LOCAL_NVM_VERSION_LIST}
+${NVM_LOCAL_VERSION_LIST}
 EOF
 
-  if [ -n "${LOCAL_NVM_LTS-}" ]; then
-    LOCAL_NVM_LTS="$(nvm_normalize_lts "lts/${LOCAL_NVM_LTS}")"
-    LOCAL_NVM_LTS="${LOCAL_NVM_LTS#lts/}"
+  if [ -n "${NVM_LOCAL_LTS-}" ]; then
+    NVM_LOCAL_LTS="$(nvm_normalize_lts "lts/${NVM_LOCAL_LTS}")"
+    NVM_LOCAL_LTS="${NVM_LOCAL_LTS#lts/}"
   fi
 
-  LOCAL_NVM_VERSIONS="$({ command awk -v lts="${LOCAL_NVM_LTS-}" '{
+  NVM_LOCAL_VERSIONS="$({ command awk -v lts="${NVM_LOCAL_LTS-}" '{
         if (!$1) { next }
         if (lts && $10 ~ /^\-?$/) { next }
         if (lts && lts != "*" && tolower($10) !~ tolower(lts)) { next }
@@ -1487,16 +1487,16 @@ EOF
         }
         prev=$10;
       }' \
-    | nvm_grep -w "${LOCAL_NVM_PATTERN:-.*}" \
-    | ${LOCAL_NVM_SORT_COMMAND}; } << EOF
-${LOCAL_NVM_VERSION_LIST}
+    | nvm_grep -w "${NVM_LOCAL_PATTERN:-.*}" \
+    | ${NVM_LOCAL_SORT_COMMAND}; } << EOF
+${NVM_LOCAL_VERSION_LIST}
 EOF
 )"
-  if [ -z "${LOCAL_NVM_VERSIONS}" ]; then
+  if [ -z "${NVM_LOCAL_VERSIONS}" ]; then
     nvm_echo 'N/A'
     return 3
   fi
-  nvm_echo "${LOCAL_NVM_VERSIONS}"
+  nvm_echo "${NVM_LOCAL_VERSIONS}"
 }
 
 nvm_get_checksum_binary() {
@@ -1524,9 +1524,9 @@ nvm_get_checksum_binary() {
 }
 
 nvm_get_checksum_alg() {
-  local LOCAL_NVM_CHECKSUM_BIN
-  LOCAL_NVM_CHECKSUM_BIN="$(nvm_get_checksum_binary 2>/dev/null)"
-  case "${LOCAL_NVM_CHECKSUM_BIN-}" in
+  local NVM_LOCAL_CHECKSUM_BIN
+  NVM_LOCAL_CHECKSUM_BIN="$(nvm_get_checksum_binary 2>/dev/null)"
+  case "${NVM_LOCAL_CHECKSUM_BIN-}" in
     sha256sum | shasum | sha256 | gsha256sum | openssl | bssl)
       nvm_echo 'sha-256'
     ;;
@@ -1541,70 +1541,70 @@ nvm_get_checksum_alg() {
 }
 
 nvm_compute_checksum() {
-  local LOCAL_NVM_FILE
-  LOCAL_NVM_FILE="${1-}"
-  if [ -z "${LOCAL_NVM_FILE}" ]; then
+  local NVM_LOCAL_FILE
+  NVM_LOCAL_FILE="${1-}"
+  if [ -z "${NVM_LOCAL_FILE}" ]; then
     nvm_err 'Provided file to checksum is empty.'
     return 2
-  elif ! [ -f "${LOCAL_NVM_FILE}" ]; then
+  elif ! [ -f "${NVM_LOCAL_FILE}" ]; then
     nvm_err 'Provided file to checksum does not exist.'
     return 1
   fi
 
   if nvm_has_non_aliased "sha256sum"; then
     nvm_err 'Computing checksum with sha256sum'
-    command sha256sum "${LOCAL_NVM_FILE}" | command awk '{print $1}'
+    command sha256sum "${NVM_LOCAL_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "shasum"; then
     nvm_err 'Computing checksum with shasum -a 256'
-    command shasum -a 256 "${LOCAL_NVM_FILE}" | command awk '{print $1}'
+    command shasum -a 256 "${NVM_LOCAL_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "sha256"; then
     nvm_err 'Computing checksum with sha256 -q'
-    command sha256 -q "${LOCAL_NVM_FILE}" | command awk '{print $1}'
+    command sha256 -q "${NVM_LOCAL_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "gsha256sum"; then
     nvm_err 'Computing checksum with gsha256sum'
-    command gsha256sum "${LOCAL_NVM_FILE}" | command awk '{print $1}'
+    command gsha256sum "${NVM_LOCAL_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "openssl"; then
     nvm_err 'Computing checksum with openssl dgst -sha256'
-    command openssl dgst -sha256 "${LOCAL_NVM_FILE}" | command awk '{print $NF}'
+    command openssl dgst -sha256 "${NVM_LOCAL_FILE}" | command awk '{print $NF}'
   elif nvm_has_non_aliased "bssl"; then
     nvm_err 'Computing checksum with bssl sha256sum'
-    command bssl sha256sum "${LOCAL_NVM_FILE}" | command awk '{print $1}'
+    command bssl sha256sum "${NVM_LOCAL_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "sha1sum"; then
     nvm_err 'Computing checksum with sha1sum'
-    command sha1sum "${LOCAL_NVM_FILE}" | command awk '{print $1}'
+    command sha1sum "${NVM_LOCAL_FILE}" | command awk '{print $1}'
   elif nvm_has_non_aliased "sha1"; then
     nvm_err 'Computing checksum with sha1 -q'
-    command sha1 -q "${LOCAL_NVM_FILE}"
+    command sha1 -q "${NVM_LOCAL_FILE}"
   fi
 }
 
 nvm_compare_checksum() {
-  local LOCAL_NVM_FILE
-  LOCAL_NVM_FILE="${1-}"
-  if [ -z "${LOCAL_NVM_FILE}" ]; then
+  local NVM_LOCAL_FILE
+  NVM_LOCAL_FILE="${1-}"
+  if [ -z "${NVM_LOCAL_FILE}" ]; then
     nvm_err 'Provided file to checksum is empty.'
     return 4
-  elif ! [ -f "${LOCAL_NVM_FILE}" ]; then
+  elif ! [ -f "${NVM_LOCAL_FILE}" ]; then
     nvm_err 'Provided file to checksum does not exist.'
     return 3
   fi
 
-  local LOCAL_NVM_COMPUTED_SUM
-  LOCAL_NVM_COMPUTED_SUM="$(nvm_compute_checksum "${LOCAL_NVM_FILE}")"
+  local NVM_LOCAL_COMPUTED_SUM
+  NVM_LOCAL_COMPUTED_SUM="$(nvm_compute_checksum "${NVM_LOCAL_FILE}")"
 
-  local LOCAL_NVM_CHECKSUM
-  LOCAL_NVM_CHECKSUM="${2-}"
-  if [ -z "${LOCAL_NVM_CHECKSUM}" ]; then
+  local NVM_LOCAL_CHECKSUM
+  NVM_LOCAL_CHECKSUM="${2-}"
+  if [ -z "${NVM_LOCAL_CHECKSUM}" ]; then
     nvm_err 'Provided checksum to compare to is empty.'
     return 2
   fi
 
-  if [ -z "${LOCAL_NVM_COMPUTED_SUM}" ]; then
-    nvm_err "Computed checksum of '${LOCAL_NVM_FILE}' is empty." # missing in raspberry pi binary
+  if [ -z "${NVM_LOCAL_COMPUTED_SUM}" ]; then
+    nvm_err "Computed checksum of '${NVM_LOCAL_FILE}' is empty." # missing in raspberry pi binary
     nvm_err 'WARNING: Continuing *without checksum verification*'
     return
-  elif [ "${LOCAL_NVM_COMPUTED_SUM}" != "${LOCAL_NVM_CHECKSUM}" ]; then
-    nvm_err "Checksums do not match: '${LOCAL_NVM_COMPUTED_SUM}' found, '${LOCAL_NVM_CHECKSUM}' expected."
+  elif [ "${NVM_LOCAL_COMPUTED_SUM}" != "${NVM_LOCAL_CHECKSUM}" ]; then
+    nvm_err "Checksums do not match: '${NVM_LOCAL_COMPUTED_SUM}' found, '${NVM_LOCAL_CHECKSUM}' expected."
     return 1
   fi
   nvm_err 'Checksums matched!'
@@ -1612,128 +1612,128 @@ nvm_compare_checksum() {
 
 # args: flavor, type, version, slug, compression
 nvm_get_checksum() {
-  local LOCAL_NVM_FLAVOR
+  local NVM_LOCAL_FLAVOR
   case "${1-}" in
-    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
+    node | iojs) NVM_LOCAL_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 2
     ;;
   esac
 
-  local LOCAL_NVM_MIRROR
-  LOCAL_NVM_MIRROR="$(nvm_get_mirror "${LOCAL_NVM_FLAVOR}" "${2-}")"
-  if [ -z "${LOCAL_NVM_MIRROR}" ]; then
+  local NVM_LOCAL_MIRROR
+  NVM_LOCAL_MIRROR="$(nvm_get_mirror "${NVM_LOCAL_FLAVOR}" "${2-}")"
+  if [ -z "${NVM_LOCAL_MIRROR}" ]; then
     return 1
   fi
 
-  local LOCAL_NVM_SHASUMS_URL
+  local NVM_LOCAL_SHASUMS_URL
   if [ "$(nvm_get_checksum_alg)" = 'sha-256' ]; then
-    LOCAL_NVM_SHASUMS_URL="${LOCAL_NVM_MIRROR}/${3}/SHASUMS256.txt"
+    NVM_LOCAL_SHASUMS_URL="${NVM_LOCAL_MIRROR}/${3}/SHASUMS256.txt"
   else
-    LOCAL_NVM_SHASUMS_URL="${LOCAL_NVM_MIRROR}/${3}/SHASUMS.txt"
+    NVM_LOCAL_SHASUMS_URL="${NVM_LOCAL_MIRROR}/${3}/SHASUMS.txt"
   fi
 
-  nvm_download -L -s "${LOCAL_NVM_SHASUMS_URL}" -o - | command awk "{ if (\"${4}.${5}\" == \$2) print \$1}"
+  nvm_download -L -s "${NVM_LOCAL_SHASUMS_URL}" -o - | command awk "{ if (\"${4}.${5}\" == \$2) print \$1}"
 }
 
 nvm_print_versions() {
-  local LOCAL_NVM_VERSION
-  local LOCAL_NVM_LTS
-  local LOCAL_NVM_FORMAT
-  local LOCAL_NVM_CURRENT
-  local LOCAL_NVM_LATEST_LTS_COLOR
-  local LOCAL_NVM_OLD_LTS_COLOR
+  local NVM_LOCAL_VERSION
+  local NVM_LOCAL_LTS
+  local NVM_LOCAL_FORMAT
+  local NVM_LOCAL_CURRENT
+  local NVM_LOCAL_LATEST_LTS_COLOR
+  local NVM_LOCAL_OLD_LTS_COLOR
 
-  local LOCAL_NVM_INSTALLED_COLOR
-  local LOCAL_NVM_SYSTEM_COLOR
-  local LOCAL_NVM_CURRENT_COLOR
-  local LOCAL_NVM_NOT_INSTALLED_COLOR
-  local LOCAL_NVM_DEFAULT_COLOR
-  local LOCAL_NVM_LTS_COLOR
+  local NVM_LOCAL_INSTALLED_COLOR
+  local NVM_LOCAL_SYSTEM_COLOR
+  local NVM_LOCAL_CURRENT_COLOR
+  local NVM_LOCAL_NOT_INSTALLED_COLOR
+  local NVM_LOCAL_DEFAULT_COLOR
+  local NVM_LOCAL_LTS_COLOR
 
-  LOCAL_NVM_INSTALLED_COLOR=$(nvm_get_colors 1)
-  LOCAL_NVM_SYSTEM_COLOR=$(nvm_get_colors 2)
-  LOCAL_NVM_CURRENT_COLOR=$(nvm_get_colors 3)
-  LOCAL_NVM_NOT_INSTALLED_COLOR=$(nvm_get_colors 4)
-  LOCAL_NVM_DEFAULT_COLOR=$(nvm_get_colors 5)
-  LOCAL_NVM_LTS_COLOR=$(nvm_get_colors 6)
+  NVM_LOCAL_INSTALLED_COLOR=$(nvm_get_colors 1)
+  NVM_LOCAL_SYSTEM_COLOR=$(nvm_get_colors 2)
+  NVM_LOCAL_CURRENT_COLOR=$(nvm_get_colors 3)
+  NVM_LOCAL_NOT_INSTALLED_COLOR=$(nvm_get_colors 4)
+  NVM_LOCAL_DEFAULT_COLOR=$(nvm_get_colors 5)
+  NVM_LOCAL_LTS_COLOR=$(nvm_get_colors 6)
 
-  LOCAL_NVM_CURRENT=$(nvm_ls_current)
-  LOCAL_NVM_LATEST_LTS_COLOR=$(nvm_echo "${LOCAL_NVM_CURRENT_COLOR}" | command tr '0;' '1;')
-  LOCAL_NVM_OLD_LTS_COLOR="${LOCAL_NVM_DEFAULT_COLOR}"
-  local LOCAL_NVM_HAS_COLORS
+  NVM_LOCAL_CURRENT=$(nvm_ls_current)
+  NVM_LOCAL_LATEST_LTS_COLOR=$(nvm_echo "${NVM_LOCAL_CURRENT_COLOR}" | command tr '0;' '1;')
+  NVM_LOCAL_OLD_LTS_COLOR="${NVM_LOCAL_DEFAULT_COLOR}"
+  local NVM_LOCAL_HAS_COLORS
   if [ -z "${NVM_NO_COLORS-}" ] && nvm_has_colors; then
-    LOCAL_NVM_HAS_COLORS=1
+    NVM_LOCAL_HAS_COLORS=1
   fi
-  local LOCAL_NVM_LTS_LENGTH
-  local LOCAL_NVM_LTS_FORMAT
+  local NVM_LOCAL_LTS_LENGTH
+  local NVM_LOCAL_LTS_FORMAT
   nvm_echo "${1-}" \
   | command sed '1!G;h;$!d' \
   | command awk '{ if ($2 && $3 && $3 == "*") { print $1, "(Latest LTS: " $2 ")" } else if ($2) { print $1, "(LTS: " $2 ")" } else { print $1 } }' \
   | command sed '1!G;h;$!d' \
-  | while read -r LOCAL_NVM_VERSION_LINE; do
-    LOCAL_NVM_VERSION="${LOCAL_NVM_VERSION_LINE%% *}"
-    LOCAL_NVM_LTS="${LOCAL_NVM_VERSION_LINE#* }"
-    LOCAL_NVM_FORMAT='%15s'
-    if [ "_${LOCAL_NVM_VERSION}" = "_${LOCAL_NVM_CURRENT}" ]; then
-      if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
-        LOCAL_NVM_FORMAT="\033[${LOCAL_NVM_CURRENT_COLOR}-> %12s\033[0m"
+  | while read -r NVM_LOCAL_VERSION_LINE; do
+    NVM_LOCAL_VERSION="${NVM_LOCAL_VERSION_LINE%% *}"
+    NVM_LOCAL_LTS="${NVM_LOCAL_VERSION_LINE#* }"
+    NVM_LOCAL_FORMAT='%15s'
+    if [ "_${NVM_LOCAL_VERSION}" = "_${NVM_LOCAL_CURRENT}" ]; then
+      if [ "${NVM_LOCAL_HAS_COLORS-}" = '1' ]; then
+        NVM_LOCAL_FORMAT="\033[${NVM_LOCAL_CURRENT_COLOR}-> %12s\033[0m"
       else
-        LOCAL_NVM_FORMAT='-> %12s *'
+        NVM_LOCAL_FORMAT='-> %12s *'
       fi
-    elif [ "${LOCAL_NVM_VERSION}" = "system" ]; then
-      if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
-        LOCAL_NVM_FORMAT="\033[${LOCAL_NVM_SYSTEM_COLOR}%15s\033[0m"
+    elif [ "${NVM_LOCAL_VERSION}" = "system" ]; then
+      if [ "${NVM_LOCAL_HAS_COLORS-}" = '1' ]; then
+        NVM_LOCAL_FORMAT="\033[${NVM_LOCAL_SYSTEM_COLOR}%15s\033[0m"
       else
-        LOCAL_NVM_FORMAT='%15s *'
+        NVM_LOCAL_FORMAT='%15s *'
       fi
-    elif nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
-      if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
-        LOCAL_NVM_FORMAT="\033[${LOCAL_NVM_INSTALLED_COLOR}%15s\033[0m"
+    elif nvm_is_version_installed "${NVM_LOCAL_VERSION}"; then
+      if [ "${NVM_LOCAL_HAS_COLORS-}" = '1' ]; then
+        NVM_LOCAL_FORMAT="\033[${NVM_LOCAL_INSTALLED_COLOR}%15s\033[0m"
       else
-        LOCAL_NVM_FORMAT='%15s *'
+        NVM_LOCAL_FORMAT='%15s *'
       fi
     fi
-    if [ "${LOCAL_NVM_LTS}" != "${LOCAL_NVM_VERSION}" ]; then
-      case "${LOCAL_NVM_LTS}" in
+    if [ "${NVM_LOCAL_LTS}" != "${NVM_LOCAL_VERSION}" ]; then
+      case "${NVM_LOCAL_LTS}" in
         *Latest*)
-          LOCAL_NVM_LTS="${LOCAL_NVM_LTS##Latest }"
-          LOCAL_NVM_LTS_LENGTH="${#LOCAL_NVM_LTS}"
-          if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
-            LOCAL_NVM_LTS_FORMAT="  \\033[${LOCAL_NVM_LATEST_LTS_COLOR}%${LOCAL_NVM_LTS_LENGTH}s\\033[0m"
+          NVM_LOCAL_LTS="${NVM_LOCAL_LTS##Latest }"
+          NVM_LOCAL_LTS_LENGTH="${#NVM_LOCAL_LTS}"
+          if [ "${NVM_LOCAL_HAS_COLORS-}" = '1' ]; then
+            NVM_LOCAL_LTS_FORMAT="  \\033[${NVM_LOCAL_LATEST_LTS_COLOR}%${NVM_LOCAL_LTS_LENGTH}s\\033[0m"
           else
-            LOCAL_NVM_LTS_FORMAT="  %${LOCAL_NVM_LTS_LENGTH}s"
+            NVM_LOCAL_LTS_FORMAT="  %${NVM_LOCAL_LTS_LENGTH}s"
           fi
         ;;
         *)
-          LOCAL_NVM_LTS_LENGTH="${#LOCAL_NVM_LTS}"
-          if [ "${LOCAL_NVM_HAS_COLORS-}" = '1' ]; then
-            LOCAL_NVM_LTS_FORMAT="  \\033[${LOCAL_NVM_OLD_LTS_COLOR}%${LOCAL_NVM_LTS_LENGTH}s\\033[0m"
+          NVM_LOCAL_LTS_LENGTH="${#NVM_LOCAL_LTS}"
+          if [ "${NVM_LOCAL_HAS_COLORS-}" = '1' ]; then
+            NVM_LOCAL_LTS_FORMAT="  \\033[${NVM_LOCAL_OLD_LTS_COLOR}%${NVM_LOCAL_LTS_LENGTH}s\\033[0m"
           else
-            LOCAL_NVM_LTS_FORMAT="  %${LOCAL_NVM_LTS_LENGTH}s"
+            NVM_LOCAL_LTS_FORMAT="  %${NVM_LOCAL_LTS_LENGTH}s"
           fi
         ;;
       esac
-      command printf -- "${LOCAL_NVM_FORMAT}${LOCAL_NVM_LTS_FORMAT}\\n" "${LOCAL_NVM_VERSION}" " ${LOCAL_NVM_LTS}"
+      command printf -- "${NVM_LOCAL_FORMAT}${NVM_LOCAL_LTS_FORMAT}\\n" "${NVM_LOCAL_VERSION}" " ${NVM_LOCAL_LTS}"
     else
-      command printf -- "${LOCAL_NVM_FORMAT}\\n" "${LOCAL_NVM_VERSION}"
+      command printf -- "${NVM_LOCAL_FORMAT}\\n" "${NVM_LOCAL_VERSION}"
     fi
   done
 }
 
 nvm_validate_implicit_alias() {
-  local LOCAL_NVM_IOJS_PREFIX
-  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local LOCAL_NVM_NODE_PREFIX
-  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
+  local NVM_LOCAL_IOJS_PREFIX
+  NVM_LOCAL_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local NVM_LOCAL_NODE_PREFIX
+  NVM_LOCAL_NODE_PREFIX="$(nvm_node_prefix)"
 
   case "$1" in
-    "stable" | "unstable" | "${LOCAL_NVM_IOJS_PREFIX}" | "${LOCAL_NVM_NODE_PREFIX}")
+    "stable" | "unstable" | "${NVM_LOCAL_IOJS_PREFIX}" | "${NVM_LOCAL_NODE_PREFIX}")
       return
     ;;
     *)
-      nvm_err "Only implicit aliases 'stable', 'unstable', '${LOCAL_NVM_IOJS_PREFIX}', and '${LOCAL_NVM_NODE_PREFIX}' are supported."
+      nvm_err "Only implicit aliases 'stable', 'unstable', '${NVM_LOCAL_IOJS_PREFIX}', and '${NVM_LOCAL_NODE_PREFIX}' are supported."
       return 1
     ;;
   esac
@@ -1745,189 +1745,189 @@ nvm_print_implicit_alias() {
     return 1
   fi
 
-  local LOCAL_NVM_IMPLICIT
-  LOCAL_NVM_IMPLICIT="$2"
-  if ! nvm_validate_implicit_alias "${LOCAL_NVM_IMPLICIT}"; then
+  local NVM_LOCAL_IMPLICIT
+  NVM_LOCAL_IMPLICIT="$2"
+  if ! nvm_validate_implicit_alias "${NVM_LOCAL_IMPLICIT}"; then
     return 2
   fi
 
-  local LOCAL_NVM_IOJS_PREFIX
-  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local LOCAL_NVM_NODE_PREFIX
-  LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
-  local LOCAL_NVM_COMMAND
-  local LOCAL_NVM_ADD_PREFIX_COMMAND
-  local LOCAL_NVM_LAST_TWO
-  case "${LOCAL_NVM_IMPLICIT}" in
-    "${LOCAL_NVM_IOJS_PREFIX}")
-      LOCAL_NVM_COMMAND="nvm_ls_remote_iojs"
-      LOCAL_NVM_ADD_PREFIX_COMMAND="nvm_add_iojs_prefix"
+  local NVM_LOCAL_IOJS_PREFIX
+  NVM_LOCAL_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local NVM_LOCAL_NODE_PREFIX
+  NVM_LOCAL_NODE_PREFIX="$(nvm_node_prefix)"
+  local NVM_LOCAL_COMMAND
+  local NVM_LOCAL_ADD_PREFIX_COMMAND
+  local NVM_LOCAL_LAST_TWO
+  case "${NVM_LOCAL_IMPLICIT}" in
+    "${NVM_LOCAL_IOJS_PREFIX}")
+      NVM_LOCAL_COMMAND="nvm_ls_remote_iojs"
+      NVM_LOCAL_ADD_PREFIX_COMMAND="nvm_add_iojs_prefix"
       if [ "_$1" = "_local" ]; then
-        LOCAL_NVM_COMMAND="nvm_ls ${LOCAL_NVM_IMPLICIT}"
+        NVM_LOCAL_COMMAND="nvm_ls ${NVM_LOCAL_IMPLICIT}"
       fi
 
       nvm_is_zsh && setopt local_options shwordsplit
 
-      local LOCAL_NVM_IOJS_VERSION
-      local LOCAL_NVM_EXIT_CODE
-      LOCAL_NVM_IOJS_VERSION="$(${LOCAL_NVM_COMMAND})" &&:
-      LOCAL_NVM_EXIT_CODE="$?"
-      if [ "_${LOCAL_NVM_EXIT_CODE}" = "_0" ]; then
-        LOCAL_NVM_IOJS_VERSION="$(nvm_echo "${LOCAL_NVM_IOJS_VERSION}" | command sed "s/^${LOCAL_NVM_IMPLICIT}-//" | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2 | uniq | command tail -1)"
+      local NVM_LOCAL_IOJS_VERSION
+      local NVM_LOCAL_EXIT_CODE
+      NVM_LOCAL_IOJS_VERSION="$(${NVM_LOCAL_COMMAND})" &&:
+      NVM_LOCAL_EXIT_CODE="$?"
+      if [ "_${NVM_LOCAL_EXIT_CODE}" = "_0" ]; then
+        NVM_LOCAL_IOJS_VERSION="$(nvm_echo "${NVM_LOCAL_IOJS_VERSION}" | command sed "s/^${NVM_LOCAL_IMPLICIT}-//" | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2 | uniq | command tail -1)"
       fi
 
-      if [ "_${LOCAL_NVM_IOJS_VERSION}" = "_N/A" ]; then
+      if [ "_${NVM_LOCAL_IOJS_VERSION}" = "_N/A" ]; then
         nvm_echo 'N/A'
       else
-        ${LOCAL_NVM_ADD_PREFIX_COMMAND} "${LOCAL_NVM_IOJS_VERSION}"
+        ${NVM_LOCAL_ADD_PREFIX_COMMAND} "${NVM_LOCAL_IOJS_VERSION}"
       fi
-      return ${LOCAL_NVM_EXIT_CODE}
+      return ${NVM_LOCAL_EXIT_CODE}
     ;;
-    "${LOCAL_NVM_NODE_PREFIX}")
+    "${NVM_LOCAL_NODE_PREFIX}")
       nvm_echo 'stable'
       return
     ;;
     *)
-      LOCAL_NVM_COMMAND="nvm_ls_remote"
+      NVM_LOCAL_COMMAND="nvm_ls_remote"
       if [ "_$1" = "_local" ]; then
-        LOCAL_NVM_COMMAND="nvm_ls node"
+        NVM_LOCAL_COMMAND="nvm_ls node"
       fi
 
       nvm_is_zsh && setopt local_options shwordsplit
 
-      LOCAL_NVM_LAST_TWO=$(${LOCAL_NVM_COMMAND} | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2 | uniq)
+      NVM_LOCAL_LAST_TWO=$(${NVM_LOCAL_COMMAND} | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2 | uniq)
     ;;
   esac
-  local LOCAL_NVM_MINOR
-  local LOCAL_NVM_STABLE
-  local LOCAL_NVM_UNSTABLE
-  local LOCAL_NVM_MOD
-  local LOCAL_NVM_NORMALIZED_VERSION
+  local NVM_LOCAL_MINOR
+  local NVM_LOCAL_STABLE
+  local NVM_LOCAL_UNSTABLE
+  local NVM_LOCAL_MOD
+  local NVM_LOCAL_NORMALIZED_VERSION
 
   nvm_is_zsh && setopt local_options shwordsplit
-  for LOCAL_NVM_MINOR in ${LOCAL_NVM_LAST_TWO}; do
-    LOCAL_NVM_NORMALIZED_VERSION="$(nvm_normalize_version "${LOCAL_NVM_MINOR}")"
-    if [ "_0${LOCAL_NVM_NORMALIZED_VERSION#?}" != "_${LOCAL_NVM_NORMALIZED_VERSION}" ]; then
-      LOCAL_NVM_STABLE="${LOCAL_NVM_MINOR}"
+  for NVM_LOCAL_MINOR in ${NVM_LOCAL_LAST_TWO}; do
+    NVM_LOCAL_NORMALIZED_VERSION="$(nvm_normalize_version "${NVM_LOCAL_MINOR}")"
+    if [ "_0${NVM_LOCAL_NORMALIZED_VERSION#?}" != "_${NVM_LOCAL_NORMALIZED_VERSION}" ]; then
+      NVM_LOCAL_STABLE="${NVM_LOCAL_MINOR}"
     else
-      LOCAL_NVM_MOD="$(awk 'BEGIN { print int(ARGV[1] / 1000000) % 2 ; exit(0) }' "${LOCAL_NVM_NORMALIZED_VERSION}")"
-      if [ "${LOCAL_NVM_MOD}" -eq 0 ]; then
-        LOCAL_NVM_STABLE="${LOCAL_NVM_MINOR}"
-      elif [ "${LOCAL_NVM_MOD}" -eq 1 ]; then
-        LOCAL_NVM_UNSTABLE="${LOCAL_NVM_MINOR}"
+      NVM_LOCAL_MOD="$(awk 'BEGIN { print int(ARGV[1] / 1000000) % 2 ; exit(0) }' "${NVM_LOCAL_NORMALIZED_VERSION}")"
+      if [ "${NVM_LOCAL_MOD}" -eq 0 ]; then
+        NVM_LOCAL_STABLE="${NVM_LOCAL_MINOR}"
+      elif [ "${NVM_LOCAL_MOD}" -eq 1 ]; then
+        NVM_LOCAL_UNSTABLE="${NVM_LOCAL_MINOR}"
       fi
     fi
   done
 
   if [ "_$2" = '_stable' ]; then
-    nvm_echo "${LOCAL_NVM_STABLE}"
+    nvm_echo "${NVM_LOCAL_STABLE}"
   elif [ "_$2" = '_unstable' ]; then
-    nvm_echo "${LOCAL_NVM_UNSTABLE:-"N/A"}"
+    nvm_echo "${NVM_LOCAL_UNSTABLE:-"N/A"}"
   fi
 }
 
 nvm_get_os() {
-  local LOCAL_NVM_UNAME
-  LOCAL_NVM_UNAME="$(command uname -a)"
-  local LOCAL_NVM_OS
-  case "${LOCAL_NVM_UNAME}" in
-    Linux\ *) LOCAL_NVM_OS=linux ;;
-    Darwin\ *) LOCAL_NVM_OS=darwin ;;
-    SunOS\ *) LOCAL_NVM_OS=sunos ;;
-    FreeBSD\ *) LOCAL_NVM_OS=freebsd ;;
-    OpenBSD\ *) LOCAL_NVM_OS=openbsd ;;
-    AIX\ *) LOCAL_NVM_OS=aix ;;
-    CYGWIN* | MSYS* | MINGW*) LOCAL_NVM_OS=win ;;
+  local NVM_LOCAL_UNAME
+  NVM_LOCAL_UNAME="$(command uname -a)"
+  local NVM_LOCAL_OS
+  case "${NVM_LOCAL_UNAME}" in
+    Linux\ *) NVM_LOCAL_OS=linux ;;
+    Darwin\ *) NVM_LOCAL_OS=darwin ;;
+    SunOS\ *) NVM_LOCAL_OS=sunos ;;
+    FreeBSD\ *) NVM_LOCAL_OS=freebsd ;;
+    OpenBSD\ *) NVM_LOCAL_OS=openbsd ;;
+    AIX\ *) NVM_LOCAL_OS=aix ;;
+    CYGWIN* | MSYS* | MINGW*) NVM_LOCAL_OS=win ;;
   esac
-  nvm_echo "${LOCAL_NVM_OS-}"
+  nvm_echo "${NVM_LOCAL_OS-}"
 }
 
 nvm_get_arch() {
-  local LOCAL_NVM_HOST_ARCH
-  local LOCAL_NVM_OS
+  local NVM_LOCAL_HOST_ARCH
+  local NVM_LOCAL_OS
 
-  LOCAL_NVM_OS="$(nvm_get_os)"
+  NVM_LOCAL_OS="$(nvm_get_os)"
   # If the OS is SunOS, first try to use pkgsrc to guess
   # the most appropriate arch. If it's not available, use
   # isainfo to get the instruction set supported by the
   # kernel.
-  if [ "_${LOCAL_NVM_OS}" = "_sunos" ]; then
-    if LOCAL_NVM_HOST_ARCH=$(pkg_info -Q MACHINE_ARCH pkg_install); then
-      LOCAL_NVM_HOST_ARCH=$(nvm_echo "${LOCAL_NVM_HOST_ARCH}" | command tail -1)
+  if [ "_${NVM_LOCAL_OS}" = "_sunos" ]; then
+    if NVM_LOCAL_HOST_ARCH=$(pkg_info -Q MACHINE_ARCH pkg_install); then
+      NVM_LOCAL_HOST_ARCH=$(nvm_echo "${NVM_LOCAL_HOST_ARCH}" | command tail -1)
     else
-      LOCAL_NVM_HOST_ARCH=$(isainfo -n)
+      NVM_LOCAL_HOST_ARCH=$(isainfo -n)
     fi
-  elif [ "_${LOCAL_NVM_OS}" = "_aix" ]; then
-    LOCAL_NVM_HOST_ARCH=ppc64
+  elif [ "_${NVM_LOCAL_OS}" = "_aix" ]; then
+    NVM_LOCAL_HOST_ARCH=ppc64
   else
-    LOCAL_NVM_HOST_ARCH="$(command uname -m)"
+    NVM_LOCAL_HOST_ARCH="$(command uname -m)"
   fi
 
-  local LOCAL_NVM_ARCH
-  case "${LOCAL_NVM_HOST_ARCH}" in
-    x86_64 | amd64) LOCAL_NVM_ARCH="x64" ;;
-    i*86) LOCAL_NVM_ARCH="x86" ;;
-    aarch64) LOCAL_NVM_ARCH="arm64" ;;
-    *) LOCAL_NVM_ARCH="${LOCAL_NVM_HOST_ARCH}" ;;
+  local NVM_LOCAL_ARCH
+  case "${NVM_LOCAL_HOST_ARCH}" in
+    x86_64 | amd64) NVM_LOCAL_ARCH="x64" ;;
+    i*86) NVM_LOCAL_ARCH="x86" ;;
+    aarch64) NVM_LOCAL_ARCH="arm64" ;;
+    *) NVM_LOCAL_ARCH="${NVM_LOCAL_HOST_ARCH}" ;;
   esac
 
   # If running a 64bit ARM kernel but a 32bit ARM userland,
   # change ARCH to 32bit ARM (armv7l) if /sbin/init is 32bit executable
-  local LOCAL_NVM_L
-  if [ "$(uname)" = "Linux" ] && [ "${LOCAL_NVM_ARCH}" = arm64 ] &&
-    LOCAL_NVM_L="$(ls -dl /sbin/init 2>/dev/null)" &&
-    [ "$(od -An -t x1 -j 4 -N 1 "${LOCAL_NVM_L#*-> }")" = ' 01' ]; then
-    LOCAL_NVM_ARCH=armv7l
-    LOCAL_NVM_HOST_ARCH=armv7l
+  local NVM_LOCAL_L
+  if [ "$(uname)" = "Linux" ] && [ "${NVM_LOCAL_ARCH}" = arm64 ] &&
+    NVM_LOCAL_L="$(ls -dl /sbin/init 2>/dev/null)" &&
+    [ "$(od -An -t x1 -j 4 -N 1 "${NVM_LOCAL_L#*-> }")" = ' 01' ]; then
+    NVM_LOCAL_ARCH=armv7l
+    NVM_LOCAL_HOST_ARCH=armv7l
   fi
 
-  nvm_echo "${LOCAL_NVM_ARCH}"
+  nvm_echo "${NVM_LOCAL_ARCH}"
 }
 
 nvm_get_minor_version() {
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="$1"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="$1"
 
-  if [ -z "${LOCAL_NVM_VERSION}" ]; then
+  if [ -z "${NVM_LOCAL_VERSION}" ]; then
     nvm_err 'a version is required'
     return 1
   fi
 
-  case "${LOCAL_NVM_VERSION}" in
+  case "${NVM_LOCAL_VERSION}" in
     v | .* | *..* | v*[!.0123456789]* | [!v]*[!.0123456789]* | [!v0123456789]* | v[!0123456789]*)
       nvm_err 'invalid version number'
       return 2
     ;;
   esac
 
-  local LOCAL_NVM_PREFIXED_VERSION
-  LOCAL_NVM_PREFIXED_VERSION="$(nvm_format_version "${LOCAL_NVM_VERSION}")"
+  local NVM_LOCAL_PREFIXED_VERSION
+  NVM_LOCAL_PREFIXED_VERSION="$(nvm_format_version "${NVM_LOCAL_VERSION}")"
 
-  local LOCAL_NVM_MINOR
-  LOCAL_NVM_MINOR="$(nvm_echo "${LOCAL_NVM_PREFIXED_VERSION}" | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2)"
-  if [ -z "${LOCAL_NVM_MINOR}" ]; then
+  local NVM_LOCAL_MINOR
+  NVM_LOCAL_MINOR="$(nvm_echo "${NVM_LOCAL_PREFIXED_VERSION}" | nvm_grep -e '^v' | command cut -c2- | command cut -d . -f 1,2)"
+  if [ -z "${NVM_LOCAL_MINOR}" ]; then
     nvm_err 'invalid version number! (please report this)'
     return 3
   fi
-  nvm_echo "${LOCAL_NVM_MINOR}"
+  nvm_echo "${NVM_LOCAL_MINOR}"
 }
 
 nvm_ensure_default_set() {
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="$1"
-  if [ -z "${LOCAL_NVM_VERSION}" ]; then
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="$1"
+  if [ -z "${NVM_LOCAL_VERSION}" ]; then
     nvm_err 'nvm_ensure_default_set: a version is required'
     return 1
   elif nvm_alias default >/dev/null 2>&1; then
     # default already set
     return 0
   fi
-  local LOCAL_NVM_OUTPUT
-  LOCAL_NVM_OUTPUT="$(nvm alias default "${LOCAL_NVM_VERSION}")"
-  local LOCAL_NVM_EXIT_CODE
-  LOCAL_NVM_EXIT_CODE="$?"
-  nvm_echo "Creating default alias: ${LOCAL_NVM_OUTPUT}"
-  return ${LOCAL_NVM_EXIT_CODE}
+  local NVM_LOCAL_OUTPUT
+  NVM_LOCAL_OUTPUT="$(nvm alias default "${NVM_LOCAL_VERSION}")"
+  local NVM_LOCAL_EXIT_CODE
+  NVM_LOCAL_EXIT_CODE="$?"
+  nvm_echo "Creating default alias: ${NVM_LOCAL_OUTPUT}"
+  return ${NVM_LOCAL_EXIT_CODE}
 }
 
 nvm_is_merged_node_version() {
@@ -1952,295 +1952,295 @@ nvm_install_binary_extract() {
     return 1
   fi
 
-  local LOCAL_NVM_OS
-  local LOCAL_NVM_PREFIXED_VERSION
-  local LOCAL_NVM_VERSION
-  local LOCAL_NVM_TARBALL
-  local LOCAL_NVM_TMPDIR
-  LOCAL_NVM_OS="${1}"
-  LOCAL_NVM_PREFIXED_VERSION="${2}"
-  LOCAL_NVM_VERSION="${3}"
-  LOCAL_NVM_TARBALL="${4}"
-  LOCAL_NVM_TMPDIR="${5}"
+  local NVM_LOCAL_OS
+  local NVM_LOCAL_PREFIXED_VERSION
+  local NVM_LOCAL_VERSION
+  local NVM_LOCAL_TARBALL
+  local NVM_LOCAL_TMPDIR
+  NVM_LOCAL_OS="${1}"
+  NVM_LOCAL_PREFIXED_VERSION="${2}"
+  NVM_LOCAL_VERSION="${3}"
+  NVM_LOCAL_TARBALL="${4}"
+  NVM_LOCAL_TMPDIR="${5}"
 
-  local LOCAL_NVM_VERSION_PATH
+  local NVM_LOCAL_VERSION_PATH
 
-  [ -n "${LOCAL_NVM_TMPDIR-}" ] && \
-  command mkdir -p "${LOCAL_NVM_TMPDIR}" && \
-  LOCAL_NVM_VERSION_PATH="$(nvm_version_path "${LOCAL_NVM_PREFIXED_VERSION}")" || return 1
+  [ -n "${NVM_LOCAL_TMPDIR-}" ] && \
+  command mkdir -p "${NVM_LOCAL_TMPDIR}" && \
+  NVM_LOCAL_VERSION_PATH="$(nvm_version_path "${NVM_LOCAL_PREFIXED_VERSION}")" || return 1
 
   # For Windows system (GitBash with MSYS, Cygwin)
-  if [ "${LOCAL_NVM_OS}" = 'win' ]; then
-    LOCAL_NVM_VERSION_PATH="${LOCAL_NVM_VERSION_PATH}/bin"
-    command unzip -q "${LOCAL_NVM_TARBALL}" -d "${LOCAL_NVM_TMPDIR}" || return 1
+  if [ "${NVM_LOCAL_OS}" = 'win' ]; then
+    NVM_LOCAL_VERSION_PATH="${NVM_LOCAL_VERSION_PATH}/bin"
+    command unzip -q "${NVM_LOCAL_TARBALL}" -d "${NVM_LOCAL_TMPDIR}" || return 1
   # For non Windows system (including WSL running on Windows)
   else
-    nvm_extract_tarball "${LOCAL_NVM_OS}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}"
+    nvm_extract_tarball "${NVM_LOCAL_OS}" "${NVM_LOCAL_VERSION}" "${NVM_LOCAL_TARBALL}" "${NVM_LOCAL_TMPDIR}"
   fi
 
-  command mkdir -p "${LOCAL_NVM_VERSION_PATH}" || return 1
+  command mkdir -p "${NVM_LOCAL_VERSION_PATH}" || return 1
 
-  if [ "${LOCAL_NVM_OS}" = 'win' ]; then
-    command mv "${LOCAL_NVM_TMPDIR}/"*/* "${LOCAL_NVM_VERSION_PATH}" || return 1
-    command chmod +x "${LOCAL_NVM_VERSION_PATH}"/node.exe || return 1
-    command chmod +x "${LOCAL_NVM_VERSION_PATH}"/npm || return 1
-    command chmod +x "${LOCAL_NVM_VERSION_PATH}"/npx 2>/dev/null
+  if [ "${NVM_LOCAL_OS}" = 'win' ]; then
+    command mv "${NVM_LOCAL_TMPDIR}/"*/* "${NVM_LOCAL_VERSION_PATH}" || return 1
+    command chmod +x "${NVM_LOCAL_VERSION_PATH}"/node.exe || return 1
+    command chmod +x "${NVM_LOCAL_VERSION_PATH}"/npm || return 1
+    command chmod +x "${NVM_LOCAL_VERSION_PATH}"/npx 2>/dev/null
   else
-    command mv "${LOCAL_NVM_TMPDIR}/"* "${LOCAL_NVM_VERSION_PATH}" || return 1
+    command mv "${NVM_LOCAL_TMPDIR}/"* "${NVM_LOCAL_VERSION_PATH}" || return 1
   fi
 
-  command rm -rf "${LOCAL_NVM_TMPDIR}"
+  command rm -rf "${NVM_LOCAL_TMPDIR}"
 
   return 0
 }
 
 # args: flavor, type, version, reinstall
 nvm_install_binary() {
-  local LOCAL_NVM_FLAVOR
+  local NVM_LOCAL_FLAVOR
   case "${1-}" in
-    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
+    node | iojs) NVM_LOCAL_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 4
     ;;
   esac
 
-  local LOCAL_NVM_TYPE
-  LOCAL_NVM_TYPE="${2-}"
+  local NVM_LOCAL_TYPE
+  NVM_LOCAL_TYPE="${2-}"
 
-  local LOCAL_NVM_PREFIXED_VERSION
-  LOCAL_NVM_PREFIXED_VERSION="${3-}"
-  if [ -z "${LOCAL_NVM_PREFIXED_VERSION}" ]; then
+  local NVM_LOCAL_PREFIXED_VERSION
+  NVM_LOCAL_PREFIXED_VERSION="${3-}"
+  if [ -z "${NVM_LOCAL_PREFIXED_VERSION}" ]; then
     nvm_err 'A version number is required.'
     return 3
   fi
 
-  local LOCAL_NVM_NOSOURCE
-  LOCAL_NVM_NOSOURCE="${4-}"
+  local NVM_LOCAL_NOSOURCE
+  NVM_LOCAL_NOSOURCE="${4-}"
 
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="$(nvm_strip_iojs_prefix "${LOCAL_NVM_PREFIXED_VERSION}")"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="$(nvm_strip_iojs_prefix "${NVM_LOCAL_PREFIXED_VERSION}")"
 
-  local LOCAL_NVM_OS
-  LOCAL_NVM_OS="$(nvm_get_os)"
+  local NVM_LOCAL_OS
+  NVM_LOCAL_OS="$(nvm_get_os)"
 
-  if [ -z "${LOCAL_NVM_OS}" ]; then
+  if [ -z "${NVM_LOCAL_OS}" ]; then
     return 2
   fi
 
-  local LOCAL_NVM_TARBALL
-  local LOCAL_NVM_TMPDIR
+  local NVM_LOCAL_TARBALL
+  local NVM_LOCAL_TMPDIR
 
-  local LOCAL_NVM_PROGRESS_BAR
-  local LOCAL_NVM_NODE_OR_IOJS
-  if [ "${LOCAL_NVM_FLAVOR}" = 'node' ]; then
-    LOCAL_NVM_NODE_OR_IOJS="${LOCAL_NVM_FLAVOR}"
-  elif [ "${LOCAL_NVM_FLAVOR}" = 'iojs' ]; then
-    LOCAL_NVM_NODE_OR_IOJS="io.js"
+  local NVM_LOCAL_PROGRESS_BAR
+  local NVM_LOCAL_NODE_OR_IOJS
+  if [ "${NVM_LOCAL_FLAVOR}" = 'node' ]; then
+    NVM_LOCAL_NODE_OR_IOJS="${NVM_LOCAL_FLAVOR}"
+  elif [ "${NVM_LOCAL_FLAVOR}" = 'iojs' ]; then
+    NVM_LOCAL_NODE_OR_IOJS="io.js"
   fi
   if [ "${NVM_NO_PROGRESS-}" = "1" ]; then
     # --silent, --show-error, use short option as @samrocketman mentions the compatibility issue.
-    LOCAL_NVM_PROGRESS_BAR="-sS"
+    NVM_LOCAL_PROGRESS_BAR="-sS"
   else
-    LOCAL_NVM_PROGRESS_BAR="--progress-bar"
+    NVM_LOCAL_PROGRESS_BAR="--progress-bar"
   fi
-  nvm_echo "Downloading and installing ${LOCAL_NVM_NODE_OR_IOJS-} ${LOCAL_NVM_VERSION}..."
-  LOCAL_NVM_TARBALL="$(LOCAL_NVM_PROGRESS_BAR="${LOCAL_NVM_PROGRESS_BAR}" nvm_download_artifact "${LOCAL_NVM_FLAVOR}" binary "${LOCAL_NVM_TYPE-}" "${LOCAL_NVM_VERSION}" | command tail -1)"
-  if [ -f "${LOCAL_NVM_TARBALL}" ]; then
-    LOCAL_NVM_TMPDIR="$(dirname "${LOCAL_NVM_TARBALL}")/files"
+  nvm_echo "Downloading and installing ${NVM_LOCAL_NODE_OR_IOJS-} ${NVM_LOCAL_VERSION}..."
+  NVM_LOCAL_TARBALL="$(NVM_LOCAL_PROGRESS_BAR="${NVM_LOCAL_PROGRESS_BAR}" nvm_download_artifact "${NVM_LOCAL_FLAVOR}" binary "${NVM_LOCAL_TYPE-}" "${NVM_LOCAL_VERSION}" | command tail -1)"
+  if [ -f "${NVM_LOCAL_TARBALL}" ]; then
+    NVM_LOCAL_TMPDIR="$(dirname "${NVM_LOCAL_TARBALL}")/files"
   fi
 
-  if nvm_install_binary_extract "${LOCAL_NVM_OS}" "${LOCAL_NVM_PREFIXED_VERSION}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}"; then
-    if [ -n "${LOCAL_NVM_ALIAS-}" ]; then
-      nvm alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_PROVIDED_VERSION}"
+  if nvm_install_binary_extract "${NVM_LOCAL_OS}" "${NVM_LOCAL_PREFIXED_VERSION}" "${NVM_LOCAL_VERSION}" "${NVM_LOCAL_TARBALL}" "${NVM_LOCAL_TMPDIR}"; then
+    if [ -n "${NVM_LOCAL_ALIAS-}" ]; then
+      nvm alias "${NVM_LOCAL_ALIAS}" "${NVM_LOCAL_PROVIDED_VERSION}"
     fi
     return 0
   fi
 
 
-  # Read LOCAL_NVM_NOSOURCE from arguments
-  if [ "${LOCAL_NVM_NOSOURCE-}" = '1' ]; then
+  # Read NVM_LOCAL_NOSOURCE from arguments
+  if [ "${NVM_LOCAL_NOSOURCE-}" = '1' ]; then
       nvm_err 'Binary download failed. Download from source aborted.'
       return 0
   fi
 
   nvm_err 'Binary download failed, trying source.'
-  if [ -n "${LOCAL_NVM_TMPDIR-}" ]; then
-    command rm -rf "${LOCAL_NVM_TMPDIR}"
+  if [ -n "${NVM_LOCAL_TMPDIR-}" ]; then
+    command rm -rf "${NVM_LOCAL_TMPDIR}"
   fi
   return 1
 }
 
 # args: flavor, kind, version
 nvm_get_download_slug() {
-  local LOCAL_NVM_FLAVOR
+  local NVM_LOCAL_FLAVOR
   case "${1-}" in
-    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
+    node | iojs) NVM_LOCAL_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 1
     ;;
   esac
 
-  local LOCAL_NVM_KIND
+  local NVM_LOCAL_KIND
   case "${2-}" in
-    binary | source) LOCAL_NVM_KIND="${2}" ;;
+    binary | source) NVM_LOCAL_KIND="${2}" ;;
     *)
       nvm_err 'supported kinds: binary, source'
       return 2
     ;;
   esac
 
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="${3-}"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="${3-}"
 
-  local LOCAL_NVM_OS
-  LOCAL_NVM_OS="$(nvm_get_os)"
+  local NVM_LOCAL_OS
+  NVM_LOCAL_OS="$(nvm_get_os)"
 
-  local LOCAL_NVM_ARCH
-  LOCAL_NVM_ARCH="$(nvm_get_arch)"
-  if ! nvm_is_merged_node_version "${LOCAL_NVM_VERSION}"; then
-    if [ "${LOCAL_NVM_ARCH}" = 'armv6l' ] || [ "${LOCAL_NVM_ARCH}" = 'armv7l' ]; then
-      LOCAL_NVM_ARCH="arm-pi"
+  local NVM_LOCAL_ARCH
+  NVM_LOCAL_ARCH="$(nvm_get_arch)"
+  if ! nvm_is_merged_node_version "${NVM_LOCAL_VERSION}"; then
+    if [ "${NVM_LOCAL_ARCH}" = 'armv6l' ] || [ "${NVM_LOCAL_ARCH}" = 'armv7l' ]; then
+      NVM_LOCAL_ARCH="arm-pi"
     fi
   fi
 
   # If node version in below 16.0.0 then there is no arm64 packages available in node repositories, so we have to install "x64" arch packages
   # If running MAC M1 :: arm64 arch and Darwin OS then use "x64" Architecture because node doesn't provide darwin_arm64 package below v16.0.0
-  if nvm_version_greater '16.0.0' "${LOCAL_NVM_VERSION}"; then
-    if [ "_${LOCAL_NVM_OS}" = '_darwin' ] && [ "${LOCAL_NVM_ARCH}" = 'arm64' ]; then
-      LOCAL_NVM_ARCH=x64
+  if nvm_version_greater '16.0.0' "${NVM_LOCAL_VERSION}"; then
+    if [ "_${NVM_LOCAL_OS}" = '_darwin' ] && [ "${NVM_LOCAL_ARCH}" = 'arm64' ]; then
+      NVM_LOCAL_ARCH=x64
     fi
   fi
 
-  if [ "${LOCAL_NVM_KIND}" = 'binary' ]; then
-    nvm_echo "${LOCAL_NVM_FLAVOR}-${LOCAL_NVM_VERSION}-${LOCAL_NVM_OS}-${LOCAL_NVM_ARCH}"
-  elif [ "${LOCAL_NVM_KIND}" = 'source' ]; then
-    nvm_echo "${LOCAL_NVM_FLAVOR}-${LOCAL_NVM_VERSION}"
+  if [ "${NVM_LOCAL_KIND}" = 'binary' ]; then
+    nvm_echo "${NVM_LOCAL_FLAVOR}-${NVM_LOCAL_VERSION}-${NVM_LOCAL_OS}-${NVM_LOCAL_ARCH}"
+  elif [ "${NVM_LOCAL_KIND}" = 'source' ]; then
+    nvm_echo "${NVM_LOCAL_FLAVOR}-${NVM_LOCAL_VERSION}"
   fi
 }
 
 nvm_get_artifact_compression() {
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="${1-}"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="${1-}"
 
-  local LOCAL_NVM_OS
-  LOCAL_NVM_OS="$(nvm_get_os)"
+  local NVM_LOCAL_OS
+  NVM_LOCAL_OS="$(nvm_get_os)"
 
-  local LOCAL_NVM_COMPRESSION
-  LOCAL_NVM_COMPRESSION='tar.gz'
-  if [ "_${LOCAL_NVM_OS}" = '_win' ]; then
-    LOCAL_NVM_COMPRESSION='zip'
-  elif nvm_supports_xz "${LOCAL_NVM_VERSION}"; then
-    LOCAL_NVM_COMPRESSION='tar.xz'
+  local NVM_LOCAL_COMPRESSION
+  NVM_LOCAL_COMPRESSION='tar.gz'
+  if [ "_${NVM_LOCAL_OS}" = '_win' ]; then
+    NVM_LOCAL_COMPRESSION='zip'
+  elif nvm_supports_xz "${NVM_LOCAL_VERSION}"; then
+    NVM_LOCAL_COMPRESSION='tar.xz'
   fi
 
-  nvm_echo "${LOCAL_NVM_COMPRESSION}"
+  nvm_echo "${NVM_LOCAL_COMPRESSION}"
 }
 
 # args: flavor, kind, type, version
 nvm_download_artifact() {
-  local LOCAL_NVM_FLAVOR
+  local NVM_LOCAL_FLAVOR
   case "${1-}" in
-    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
+    node | iojs) NVM_LOCAL_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 1
     ;;
   esac
 
-  local LOCAL_NVM_KIND
+  local NVM_LOCAL_KIND
   case "${2-}" in
-    binary | source) LOCAL_NVM_KIND="${2}" ;;
+    binary | source) NVM_LOCAL_KIND="${2}" ;;
     *)
       nvm_err 'supported kinds: binary, source'
       return 1
     ;;
   esac
 
-  local LOCAL_NVM_TYPE
-  LOCAL_NVM_TYPE="${3-}"
+  local NVM_LOCAL_TYPE
+  NVM_LOCAL_TYPE="${3-}"
 
-  local LOCAL_NVM_MIRROR
-  LOCAL_NVM_MIRROR="$(nvm_get_mirror "${LOCAL_NVM_FLAVOR}" "${LOCAL_NVM_TYPE}")"
-  if [ -z "${LOCAL_NVM_MIRROR}" ]; then
+  local NVM_LOCAL_MIRROR
+  NVM_LOCAL_MIRROR="$(nvm_get_mirror "${NVM_LOCAL_FLAVOR}" "${NVM_LOCAL_TYPE}")"
+  if [ -z "${NVM_LOCAL_MIRROR}" ]; then
     return 2
   fi
 
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="${4}"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="${4}"
 
-  if [ -z "${LOCAL_NVM_VERSION}" ]; then
+  if [ -z "${NVM_LOCAL_VERSION}" ]; then
     nvm_err 'A version number is required.'
     return 3
   fi
 
-  if [ "${LOCAL_NVM_KIND}" = 'binary' ] && ! nvm_binary_available "${LOCAL_NVM_VERSION}"; then
-    nvm_err "No precompiled binary available for ${LOCAL_NVM_VERSION}."
+  if [ "${NVM_LOCAL_KIND}" = 'binary' ] && ! nvm_binary_available "${NVM_LOCAL_VERSION}"; then
+    nvm_err "No precompiled binary available for ${NVM_LOCAL_VERSION}."
     return
   fi
 
-  local LOCAL_NVM_SLUG
-  LOCAL_NVM_SLUG="$(nvm_get_download_slug "${LOCAL_NVM_FLAVOR}" "${LOCAL_NVM_KIND}" "${LOCAL_NVM_VERSION}")"
+  local NVM_LOCAL_SLUG
+  NVM_LOCAL_SLUG="$(nvm_get_download_slug "${NVM_LOCAL_FLAVOR}" "${NVM_LOCAL_KIND}" "${NVM_LOCAL_VERSION}")"
 
-  local LOCAL_NVM_COMPRESSION
-  LOCAL_NVM_COMPRESSION="$(nvm_get_artifact_compression "${LOCAL_NVM_VERSION}")"
+  local NVM_LOCAL_COMPRESSION
+  NVM_LOCAL_COMPRESSION="$(nvm_get_artifact_compression "${NVM_LOCAL_VERSION}")"
 
-  local LOCAL_NVM_CHECKSUM
-  LOCAL_NVM_CHECKSUM="$(nvm_get_checksum "${LOCAL_NVM_FLAVOR}" "${LOCAL_NVM_TYPE}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_SLUG}" "${LOCAL_NVM_COMPRESSION}")"
+  local NVM_LOCAL_CHECKSUM
+  NVM_LOCAL_CHECKSUM="$(nvm_get_checksum "${NVM_LOCAL_FLAVOR}" "${NVM_LOCAL_TYPE}" "${NVM_LOCAL_VERSION}" "${NVM_LOCAL_SLUG}" "${NVM_LOCAL_COMPRESSION}")"
 
-  local LOCAL_NVM_TMPDIR
-  if [ "${LOCAL_NVM_KIND}" = 'binary' ]; then
-    LOCAL_NVM_TMPDIR="$(nvm_cache_dir)/bin/${LOCAL_NVM_SLUG}"
+  local NVM_LOCAL_TMPDIR
+  if [ "${NVM_LOCAL_KIND}" = 'binary' ]; then
+    NVM_LOCAL_TMPDIR="$(nvm_cache_dir)/bin/${NVM_LOCAL_SLUG}"
   else
-    LOCAL_NVM_TMPDIR="$(nvm_cache_dir)/src/${LOCAL_NVM_SLUG}"
+    NVM_LOCAL_TMPDIR="$(nvm_cache_dir)/src/${NVM_LOCAL_SLUG}"
   fi
-  command mkdir -p "${LOCAL_NVM_TMPDIR}/files" || (
-    nvm_err "creating directory ${LOCAL_NVM_TMPDIR}/files failed"
+  command mkdir -p "${NVM_LOCAL_TMPDIR}/files" || (
+    nvm_err "creating directory ${NVM_LOCAL_TMPDIR}/files failed"
     return 3
   )
 
-  local LOCAL_NVM_TARBALL
-  LOCAL_NVM_TARBALL="${LOCAL_NVM_TMPDIR}/${LOCAL_NVM_SLUG}.${LOCAL_NVM_COMPRESSION}"
-  local LOCAL_NVM_TARBALL_URL
-  if nvm_version_greater_than_or_equal_to "${LOCAL_NVM_VERSION}" 0.1.14; then
-    LOCAL_NVM_TARBALL_URL="${LOCAL_NVM_MIRROR}/${LOCAL_NVM_VERSION}/${LOCAL_NVM_SLUG}.${LOCAL_NVM_COMPRESSION}"
+  local NVM_LOCAL_TARBALL
+  NVM_LOCAL_TARBALL="${NVM_LOCAL_TMPDIR}/${NVM_LOCAL_SLUG}.${NVM_LOCAL_COMPRESSION}"
+  local NVM_LOCAL_TARBALL_URL
+  if nvm_version_greater_than_or_equal_to "${NVM_LOCAL_VERSION}" 0.1.14; then
+    NVM_LOCAL_TARBALL_URL="${NVM_LOCAL_MIRROR}/${NVM_LOCAL_VERSION}/${NVM_LOCAL_SLUG}.${NVM_LOCAL_COMPRESSION}"
   else
     # node <= 0.1.13 does not have a directory
-    LOCAL_NVM_TARBALL_URL="${LOCAL_NVM_MIRROR}/${LOCAL_NVM_SLUG}.${LOCAL_NVM_COMPRESSION}"
+    NVM_LOCAL_TARBALL_URL="${NVM_LOCAL_MIRROR}/${NVM_LOCAL_SLUG}.${NVM_LOCAL_COMPRESSION}"
   fi
 
-  if [ -r "${LOCAL_NVM_TARBALL}" ]; then
-    nvm_err "Local cache found: $(nvm_sanitize_path "${LOCAL_NVM_TARBALL}")"
-    if nvm_compare_checksum "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_CHECKSUM}" >/dev/null 2>&1; then
-      nvm_err "Checksums match! Using existing downloaded archive $(nvm_sanitize_path "${LOCAL_NVM_TARBALL}")"
-      nvm_echo "${LOCAL_NVM_TARBALL}"
+  if [ -r "${NVM_LOCAL_TARBALL}" ]; then
+    nvm_err "Local cache found: $(nvm_sanitize_path "${NVM_LOCAL_TARBALL}")"
+    if nvm_compare_checksum "${NVM_LOCAL_TARBALL}" "${NVM_LOCAL_CHECKSUM}" >/dev/null 2>&1; then
+      nvm_err "Checksums match! Using existing downloaded archive $(nvm_sanitize_path "${NVM_LOCAL_TARBALL}")"
+      nvm_echo "${NVM_LOCAL_TARBALL}"
       return 0
     fi
-    nvm_compare_checksum "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_CHECKSUM}"
+    nvm_compare_checksum "${NVM_LOCAL_TARBALL}" "${NVM_LOCAL_CHECKSUM}"
     nvm_err "Checksum check failed!"
     nvm_err "Removing the broken local cache..."
-    command rm -rf "${LOCAL_NVM_TARBALL}"
+    command rm -rf "${NVM_LOCAL_TARBALL}"
   fi
-  nvm_err "Downloading ${LOCAL_NVM_TARBALL_URL}..."
-  nvm_download -L -C - "${LOCAL_NVM_PROGRESS_BAR}" "${LOCAL_NVM_TARBALL_URL}" -o "${LOCAL_NVM_TARBALL}" || (
-    command rm -rf "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}"
-    nvm_err "Binary download from ${LOCAL_NVM_TARBALL_URL} failed, trying source."
+  nvm_err "Downloading ${NVM_LOCAL_TARBALL_URL}..."
+  nvm_download -L -C - "${NVM_LOCAL_PROGRESS_BAR}" "${NVM_LOCAL_TARBALL_URL}" -o "${NVM_LOCAL_TARBALL}" || (
+    command rm -rf "${NVM_LOCAL_TARBALL}" "${NVM_LOCAL_TMPDIR}"
+    nvm_err "Binary download from ${NVM_LOCAL_TARBALL_URL} failed, trying source."
     return 4
   )
 
-  if nvm_grep '404 Not Found' "${LOCAL_NVM_TARBALL}" >/dev/null; then
-    command rm -rf "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}"
-    nvm_err "HTTP 404 at URL ${LOCAL_NVM_TARBALL_URL}"
+  if nvm_grep '404 Not Found' "${NVM_LOCAL_TARBALL}" >/dev/null; then
+    command rm -rf "${NVM_LOCAL_TARBALL}" "${NVM_LOCAL_TMPDIR}"
+    nvm_err "HTTP 404 at URL ${NVM_LOCAL_TARBALL_URL}"
     return 5
   fi
 
-  nvm_compare_checksum "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_CHECKSUM}" || (
-    command rm -rf "${LOCAL_NVM_TMPDIR}/files"
+  nvm_compare_checksum "${NVM_LOCAL_TARBALL}" "${NVM_LOCAL_CHECKSUM}" || (
+    command rm -rf "${NVM_LOCAL_TMPDIR}/files"
     return 6
   )
 
-  nvm_echo "${LOCAL_NVM_TARBALL}"
+  nvm_echo "${NVM_LOCAL_TARBALL}"
 }
 
 # args: nvm_os, version, tarball, tmpdir
@@ -2250,78 +2250,78 @@ nvm_extract_tarball() {
     return 5
   fi
 
-  local LOCAL_NVM_OS
-  LOCAL_NVM_OS="${1-}"
+  local NVM_LOCAL_OS
+  NVM_LOCAL_OS="${1-}"
 
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="${2-}"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="${2-}"
 
-  local LOCAL_NVM_TARBALL
-  LOCAL_NVM_TARBALL="${3-}"
+  local NVM_LOCAL_TARBALL
+  NVM_LOCAL_TARBALL="${3-}"
 
-  local LOCAL_NVM_TMPDIR
-  LOCAL_NVM_TMPDIR="${4-}"
+  local NVM_LOCAL_TMPDIR
+  NVM_LOCAL_TMPDIR="${4-}"
 
-  local LOCAL_NVM_TAR_COMPRESSION_FLAG
-  LOCAL_NVM_TAR_COMPRESSION_FLAG='z'
-  if nvm_supports_xz "${LOCAL_NVM_VERSION}"; then
-    LOCAL_NVM_TAR_COMPRESSION_FLAG='J'
+  local NVM_LOCAL_TAR_COMPRESSION_FLAG
+  NVM_LOCAL_TAR_COMPRESSION_FLAG='z'
+  if nvm_supports_xz "${NVM_LOCAL_VERSION}"; then
+    NVM_LOCAL_TAR_COMPRESSION_FLAG='J'
   fi
 
-  local LOCAL_NVM_TOOL_TAR
-  LOCAL_NVM_TOOL_TAR='tar'
-  if [ "${LOCAL_NVM_OS}" = 'aix' ]; then
-    LOCAL_NVM_TOOL_TAR='gtar'
+  local NVM_LOCAL_TOOL_TAR
+  NVM_LOCAL_TOOL_TAR='tar'
+  if [ "${NVM_LOCAL_OS}" = 'aix' ]; then
+    NVM_LOCAL_TOOL_TAR='gtar'
   fi
 
-  if [ "${LOCAL_NVM_OS}" = 'openbsd' ]; then
-    if [ "${LOCAL_NVM_TAR_COMPRESSION_FLAG}" = 'J' ]; then
-      command xzcat "${LOCAL_NVM_TARBALL}" | "${LOCAL_NVM_TOOL_TAR}" -xf - -C "${LOCAL_NVM_TMPDIR}" -s '/[^\/]*\///' || return 1
+  if [ "${NVM_LOCAL_OS}" = 'openbsd' ]; then
+    if [ "${NVM_LOCAL_TAR_COMPRESSION_FLAG}" = 'J' ]; then
+      command xzcat "${NVM_LOCAL_TARBALL}" | "${NVM_LOCAL_TOOL_TAR}" -xf - -C "${NVM_LOCAL_TMPDIR}" -s '/[^\/]*\///' || return 1
     else
-      command "${LOCAL_NVM_TOOL_TAR}" -x${LOCAL_NVM_TAR_COMPRESSION_FLAG}f "${LOCAL_NVM_TARBALL}" -C "${LOCAL_NVM_TMPDIR}" -s '/[^\/]*\///' || return 1
+      command "${NVM_LOCAL_TOOL_TAR}" -x${NVM_LOCAL_TAR_COMPRESSION_FLAG}f "${NVM_LOCAL_TARBALL}" -C "${NVM_LOCAL_TMPDIR}" -s '/[^\/]*\///' || return 1
     fi
   else
-    command "${LOCAL_NVM_TOOL_TAR}" -x${LOCAL_NVM_TAR_COMPRESSION_FLAG}f "${LOCAL_NVM_TARBALL}" -C "${LOCAL_NVM_TMPDIR}" --strip-components 1 || return 1
+    command "${NVM_LOCAL_TOOL_TAR}" -x${NVM_LOCAL_TAR_COMPRESSION_FLAG}f "${NVM_LOCAL_TARBALL}" -C "${NVM_LOCAL_TMPDIR}" --strip-components 1 || return 1
   fi
 }
 
 nvm_get_make_jobs() {
   if nvm_is_natural_num "${1-}"; then
-    LOCAL_NVM_MAKE_JOBS="$1"
-    nvm_echo "number of \`make\` jobs: ${LOCAL_NVM_MAKE_JOBS}"
+    NVM_LOCAL_MAKE_JOBS="$1"
+    nvm_echo "number of \`make\` jobs: ${NVM_LOCAL_MAKE_JOBS}"
     return
   elif [ -n "${1-}" ]; then
-    unset LOCAL_NVM_MAKE_JOBS
+    unset NVM_LOCAL_MAKE_JOBS
     nvm_err "$1 is invalid for number of \`make\` jobs, must be a natural number"
   fi
-  local LOCAL_NVM_OS
-  LOCAL_NVM_OS="$(nvm_get_os)"
-  local LOCAL_NVM_CPU_CORES
-  case "_${LOCAL_NVM_OS}" in
+  local NVM_LOCAL_OS
+  NVM_LOCAL_OS="$(nvm_get_os)"
+  local NVM_LOCAL_CPU_CORES
+  case "_${NVM_LOCAL_OS}" in
     "_linux")
-      LOCAL_NVM_CPU_CORES="$(nvm_grep -c -E '^processor.+: [0-9]+' /proc/cpuinfo)"
+      NVM_LOCAL_CPU_CORES="$(nvm_grep -c -E '^processor.+: [0-9]+' /proc/cpuinfo)"
     ;;
     "_freebsd" | "_darwin" | "_openbsd")
-      LOCAL_NVM_CPU_CORES="$(sysctl -n hw.ncpu)"
+      NVM_LOCAL_CPU_CORES="$(sysctl -n hw.ncpu)"
     ;;
     "_sunos")
-      LOCAL_NVM_CPU_CORES="$(psrinfo | wc -l)"
+      NVM_LOCAL_CPU_CORES="$(psrinfo | wc -l)"
     ;;
     "_aix")
-      LOCAL_NVM_CPU_CORES="$(pmcycles -m | wc -l)"
+      NVM_LOCAL_CPU_CORES="$(pmcycles -m | wc -l)"
     ;;
   esac
-  if ! nvm_is_natural_num "${LOCAL_NVM_CPU_CORES}"; then
+  if ! nvm_is_natural_num "${NVM_LOCAL_CPU_CORES}"; then
     nvm_err 'Can not determine how many core(s) are available, running in single-threaded mode.'
     nvm_err 'Please report an issue on GitHub to help us make nvm run faster on your computer!'
-    LOCAL_NVM_MAKE_JOBS=1
+    NVM_LOCAL_MAKE_JOBS=1
   else
-    nvm_echo "Detected that you have ${LOCAL_NVM_CPU_CORES} CPU core(s)"
-    if [ "${LOCAL_NVM_CPU_CORES}" -gt 2 ]; then
-      LOCAL_NVM_MAKE_JOBS=$((LOCAL_NVM_CPU_CORES - 1))
-      nvm_echo "Running with ${LOCAL_NVM_MAKE_JOBS} threads to speed up the build"
+    nvm_echo "Detected that you have ${NVM_LOCAL_CPU_CORES} CPU core(s)"
+    if [ "${NVM_LOCAL_CPU_CORES}" -gt 2 ]; then
+      NVM_LOCAL_MAKE_JOBS=$((NVM_LOCAL_CPU_CORES - 1))
+      nvm_echo "Running with ${NVM_LOCAL_MAKE_JOBS} threads to speed up the build"
     else
-      LOCAL_NVM_MAKE_JOBS=1
+      NVM_LOCAL_MAKE_JOBS=1
       nvm_echo 'Number of CPU core(s) less than or equal to 2, running in single-threaded mode'
     fi
   fi
@@ -2329,103 +2329,103 @@ nvm_get_make_jobs() {
 
 # args: flavor, type, version, make jobs, additional
 nvm_install_source() {
-  local LOCAL_NVM_FLAVOR
+  local NVM_LOCAL_FLAVOR
   case "${1-}" in
-    node | iojs) LOCAL_NVM_FLAVOR="${1}" ;;
+    node | iojs) NVM_LOCAL_FLAVOR="${1}" ;;
     *)
       nvm_err 'supported flavors: node, iojs'
       return 4
     ;;
   esac
 
-  local LOCAL_NVM_TYPE
-  LOCAL_NVM_TYPE="${2-}"
+  local NVM_LOCAL_TYPE
+  NVM_LOCAL_TYPE="${2-}"
 
-  local LOCAL_NVM_PREFIXED_VERSION
-  LOCAL_NVM_PREFIXED_VERSION="${3-}"
-  if [ -z "${LOCAL_NVM_PREFIXED_VERSION}" ]; then
+  local NVM_LOCAL_PREFIXED_VERSION
+  NVM_LOCAL_PREFIXED_VERSION="${3-}"
+  if [ -z "${NVM_LOCAL_PREFIXED_VERSION}" ]; then
     nvm_err 'A version number is required.'
     return 3
   fi
 
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="$(nvm_strip_iojs_prefix "${LOCAL_NVM_PREFIXED_VERSION}")"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="$(nvm_strip_iojs_prefix "${NVM_LOCAL_PREFIXED_VERSION}")"
 
-  local LOCAL_NVM_MAKE_JOBS
-  LOCAL_NVM_MAKE_JOBS="${4-}"
+  local NVM_LOCAL_MAKE_JOBS
+  NVM_LOCAL_MAKE_JOBS="${4-}"
 
-  local LOCAL_NVM_ADDITIONAL_PARAMETERS
-  LOCAL_NVM_ADDITIONAL_PARAMETERS="${5-}"
+  local NVM_LOCAL_ADDITIONAL_PARAMETERS
+  NVM_LOCAL_ADDITIONAL_PARAMETERS="${5-}"
 
-  local LOCAL_NVM_ARCH
-  LOCAL_NVM_ARCH="$(nvm_get_arch)"
-  if [ "${LOCAL_NVM_ARCH}" = 'armv6l' ] || [ "${LOCAL_NVM_ARCH}" = 'armv7l' ]; then
-    if [ -n "${LOCAL_NVM_ADDITIONAL_PARAMETERS}" ]; then
-      LOCAL_NVM_ADDITIONAL_PARAMETERS="--without-snapshot ${LOCAL_NVM_ADDITIONAL_PARAMETERS}"
+  local NVM_LOCAL_ARCH
+  NVM_LOCAL_ARCH="$(nvm_get_arch)"
+  if [ "${NVM_LOCAL_ARCH}" = 'armv6l' ] || [ "${NVM_LOCAL_ARCH}" = 'armv7l' ]; then
+    if [ -n "${NVM_LOCAL_ADDITIONAL_PARAMETERS}" ]; then
+      NVM_LOCAL_ADDITIONAL_PARAMETERS="--without-snapshot ${NVM_LOCAL_ADDITIONAL_PARAMETERS}"
     else
-      LOCAL_NVM_ADDITIONAL_PARAMETERS='--without-snapshot'
+      NVM_LOCAL_ADDITIONAL_PARAMETERS='--without-snapshot'
     fi
   fi
 
-  if [ -n "${LOCAL_NVM_ADDITIONAL_PARAMETERS}" ]; then
-    nvm_echo "Additional options while compiling: ${LOCAL_NVM_ADDITIONAL_PARAMETERS}"
+  if [ -n "${NVM_LOCAL_ADDITIONAL_PARAMETERS}" ]; then
+    nvm_echo "Additional options while compiling: ${NVM_LOCAL_ADDITIONAL_PARAMETERS}"
   fi
 
-  local LOCAL_NVM_OS
-  LOCAL_NVM_OS="$(nvm_get_os)"
+  local NVM_LOCAL_OS
+  NVM_LOCAL_OS="$(nvm_get_os)"
 
-  local LOCAL_NVM_TOOL_MAKE
-  LOCAL_NVM_TOOL_MAKE='make'
-  local LOCAL_NVM_MAKE_CXX
-  case "${LOCAL_NVM_OS}" in
+  local NVM_LOCAL_TOOL_MAKE
+  NVM_LOCAL_TOOL_MAKE='make'
+  local NVM_LOCAL_MAKE_CXX
+  case "${NVM_LOCAL_OS}" in
     'freebsd' | 'openbsd')
-      LOCAL_NVM_TOOL_MAKE='gmake'
-      LOCAL_NVM_MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
+      NVM_LOCAL_TOOL_MAKE='gmake'
+      NVM_LOCAL_MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
     ;;
     'darwin')
-      LOCAL_NVM_MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
+      NVM_LOCAL_MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
     ;;
     'aix')
-      LOCAL_NVM_TOOL_MAKE='gmake'
+      NVM_LOCAL_TOOL_MAKE='gmake'
     ;;
   esac
   if nvm_has "clang++" && nvm_has "clang" && nvm_version_greater_than_or_equal_to "$(nvm_clang_version)" 3.5; then
     if [ -z "${CC-}" ] || [ -z "${CXX-}" ]; then
       nvm_echo "Clang v3.5+ detected! CC or CXX not specified, will use Clang as C/C++ compiler!"
-      LOCAL_NVM_MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
+      NVM_LOCAL_MAKE_CXX="CC=${CC:-cc} CXX=${CXX:-c++}"
     fi
   fi
 
-  local LOCAL_NVM_TARBALL
-  local LOCAL_NVM_TMPDIR
-  local LOCAL_NVM_VERSION_PATH
+  local NVM_LOCAL_TARBALL
+  local NVM_LOCAL_TMPDIR
+  local NVM_LOCAL_VERSION_PATH
 
   if [ "${NVM_NO_PROGRESS-}" = "1" ]; then
     # --silent, --show-error, use short option as @samrocketman mentions the compatibility issue.
-    LOCAL_NVM_PROGRESS_BAR="-sS"
+    NVM_LOCAL_PROGRESS_BAR="-sS"
   else
-    LOCAL_NVM_PROGRESS_BAR="--progress-bar"
+    NVM_LOCAL_PROGRESS_BAR="--progress-bar"
   fi
 
   nvm_is_zsh && setopt local_options shwordsplit
 
-  LOCAL_NVM_TARBALL="$(LOCAL_NVM_PROGRESS_BAR="${LOCAL_NVM_PROGRESS_BAR}" nvm_download_artifact "${LOCAL_NVM_FLAVOR}" source "${LOCAL_NVM_TYPE}" "${LOCAL_NVM_VERSION}" | command tail -1)" && \
-  [ -f "${LOCAL_NVM_TARBALL}" ] && \
-  LOCAL_NVM_TMPDIR="$(dirname "${LOCAL_NVM_TARBALL}")/files" && \
+  NVM_LOCAL_TARBALL="$(NVM_LOCAL_PROGRESS_BAR="${NVM_LOCAL_PROGRESS_BAR}" nvm_download_artifact "${NVM_LOCAL_FLAVOR}" source "${NVM_LOCAL_TYPE}" "${NVM_LOCAL_VERSION}" | command tail -1)" && \
+  [ -f "${NVM_LOCAL_TARBALL}" ] && \
+  NVM_LOCAL_TMPDIR="$(dirname "${NVM_LOCAL_TARBALL}")/files" && \
   if ! (
     # shellcheck disable=SC2086
-    command mkdir -p "${LOCAL_NVM_TMPDIR}" && \
-    nvm_extract_tarball "${LOCAL_NVM_OS}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_TARBALL}" "${LOCAL_NVM_TMPDIR}" && \
-    LOCAL_NVM_VERSION_PATH="$(nvm_version_path "${LOCAL_NVM_PREFIXED_VERSION}")" && \
-    nvm_cd "${LOCAL_NVM_TMPDIR}" && \
-    nvm_echo '$>'./configure --prefix="${LOCAL_NVM_VERSION_PATH}" ${LOCAL_NVM_ADDITIONAL_PARAMETERS}'<' && \
-    ./configure --prefix="${LOCAL_NVM_VERSION_PATH}" ${LOCAL_NVM_ADDITIONAL_PARAMETERS} && \
-    ${LOCAL_NVM_TOOL_MAKE} -j "${LOCAL_NVM_MAKE_JOBS}" ${LOCAL_NVM_MAKE_CXX-} && \
-    command rm -f "${LOCAL_NVM_VERSION_PATH}" 2>/dev/null && \
-    ${LOCAL_NVM_TOOL_MAKE} -j "${LOCAL_NVM_MAKE_JOBS}" ${LOCAL_NVM_MAKE_CXX-} install
+    command mkdir -p "${NVM_LOCAL_TMPDIR}" && \
+    nvm_extract_tarball "${NVM_LOCAL_OS}" "${NVM_LOCAL_VERSION}" "${NVM_LOCAL_TARBALL}" "${NVM_LOCAL_TMPDIR}" && \
+    NVM_LOCAL_VERSION_PATH="$(nvm_version_path "${NVM_LOCAL_PREFIXED_VERSION}")" && \
+    nvm_cd "${NVM_LOCAL_TMPDIR}" && \
+    nvm_echo '$>'./configure --prefix="${NVM_LOCAL_VERSION_PATH}" ${NVM_LOCAL_ADDITIONAL_PARAMETERS}'<' && \
+    ./configure --prefix="${NVM_LOCAL_VERSION_PATH}" ${NVM_LOCAL_ADDITIONAL_PARAMETERS} && \
+    ${NVM_LOCAL_TOOL_MAKE} -j "${NVM_LOCAL_MAKE_JOBS}" ${NVM_LOCAL_MAKE_CXX-} && \
+    command rm -f "${NVM_LOCAL_VERSION_PATH}" 2>/dev/null && \
+    ${NVM_LOCAL_TOOL_MAKE} -j "${NVM_LOCAL_MAKE_JOBS}" ${NVM_LOCAL_MAKE_CXX-} install
   ); then
-    nvm_err "nvm: install ${LOCAL_NVM_VERSION} failed!"
-    command rm -rf "${LOCAL_NVM_TMPDIR-}"
+    nvm_err "nvm: install ${NVM_LOCAL_VERSION} failed!"
+    command rm -rf "${NVM_LOCAL_TMPDIR-}"
     return 1
   fi
 }
@@ -2438,14 +2438,14 @@ nvm_use_if_needed() {
 }
 
 nvm_install_npm_if_needed() {
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="$(nvm_ls_current)"
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="$(nvm_ls_current)"
   if ! nvm_has "npm"; then
     nvm_echo 'Installing npm...'
-    if nvm_version_greater 0.2.0 "${LOCAL_NVM_VERSION}"; then
+    if nvm_version_greater 0.2.0 "${NVM_LOCAL_VERSION}"; then
       nvm_err 'npm requires node v0.2.3 or higher'
-    elif nvm_version_greater_than_or_equal_to "${LOCAL_NVM_VERSION}" 0.2.0; then
-      if nvm_version_greater 0.2.3 "${LOCAL_NVM_VERSION}"; then
+    elif nvm_version_greater_than_or_equal_to "${NVM_LOCAL_VERSION}" 0.2.0; then
+      if nvm_version_greater 0.2.3 "${NVM_LOCAL_VERSION}"; then
         nvm_err 'npm requires node v0.2.3 or higher'
       else
         nvm_download -L https://npmjs.org/install.sh -o - | clean=yes npm_install=0.2.19 sh
@@ -2458,62 +2458,62 @@ nvm_install_npm_if_needed() {
 }
 
 nvm_match_version() {
-  local LOCAL_NVM_IOJS_PREFIX
-  LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-  local LOCAL_NVM_PROVIDED_VERSION
-  LOCAL_NVM_PROVIDED_VERSION="$1"
-  case "_${LOCAL_NVM_PROVIDED_VERSION}" in
-    "_${LOCAL_NVM_IOJS_PREFIX}" | '_io.js')
-      nvm_version "${LOCAL_NVM_IOJS_PREFIX}"
+  local NVM_LOCAL_IOJS_PREFIX
+  NVM_LOCAL_IOJS_PREFIX="$(nvm_iojs_prefix)"
+  local NVM_LOCAL_PROVIDED_VERSION
+  NVM_LOCAL_PROVIDED_VERSION="$1"
+  case "_${NVM_LOCAL_PROVIDED_VERSION}" in
+    "_${NVM_LOCAL_IOJS_PREFIX}" | '_io.js')
+      nvm_version "${NVM_LOCAL_IOJS_PREFIX}"
     ;;
     '_system')
       nvm_echo 'system'
     ;;
     *)
-      nvm_version "${LOCAL_NVM_PROVIDED_VERSION}"
+      nvm_version "${NVM_LOCAL_PROVIDED_VERSION}"
     ;;
   esac
 }
 
 nvm_npm_global_modules() {
-  local LOCAL_NVM_NPMLIST
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="$1"
-  LOCAL_NVM_NPMLIST=$(nvm use "${LOCAL_NVM_VERSION}" >/dev/null && npm list -g --depth=0 2>/dev/null | command sed 1,1d | nvm_grep -v 'UNMET PEER DEPENDENCY')
+  local NVM_LOCAL_NPMLIST
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="$1"
+  NVM_LOCAL_NPMLIST=$(nvm use "${NVM_LOCAL_VERSION}" >/dev/null && npm list -g --depth=0 2>/dev/null | command sed 1,1d | nvm_grep -v 'UNMET PEER DEPENDENCY')
 
-  local LOCAL_NVM_INSTALLS
-  LOCAL_NVM_INSTALLS=$(nvm_echo "${LOCAL_NVM_NPMLIST}" | command sed -e '/ -> / d' -e '/\(empty\)/ d' -e 's/^.* \(.*@[^ ]*\).*/\1/' -e '/^npm@[^ ]*.*$/ d' | command xargs)
+  local NVM_LOCAL_INSTALLS
+  NVM_LOCAL_INSTALLS=$(nvm_echo "${NVM_LOCAL_NPMLIST}" | command sed -e '/ -> / d' -e '/\(empty\)/ d' -e 's/^.* \(.*@[^ ]*\).*/\1/' -e '/^npm@[^ ]*.*$/ d' | command xargs)
 
-  local LOCAL_NVM_LINKS
-  LOCAL_NVM_LINKS="$(nvm_echo "${LOCAL_NVM_NPMLIST}" | command sed -n 's/.* -> \(.*\)/\1/ p')"
+  local NVM_LOCAL_LINKS
+  NVM_LOCAL_LINKS="$(nvm_echo "${NVM_LOCAL_NPMLIST}" | command sed -n 's/.* -> \(.*\)/\1/ p')"
 
-  nvm_echo "${LOCAL_NVM_INSTALLS} //// ${LOCAL_NVM_LINKS}"
+  nvm_echo "${NVM_LOCAL_INSTALLS} //// ${NVM_LOCAL_LINKS}"
 }
 
 nvm_npmrc_bad_news_bears() {
-  local LOCAL_NVM_NPMRC
-  LOCAL_NVM_NPMRC="${1-}"
-  if [ -n "${LOCAL_NVM_NPMRC}" ] && [ -f "${LOCAL_NVM_NPMRC}" ] && nvm_grep -Ee '^(prefix|globalconfig) *=' <"${LOCAL_NVM_NPMRC}" >/dev/null; then
+  local NVM_LOCAL_NPMRC
+  NVM_LOCAL_NPMRC="${1-}"
+  if [ -n "${NVM_LOCAL_NPMRC}" ] && [ -f "${NVM_LOCAL_NPMRC}" ] && nvm_grep -Ee '^(prefix|globalconfig) *=' <"${NVM_LOCAL_NPMRC}" >/dev/null; then
     return 0
   fi
   return 1
 }
 
 nvm_die_on_prefix() {
-  local LOCAL_NVM_DELETE_PREFIX
-  LOCAL_NVM_DELETE_PREFIX="${1-}"
-  case "${LOCAL_NVM_DELETE_PREFIX}" in
+  local NVM_LOCAL_DELETE_PREFIX
+  NVM_LOCAL_DELETE_PREFIX="${1-}"
+  case "${NVM_LOCAL_DELETE_PREFIX}" in
     0 | 1) ;;
     *)
       nvm_err 'First argument "delete the prefix" must be zero or one'
       return 1
     ;;
   esac
-  local LOCAL_NVM_COMMAND
-  LOCAL_NVM_COMMAND="${2-}"
-  local LOCAL_NVM_VERSION_DIR
-  LOCAL_NVM_VERSION_DIR="${3-}"
-  if [ -z "${LOCAL_NVM_COMMAND}" ] || [ -z "${LOCAL_NVM_VERSION_DIR}" ]; then
+  local NVM_LOCAL_COMMAND
+  NVM_LOCAL_COMMAND="${2-}"
+  local NVM_LOCAL_VERSION_DIR
+  NVM_LOCAL_VERSION_DIR="${3-}"
+  if [ -z "${NVM_LOCAL_COMMAND}" ] || [ -z "${NVM_LOCAL_VERSION_DIR}" ]; then
     nvm_err 'Second argument "nvm command", and third argument "nvm version dir", must both be nonempty'
     return 2
   fi
@@ -2528,8 +2528,8 @@ nvm_die_on_prefix() {
     return 3
   fi
 
-  local LOCAL_NVM_OS
-  LOCAL_NVM_OS="$(nvm_get_os)"
+  local NVM_LOCAL_OS
+  NVM_LOCAL_OS="$(nvm_get_os)"
 
   # npm normalizes NPM_CONFIG_-prefixed env vars
   # https://github.com/npm/npmconf/blob/22827e4038d6eebaafeb5c13ed2b92cf97b8fb82/npmconf.js#L331-L348
@@ -2537,18 +2537,18 @@ nvm_die_on_prefix() {
   #
   # here, we avoid trying to replicate "which one wins" or testing the value; if any are defined, it errors
   # until none are left.
-  local LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV
-  LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV="$(command awk 'BEGIN { for (name in ENVIRON) if (toupper(name) == "NPM_CONFIG_PREFIX") { print name; break } }')"
-  if [ -n "${LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV-}" ]; then
-    local LOCAL_NVM_CONFIG_VALUE
-    eval "LOCAL_NVM_CONFIG_VALUE=\"\$${LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV}\""
-    if [ -n "${LOCAL_NVM_CONFIG_VALUE-}" ] && [ "_${LOCAL_NVM_OS}" = "_win" ]; then
-      LOCAL_NVM_CONFIG_VALUE="$(cd "${LOCAL_NVM_CONFIG_VALUE}" 2>/dev/null && pwd)"
+  local NVM_LOCAL_NPM_CONFIG_x_PREFIX_ENV
+  NVM_LOCAL_NPM_CONFIG_x_PREFIX_ENV="$(command awk 'BEGIN { for (name in ENVIRON) if (toupper(name) == "NPM_CONFIG_PREFIX") { print name; break } }')"
+  if [ -n "${NVM_LOCAL_NPM_CONFIG_x_PREFIX_ENV-}" ]; then
+    local NVM_LOCAL_CONFIG_VALUE
+    eval "NVM_LOCAL_CONFIG_VALUE=\"\$${NVM_LOCAL_NPM_CONFIG_x_PREFIX_ENV}\""
+    if [ -n "${NVM_LOCAL_CONFIG_VALUE-}" ] && [ "_${NVM_LOCAL_OS}" = "_win" ]; then
+      NVM_LOCAL_CONFIG_VALUE="$(cd "${NVM_LOCAL_CONFIG_VALUE}" 2>/dev/null && pwd)"
     fi
-    if [ -n "${LOCAL_NVM_CONFIG_VALUE-}" ] && ! nvm_tree_contains_path "${NVM_DIR}" "${LOCAL_NVM_CONFIG_VALUE}"; then
+    if [ -n "${NVM_LOCAL_CONFIG_VALUE-}" ] && ! nvm_tree_contains_path "${NVM_DIR}" "${NVM_LOCAL_CONFIG_VALUE}"; then
       nvm deactivate >/dev/null 2>&1
-      nvm_err "nvm is not compatible with the \"${LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV}\" environment variable: currently set to \"${LOCAL_NVM_CONFIG_VALUE}\""
-      nvm_err "Run \`unset ${LOCAL_NVM_NPM_CONFIG_x_PREFIX_ENV}\` to unset it."
+      nvm_err "nvm is not compatible with the \"${NVM_LOCAL_NPM_CONFIG_x_PREFIX_ENV}\" environment variable: currently set to \"${NVM_LOCAL_CONFIG_VALUE}\""
+      nvm_err "Run \`unset ${NVM_LOCAL_NPM_CONFIG_x_PREFIX_ENV}\` to unset it."
       return 4
     fi
   fi
@@ -2565,126 +2565,126 @@ nvm_die_on_prefix() {
   # if any of them have a `prefix`, fail.
   # if any have `globalconfig`, fail also, just in case, to avoid spidering configs.
 
-  local LOCAL_NVM_NPM_BUILTIN_NPMRC
-  LOCAL_NVM_NPM_BUILTIN_NPMRC="${LOCAL_NVM_VERSION_DIR}/lib/node_modules/npm/npmrc"
-  if nvm_npmrc_bad_news_bears "${LOCAL_NVM_NPM_BUILTIN_NPMRC}"; then
-    if [ "_${LOCAL_NVM_DELETE_PREFIX}" = "_1" ]; then
-      npm config --loglevel=warn delete prefix --userconfig="${LOCAL_NVM_NPM_BUILTIN_NPMRC}"
-      npm config --loglevel=warn delete globalconfig --userconfig="${LOCAL_NVM_NPM_BUILTIN_NPMRC}"
+  local NVM_LOCAL_NPM_BUILTIN_NPMRC
+  NVM_LOCAL_NPM_BUILTIN_NPMRC="${NVM_LOCAL_VERSION_DIR}/lib/node_modules/npm/npmrc"
+  if nvm_npmrc_bad_news_bears "${NVM_LOCAL_NPM_BUILTIN_NPMRC}"; then
+    if [ "_${NVM_LOCAL_DELETE_PREFIX}" = "_1" ]; then
+      npm config --loglevel=warn delete prefix --userconfig="${NVM_LOCAL_NPM_BUILTIN_NPMRC}"
+      npm config --loglevel=warn delete globalconfig --userconfig="${NVM_LOCAL_NPM_BUILTIN_NPMRC}"
     else
-      nvm_err "Your builtin npmrc file ($(nvm_sanitize_path "${LOCAL_NVM_NPM_BUILTIN_NPMRC}"))"
+      nvm_err "Your builtin npmrc file ($(nvm_sanitize_path "${NVM_LOCAL_NPM_BUILTIN_NPMRC}"))"
       nvm_err 'has a `globalconfig` and/or a `prefix` setting, which are incompatible with nvm.'
-      nvm_err "Run \`${LOCAL_NVM_COMMAND}\` to unset it."
+      nvm_err "Run \`${NVM_LOCAL_COMMAND}\` to unset it."
       return 10
     fi
   fi
 
-  local LOCAL_NVM_NPM_GLOBAL_NPMRC
-  LOCAL_NVM_NPM_GLOBAL_NPMRC="${LOCAL_NVM_VERSION_DIR}/etc/npmrc"
-  if nvm_npmrc_bad_news_bears "${LOCAL_NVM_NPM_GLOBAL_NPMRC}"; then
-    if [ "_${LOCAL_NVM_DELETE_PREFIX}" = "_1" ]; then
+  local NVM_LOCAL_NPM_GLOBAL_NPMRC
+  NVM_LOCAL_NPM_GLOBAL_NPMRC="${NVM_LOCAL_VERSION_DIR}/etc/npmrc"
+  if nvm_npmrc_bad_news_bears "${NVM_LOCAL_NPM_GLOBAL_NPMRC}"; then
+    if [ "_${NVM_LOCAL_DELETE_PREFIX}" = "_1" ]; then
       npm config --global --loglevel=warn delete prefix
       npm config --global --loglevel=warn delete globalconfig
     else
-      nvm_err "Your global npmrc file ($(nvm_sanitize_path "${LOCAL_NVM_NPM_GLOBAL_NPMRC}"))"
+      nvm_err "Your global npmrc file ($(nvm_sanitize_path "${NVM_LOCAL_NPM_GLOBAL_NPMRC}"))"
       nvm_err 'has a `globalconfig` and/or a `prefix` setting, which are incompatible with nvm.'
-      nvm_err "Run \`${LOCAL_NVM_COMMAND}\` to unset it."
+      nvm_err "Run \`${NVM_LOCAL_COMMAND}\` to unset it."
       return 10
     fi
   fi
 
-  local LOCAL_NVM_NPM_USER_NPMRC
-  LOCAL_NVM_NPM_USER_NPMRC="${HOME}/.npmrc"
-  if nvm_npmrc_bad_news_bears "${LOCAL_NVM_NPM_USER_NPMRC}"; then
-    if [ "_${LOCAL_NVM_DELETE_PREFIX}" = "_1" ]; then
-      npm config --loglevel=warn delete prefix --userconfig="${LOCAL_NVM_NPM_USER_NPMRC}"
-      npm config --loglevel=warn delete globalconfig --userconfig="${LOCAL_NVM_NPM_USER_NPMRC}"
+  local NVM_LOCAL_NPM_USER_NPMRC
+  NVM_LOCAL_NPM_USER_NPMRC="${HOME}/.npmrc"
+  if nvm_npmrc_bad_news_bears "${NVM_LOCAL_NPM_USER_NPMRC}"; then
+    if [ "_${NVM_LOCAL_DELETE_PREFIX}" = "_1" ]; then
+      npm config --loglevel=warn delete prefix --userconfig="${NVM_LOCAL_NPM_USER_NPMRC}"
+      npm config --loglevel=warn delete globalconfig --userconfig="${NVM_LOCAL_NPM_USER_NPMRC}"
     else
-      nvm_err "Your user’s .npmrc file ($(nvm_sanitize_path "${LOCAL_NVM_NPM_USER_NPMRC}"))"
+      nvm_err "Your user’s .npmrc file ($(nvm_sanitize_path "${NVM_LOCAL_NPM_USER_NPMRC}"))"
       nvm_err 'has a `globalconfig` and/or a `prefix` setting, which are incompatible with nvm.'
-      nvm_err "Run \`${LOCAL_NVM_COMMAND}\` to unset it."
+      nvm_err "Run \`${NVM_LOCAL_COMMAND}\` to unset it."
       return 10
     fi
   fi
 
-  local LOCAL_NVM_NPM_PROJECT_NPMRC
-  LOCAL_NVM_NPM_PROJECT_NPMRC="$(nvm_find_project_dir)/.npmrc"
-  if nvm_npmrc_bad_news_bears "${LOCAL_NVM_NPM_PROJECT_NPMRC}"; then
-    if [ "_${LOCAL_NVM_DELETE_PREFIX}" = "_1" ]; then
+  local NVM_LOCAL_NPM_PROJECT_NPMRC
+  NVM_LOCAL_NPM_PROJECT_NPMRC="$(nvm_find_project_dir)/.npmrc"
+  if nvm_npmrc_bad_news_bears "${NVM_LOCAL_NPM_PROJECT_NPMRC}"; then
+    if [ "_${NVM_LOCAL_DELETE_PREFIX}" = "_1" ]; then
       npm config --loglevel=warn delete prefix
       npm config --loglevel=warn delete globalconfig
     else
-      nvm_err "Your project npmrc file ($(nvm_sanitize_path "${LOCAL_NVM_NPM_PROJECT_NPMRC}"))"
+      nvm_err "Your project npmrc file ($(nvm_sanitize_path "${NVM_LOCAL_NPM_PROJECT_NPMRC}"))"
       nvm_err 'has a `globalconfig` and/or a `prefix` setting, which are incompatible with nvm.'
-      nvm_err "Run \`${LOCAL_NVM_COMMAND}\` to unset it."
+      nvm_err "Run \`${NVM_LOCAL_COMMAND}\` to unset it."
       return 10
     fi
   fi
 }
 
-# Succeeds if ${LOCAL_NVM_IOJS_VERSION} represents an io.js version that has a
+# Succeeds if ${NVM_LOCAL_IOJS_VERSION} represents an io.js version that has a
 # Solaris binary, fails otherwise.
 # Currently, only io.js 3.3.1 has a Solaris binary available, and it's the
 # latest io.js version available. The expectation is that any potential io.js
 # version later than v3.3.1 will also have Solaris binaries.
 nvm_iojs_version_has_solaris_binary() {
-  local LOCAL_NVM_IOJS_VERSION
-  LOCAL_NVM_IOJS_VERSION="$1"
-  local LOCAL_NVM_STRIPPED_IOJS_VERSION
-  LOCAL_NVM_STRIPPED_IOJS_VERSION="$(nvm_strip_iojs_prefix "${LOCAL_NVM_IOJS_VERSION}")"
-  if [ "_${LOCAL_NVM_STRIPPED_IOJS_VERSION}" = "${LOCAL_NVM_IOJS_VERSION}" ]; then
+  local NVM_LOCAL_IOJS_VERSION
+  NVM_LOCAL_IOJS_VERSION="$1"
+  local NVM_LOCAL_STRIPPED_IOJS_VERSION
+  NVM_LOCAL_STRIPPED_IOJS_VERSION="$(nvm_strip_iojs_prefix "${NVM_LOCAL_IOJS_VERSION}")"
+  if [ "_${NVM_LOCAL_STRIPPED_IOJS_VERSION}" = "${NVM_LOCAL_IOJS_VERSION}" ]; then
     return 1
   fi
 
   # io.js started shipping Solaris binaries with io.js v3.3.1
-  nvm_version_greater_than_or_equal_to "${LOCAL_NVM_STRIPPED_IOJS_VERSION}" v3.3.1
+  nvm_version_greater_than_or_equal_to "${NVM_LOCAL_STRIPPED_IOJS_VERSION}" v3.3.1
 }
 
-# Succeeds if ${LOCAL_NVM_NODE_VERSION} represents a node version that has a
+# Succeeds if ${NVM_LOCAL_NODE_VERSION} represents a node version that has a
 # Solaris binary, fails otherwise.
 # Currently, node versions starting from v0.8.6 have a Solaris binary
 # available.
 nvm_node_version_has_solaris_binary() {
-  local LOCAL_NVM_NODE_VERSION
-  LOCAL_NVM_NODE_VERSION="$1"
-  # Error out if ${LOCAL_NVM_NODE_VERSION} is actually an io.js version
-  local LOCAL_NVM_STRIPPED_IOJS_VERSION
-  LOCAL_NVM_STRIPPED_IOJS_VERSION="$(nvm_strip_iojs_prefix "${LOCAL_NVM_NODE_VERSION}")"
-  if [ "_${LOCAL_NVM_STRIPPED_IOJS_VERSION}" != "_${LOCAL_NVM_NODE_VERSION}" ]; then
+  local NVM_LOCAL_NODE_VERSION
+  NVM_LOCAL_NODE_VERSION="$1"
+  # Error out if ${NVM_LOCAL_NODE_VERSION} is actually an io.js version
+  local NVM_LOCAL_STRIPPED_IOJS_VERSION
+  NVM_LOCAL_STRIPPED_IOJS_VERSION="$(nvm_strip_iojs_prefix "${NVM_LOCAL_NODE_VERSION}")"
+  if [ "_${NVM_LOCAL_STRIPPED_IOJS_VERSION}" != "_${NVM_LOCAL_NODE_VERSION}" ]; then
     return 1
   fi
 
   # node (unmerged) started shipping Solaris binaries with v0.8.6 and
   # node versions v1.0.0 or greater are not considered valid "unmerged" node
   # versions.
-  nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" v0.8.6 \
-  && ! nvm_version_greater_than_or_equal_to "${LOCAL_NVM_NODE_VERSION}" v1.0.0
+  nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" v0.8.6 \
+  && ! nvm_version_greater_than_or_equal_to "${NVM_LOCAL_NODE_VERSION}" v1.0.0
 }
 
-# Succeeds if ${LOCAL_NVM_VERSION} represents a version (node, io.js or merged) that has a
+# Succeeds if ${NVM_LOCAL_VERSION} represents a version (node, io.js or merged) that has a
 # Solaris binary, fails otherwise.
 nvm_has_solaris_binary() {
-  local LOCAL_NVM_VERSION
-  LOCAL_NVM_VERSION="${1-}"
-  if nvm_is_merged_node_version "${LOCAL_NVM_VERSION}"; then
+  local NVM_LOCAL_VERSION
+  NVM_LOCAL_VERSION="${1-}"
+  if nvm_is_merged_node_version "${NVM_LOCAL_VERSION}"; then
     return 0 # All merged node versions have a Solaris binary
-  elif nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
-    nvm_iojs_version_has_solaris_binary "${LOCAL_NVM_VERSION}"
+  elif nvm_is_iojs_version "${NVM_LOCAL_VERSION}"; then
+    nvm_iojs_version_has_solaris_binary "${NVM_LOCAL_VERSION}"
   else
-    nvm_node_version_has_solaris_binary "${LOCAL_NVM_VERSION}"
+    nvm_node_version_has_solaris_binary "${NVM_LOCAL_VERSION}"
   fi
 }
 
 nvm_sanitize_path() {
-  local LOCAL_NVM_SANITIZED_PATH
-  LOCAL_NVM_SANITIZED_PATH="${1-}"
-  if [ "_${LOCAL_NVM_SANITIZED_PATH}" != "_${NVM_DIR}" ]; then
-    LOCAL_NVM_SANITIZED_PATH="$(nvm_echo "${LOCAL_NVM_SANITIZED_PATH}" | command sed -e "s#${NVM_DIR}#\${NVM_DIR}#g")"
+  local NVM_LOCAL_SANITIZED_PATH
+  NVM_LOCAL_SANITIZED_PATH="${1-}"
+  if [ "_${NVM_LOCAL_SANITIZED_PATH}" != "_${NVM_DIR}" ]; then
+    NVM_LOCAL_SANITIZED_PATH="$(nvm_echo "${NVM_LOCAL_SANITIZED_PATH}" | command sed -e "s#${NVM_DIR}#\${NVM_DIR}#g")"
   fi
-  if [ "_${LOCAL_NVM_SANITIZED_PATH}" != "_${HOME}" ]; then
-    LOCAL_NVM_SANITIZED_PATH="$(nvm_echo "${LOCAL_NVM_SANITIZED_PATH}" | command sed -e "s#${HOME}#\${HOME}#g")"
+  if [ "_${NVM_LOCAL_SANITIZED_PATH}" != "_${HOME}" ]; then
+    NVM_LOCAL_SANITIZED_PATH="$(nvm_echo "${NVM_LOCAL_SANITIZED_PATH}" | command sed -e "s#${HOME}#\${HOME}#g")"
   fi
-  nvm_echo "${LOCAL_NVM_SANITIZED_PATH}"
+  nvm_echo "${NVM_LOCAL_SANITIZED_PATH}"
 }
 
 nvm_is_natural_num() {
@@ -2729,94 +2729,94 @@ nvm() {
     return
   fi
 
-  local LOCAL_NVM_DEFAULT_IFS
-  LOCAL_NVM_DEFAULT_IFS=" $(nvm_echo t | command tr t \\t)
+  local NVM_LOCAL_DEFAULT_IFS
+  NVM_LOCAL_DEFAULT_IFS=" $(nvm_echo t | command tr t \\t)
 "
   if [ "${-#*e}" != "$-" ]; then
     set +e
-    local LOCAL_NVM_EXIT_CODE
-    IFS="${LOCAL_NVM_DEFAULT_IFS}" nvm "$@"
-    LOCAL_NVM_EXIT_CODE="$?"
+    local NVM_LOCAL_EXIT_CODE
+    IFS="${NVM_LOCAL_DEFAULT_IFS}" nvm "$@"
+    NVM_LOCAL_EXIT_CODE="$?"
     set -e
-    return "${LOCAL_NVM_EXIT_CODE}"
+    return "${NVM_LOCAL_EXIT_CODE}"
   elif [ "${-#*a}" != "$-" ]; then
     set +a
-    local LOCAL_NVM_EXIT_CODE
-    IFS="${LOCAL_NVM_DEFAULT_IFS}" nvm "$@"
-    LOCAL_NVM_EXIT_CODE="$?"
+    local NVM_LOCAL_EXIT_CODE
+    IFS="${NVM_LOCAL_DEFAULT_IFS}" nvm "$@"
+    NVM_LOCAL_EXIT_CODE="$?"
     set -a
-    return "${LOCAL_NVM_EXIT_CODE}"
+    return "${NVM_LOCAL_EXIT_CODE}"
   elif [ -n "${BASH-}" ] && [ "${-#*E}" != "$-" ]; then
     # shellcheck disable=SC3041
     set +E
-    local LOCAL_NVM_EXIT_CODE
-    IFS="${LOCAL_NVM_DEFAULT_IFS}" nvm "$@"
-    LOCAL_NVM_EXIT_CODE="$?"
+    local NVM_LOCAL_EXIT_CODE
+    IFS="${NVM_LOCAL_DEFAULT_IFS}" nvm "$@"
+    NVM_LOCAL_EXIT_CODE="$?"
     # shellcheck disable=SC3041
     set -E
-    return "${LOCAL_NVM_EXIT_CODE}"
-  elif [ "${IFS}" != "${LOCAL_NVM_DEFAULT_IFS}" ]; then
-    IFS="${LOCAL_NVM_DEFAULT_IFS}" nvm "$@"
+    return "${NVM_LOCAL_EXIT_CODE}"
+  elif [ "${IFS}" != "${NVM_LOCAL_DEFAULT_IFS}" ]; then
+    IFS="${NVM_LOCAL_DEFAULT_IFS}" nvm "$@"
     return "$?"
   fi
 
-  local LOCAL_NVM_I
-  for LOCAL_NVM_I in "$@"; do
-    case ${LOCAL_NVM_I} in
+  local NVM_LOCAL_I
+  for NVM_LOCAL_I in "$@"; do
+    case ${NVM_LOCAL_I} in
       --) break ;;
       '-h'|'help'|'--help')
         NVM_NO_COLORS=""
-        for LOCAL_NVM_J in "$@"; do
-          if [ "${LOCAL_NVM_J}" = '--no-colors' ]; then
-            NVM_NO_COLORS="${LOCAL_NVM_J}"
+        for NVM_LOCAL_J in "$@"; do
+          if [ "${NVM_LOCAL_J}" = '--no-colors' ]; then
+            NVM_NO_COLORS="${NVM_LOCAL_J}"
             break
           fi
         done
 
-        local LOCAL_NVM_INITIAL_COLOR_INFO
-        local LOCAL_NVM_RED_INFO
-        local LOCAL_NVM_GREEN_INFO
-        local LOCAL_NVM_BLUE_INFO
-        local LOCAL_NVM_CYAN_INFO
-        local LOCAL_NVM_MAGENTA_INFO
-        local LOCAL_NVM_YELLOW_INFO
-        local LOCAL_NVM_BLACK_INFO
-        local LOCAL_NVM_GREY_WHITE_INFO
+        local NVM_LOCAL_INITIAL_COLOR_INFO
+        local NVM_LOCAL_RED_INFO
+        local NVM_LOCAL_GREEN_INFO
+        local NVM_LOCAL_BLUE_INFO
+        local NVM_LOCAL_CYAN_INFO
+        local NVM_LOCAL_MAGENTA_INFO
+        local NVM_LOCAL_YELLOW_INFO
+        local NVM_LOCAL_BLACK_INFO
+        local NVM_LOCAL_GREY_WHITE_INFO
 
         if [ -z "${NVM_NO_COLORS-}"  ] && nvm_has_colors; then
-          LOCAL_NVM_INITIAL_COLOR_INFO='\033[0;32m g\033[0m \033[0;34m b\033[0m \033[0;33m y\033[0m \033[0;31m r\033[0m \033[0;37m e\033[0m'
-          LOCAL_NVM_RED_INFO='\033[0;31m r\033[0m/\033[1;31mR\033[0m = \033[0;31mred\033[0m / \033[1;31mbold red\033[0m'
-          LOCAL_NVM_GREEN_INFO='\033[0;32m g\033[0m/\033[1;32mG\033[0m = \033[0;32mgreen\033[0m / \033[1;32mbold green\033[0m'
-          LOCAL_NVM_BLUE_INFO='\033[0;34m b\033[0m/\033[1;34mB\033[0m = \033[0;34mblue\033[0m / \033[1;34mbold blue\033[0m'
-          LOCAL_NVM_CYAN_INFO='\033[0;36m c\033[0m/\033[1;36mC\033[0m = \033[0;36mcyan\033[0m / \033[1;36mbold cyan\033[0m'
-          LOCAL_NVM_MAGENTA_INFO='\033[0;35m m\033[0m/\033[1;35mM\033[0m = \033[0;35mmagenta\033[0m / \033[1;35mbold magenta\033[0m'
-          LOCAL_NVM_YELLOW_INFO='\033[0;33m y\033[0m/\033[1;33mY\033[0m = \033[0;33myellow\033[0m / \033[1;33mbold yellow\033[0m'
-          LOCAL_NVM_BLACK_INFO='\033[0;30m k\033[0m/\033[1;30mK\033[0m = \033[0;30mblack\033[0m / \033[1;30mbold black\033[0m'
-          LOCAL_NVM_GREY_WHITE_INFO='\033[0;37m e\033[0m/\033[1;37mW\033[0m = \033[0;37mlight grey\033[0m / \033[1;37mwhite\033[0m'
+          NVM_LOCAL_INITIAL_COLOR_INFO='\033[0;32m g\033[0m \033[0;34m b\033[0m \033[0;33m y\033[0m \033[0;31m r\033[0m \033[0;37m e\033[0m'
+          NVM_LOCAL_RED_INFO='\033[0;31m r\033[0m/\033[1;31mR\033[0m = \033[0;31mred\033[0m / \033[1;31mbold red\033[0m'
+          NVM_LOCAL_GREEN_INFO='\033[0;32m g\033[0m/\033[1;32mG\033[0m = \033[0;32mgreen\033[0m / \033[1;32mbold green\033[0m'
+          NVM_LOCAL_BLUE_INFO='\033[0;34m b\033[0m/\033[1;34mB\033[0m = \033[0;34mblue\033[0m / \033[1;34mbold blue\033[0m'
+          NVM_LOCAL_CYAN_INFO='\033[0;36m c\033[0m/\033[1;36mC\033[0m = \033[0;36mcyan\033[0m / \033[1;36mbold cyan\033[0m'
+          NVM_LOCAL_MAGENTA_INFO='\033[0;35m m\033[0m/\033[1;35mM\033[0m = \033[0;35mmagenta\033[0m / \033[1;35mbold magenta\033[0m'
+          NVM_LOCAL_YELLOW_INFO='\033[0;33m y\033[0m/\033[1;33mY\033[0m = \033[0;33myellow\033[0m / \033[1;33mbold yellow\033[0m'
+          NVM_LOCAL_BLACK_INFO='\033[0;30m k\033[0m/\033[1;30mK\033[0m = \033[0;30mblack\033[0m / \033[1;30mbold black\033[0m'
+          NVM_LOCAL_GREY_WHITE_INFO='\033[0;37m e\033[0m/\033[1;37mW\033[0m = \033[0;37mlight grey\033[0m / \033[1;37mwhite\033[0m'
         else
-          LOCAL_NVM_INITIAL_COLOR_INFO='gbYre'
-          LOCAL_NVM_RED_INFO='r/R = red / bold red'
-          LOCAL_NVM_GREEN_INFO='g/G = green / bold green'
-          LOCAL_NVM_BLUE_INFO='b/B = blue / bold blue'
-          LOCAL_NVM_CYAN_INFO='c/C = cyan / bold cyan'
-          LOCAL_NVM_MAGENTA_INFO='m/M = magenta / bold magenta'
-          LOCAL_NVM_YELLOW_INFO='y/Y = yellow / bold yellow'
-          LOCAL_NVM_BLACK_INFO='k/K = black / bold black'
-          LOCAL_NVM_GREY_WHITE_INFO='e/W = light grey / white'
+          NVM_LOCAL_INITIAL_COLOR_INFO='gbYre'
+          NVM_LOCAL_RED_INFO='r/R = red / bold red'
+          NVM_LOCAL_GREEN_INFO='g/G = green / bold green'
+          NVM_LOCAL_BLUE_INFO='b/B = blue / bold blue'
+          NVM_LOCAL_CYAN_INFO='c/C = cyan / bold cyan'
+          NVM_LOCAL_MAGENTA_INFO='m/M = magenta / bold magenta'
+          NVM_LOCAL_YELLOW_INFO='y/Y = yellow / bold yellow'
+          NVM_LOCAL_BLACK_INFO='k/K = black / bold black'
+          NVM_LOCAL_GREY_WHITE_INFO='e/W = light grey / white'
         fi
 
-        local LOCAL_NVM_IOJS_PREFIX
-        LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-        local LOCAL_NVM_NODE_PREFIX
-        LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
-        local LOCAL_NVM_VERSION
-        LOCAL_NVM_VERSION="$(nvm --version)"
+        local NVM_LOCAL_IOJS_PREFIX
+        NVM_LOCAL_IOJS_PREFIX="$(nvm_iojs_prefix)"
+        local NVM_LOCAL_NODE_PREFIX
+        NVM_LOCAL_NODE_PREFIX="$(nvm_node_prefix)"
+        local NVM_LOCAL_VERSION
+        NVM_LOCAL_VERSION="$(nvm --version)"
         nvm_echo
-        nvm_echo "Node Version Manager (v${LOCAL_NVM_VERSION})"
+        nvm_echo "Node Version Manager (v${NVM_LOCAL_VERSION})"
         nvm_echo
         nvm_echo 'Note: <version> refers to any version-like string nvm understands. This includes:'
         nvm_echo '  - full or partial version numbers, starting with an optional "v" (0.10, v0.1.2, v1)'
-        nvm_echo "  - default (built-in) aliases: ${LOCAL_NVM_NODE_PREFIX}, stable, unstable, ${LOCAL_NVM_IOJS_PREFIX}, system"
+        nvm_echo "  - default (built-in) aliases: ${NVM_LOCAL_NODE_PREFIX}, stable, unstable, ${NVM_LOCAL_IOJS_PREFIX}, system"
         nvm_echo '  - custom aliases you define with `nvm alias foo`'
         nvm_echo
         nvm_echo ' Any options that produce colorized output should respect the `--no-colors` option.'
@@ -2882,16 +2882,16 @@ nvm() {
         nvm_echo '  nvm cache clear                             Empty cache directory for nvm'
         nvm_echo '  nvm set-colors [<color codes>]              Set five text colors using format "yMeBg". Available when supported.'
         nvm_echo '                                               Initial colors are:'
-        nvm_echo_with_colors "                                                  ${LOCAL_NVM_INITIAL_COLOR_INFO}"
+        nvm_echo_with_colors "                                                  ${NVM_LOCAL_INITIAL_COLOR_INFO}"
         nvm_echo '                                               Color codes:'
-        nvm_echo_with_colors "                                                ${LOCAL_NVM_RED_INFO}"
-        nvm_echo_with_colors "                                                ${LOCAL_NVM_GREEN_INFO}"
-        nvm_echo_with_colors "                                                ${LOCAL_NVM_BLUE_INFO}"
-        nvm_echo_with_colors "                                                ${LOCAL_NVM_CYAN_INFO}"
-        nvm_echo_with_colors "                                                ${LOCAL_NVM_MAGENTA_INFO}"
-        nvm_echo_with_colors "                                                ${LOCAL_NVM_YELLOW_INFO}"
-        nvm_echo_with_colors "                                                ${LOCAL_NVM_BLACK_INFO}"
-        nvm_echo_with_colors "                                                ${LOCAL_NVM_GREY_WHITE_INFO}"
+        nvm_echo_with_colors "                                                ${NVM_LOCAL_RED_INFO}"
+        nvm_echo_with_colors "                                                ${NVM_LOCAL_GREEN_INFO}"
+        nvm_echo_with_colors "                                                ${NVM_LOCAL_BLUE_INFO}"
+        nvm_echo_with_colors "                                                ${NVM_LOCAL_CYAN_INFO}"
+        nvm_echo_with_colors "                                                ${NVM_LOCAL_MAGENTA_INFO}"
+        nvm_echo_with_colors "                                                ${NVM_LOCAL_YELLOW_INFO}"
+        nvm_echo_with_colors "                                                ${NVM_LOCAL_BLACK_INFO}"
+        nvm_echo_with_colors "                                                ${NVM_LOCAL_GREY_WHITE_INFO}"
         nvm_echo
         nvm_echo 'Example:'
         nvm_echo '  nvm install 8.0.0                     Install a specific version number'
@@ -2916,25 +2916,25 @@ nvm() {
     esac
   done
 
-  local LOCAL_NVM_COMMAND
-  LOCAL_NVM_COMMAND="${1-}"
+  local NVM_LOCAL_COMMAND
+  NVM_LOCAL_COMMAND="${1-}"
   shift
 
   # initialize local variables
-  local LOCAL_NVM_VERSION
-  local LOCAL_NVM_ADDITIONAL_PARAMETERS
+  local NVM_LOCAL_VERSION
+  local NVM_LOCAL_ADDITIONAL_PARAMETERS
 
-  case ${LOCAL_NVM_COMMAND} in
+  case ${NVM_LOCAL_COMMAND} in
     "cache")
       case "${1-}" in
         dir) nvm_cache_dir ;;
         clear)
-          local LOCAL_NVM_DIR
-          LOCAL_NVM_DIR="$(nvm_cache_dir)"
-          if command rm -rf "${LOCAL_NVM_DIR}" && command mkdir -p "${LOCAL_NVM_DIR}"; then
+          local NVM_LOCAL_DIR
+          NVM_LOCAL_DIR="$(nvm_cache_dir)"
+          if command rm -rf "${NVM_LOCAL_DIR}" && command mkdir -p "${NVM_LOCAL_DIR}"; then
             nvm_echo 'nvm cache cleared.'
           else
-            nvm_err "Unable to clear nvm cache: ${LOCAL_NVM_DIR}"
+            nvm_err "Unable to clear nvm cache: ${NVM_LOCAL_DIR}"
             return 1
           fi
         ;;
@@ -2946,7 +2946,7 @@ nvm() {
     ;;
 
     "debug")
-      local LOCAL_NVM_OS_VERSION
+      local NVM_LOCAL_OS_VERSION
       nvm_is_zsh && setopt local_options shwordsplit
       nvm_err "nvm --version: v$(nvm --version)"
       if [ -n "${TERM_PROGRAM-}" ]; then
@@ -2967,16 +2967,16 @@ nvm() {
       nvm_err "uname -a: '$(command uname -a | command awk '{$2=""; print}' | command xargs)'"
       nvm_err "checksum binary: '$(nvm_get_checksum_binary 2>/dev/null)'"
       if [ "$(nvm_get_os)" = "darwin" ] && nvm_has sw_vers; then
-        LOCAL_NVM_OS_VERSION="$(sw_vers | command awk '{print $2}' | command xargs)"
+        NVM_LOCAL_OS_VERSION="$(sw_vers | command awk '{print $2}' | command xargs)"
       elif [ -r "/etc/issue" ]; then
-        LOCAL_NVM_OS_VERSION="$(command head -n 1 /etc/issue | command sed 's/\\.//g')"
-        if [ -z "${LOCAL_NVM_OS_VERSION}" ] && [ -r "/etc/os-release" ]; then
+        NVM_LOCAL_OS_VERSION="$(command head -n 1 /etc/issue | command sed 's/\\.//g')"
+        if [ -z "${NVM_LOCAL_OS_VERSION}" ] && [ -r "/etc/os-release" ]; then
           # shellcheck disable=SC1091
-          LOCAL_NVM_OS_VERSION="$(. /etc/os-release && echo "${NAME}" "${VERSION}")"
+          NVM_LOCAL_OS_VERSION="$(. /etc/os-release && echo "${NAME}" "${VERSION}")"
         fi
       fi
-      if [ -n "${LOCAL_NVM_OS_VERSION}" ]; then
-        nvm_err "OS version: ${LOCAL_NVM_OS_VERSION}"
+      if [ -n "${NVM_LOCAL_OS_VERSION}" ]; then
+        nvm_err "OS version: ${NVM_LOCAL_OS_VERSION}"
       fi
       if nvm_has "curl"; then
         nvm_err "curl: $(nvm_command_info curl), $(command curl -V | command head -n 1)"
@@ -2989,51 +2989,51 @@ nvm() {
         nvm_err "wget: not found"
       fi
 
-      local LOCAL_NVM_TEST_TOOLS
-      local LOCAL_NVM_ADD_TEST_TOOLS
-      LOCAL_NVM_TEST_TOOLS="git grep awk"
-      LOCAL_NVM_ADD_TEST_TOOLS="sed cut basename rm mkdir xargs"
+      local NVM_LOCAL_TEST_TOOLS
+      local NVM_LOCAL_ADD_TEST_TOOLS
+      NVM_LOCAL_TEST_TOOLS="git grep awk"
+      NVM_LOCAL_ADD_TEST_TOOLS="sed cut basename rm mkdir xargs"
       if [ "darwin" != "$(nvm_get_os)" ] && [ "freebsd" != "$(nvm_get_os)" ]; then
-        LOCAL_NVM_TEST_TOOLS="${LOCAL_NVM_TEST_TOOLS} ${LOCAL_NVM_ADD_TEST_TOOLS}"
+        NVM_LOCAL_TEST_TOOLS="${NVM_LOCAL_TEST_TOOLS} ${NVM_LOCAL_ADD_TEST_TOOLS}"
       else
-        for LOCAL_NVM_TOOL in ${LOCAL_NVM_ADD_TEST_TOOLS} ; do
-          if nvm_has "${LOCAL_NVM_TOOL}"; then
-            nvm_err "${LOCAL_NVM_TOOL}: $(nvm_command_info "${LOCAL_NVM_TOOL}")"
+        for NVM_LOCAL_TOOL in ${NVM_LOCAL_ADD_TEST_TOOLS} ; do
+          if nvm_has "${NVM_LOCAL_TOOL}"; then
+            nvm_err "${NVM_LOCAL_TOOL}: $(nvm_command_info "${NVM_LOCAL_TOOL}")"
           else
-            nvm_err "${LOCAL_NVM_TOOL}: not found"
+            nvm_err "${NVM_LOCAL_TOOL}: not found"
           fi
         done
       fi
-      for LOCAL_NVM_TOOL in ${LOCAL_NVM_TEST_TOOLS} ; do
-        local LOCAL_NVM_TOOL_VERSION
-        if nvm_has "${LOCAL_NVM_TOOL}"; then
-          if command ls -l "$(nvm_command_info "${LOCAL_NVM_TOOL}" | command awk '{print $1}')" | command grep -q busybox; then
-            LOCAL_NVM_TOOL_VERSION="$(command "${LOCAL_NVM_TOOL}" --help 2>&1 | command head -n 1)"
+      for NVM_LOCAL_TOOL in ${NVM_LOCAL_TEST_TOOLS} ; do
+        local NVM_LOCAL_TOOL_VERSION
+        if nvm_has "${NVM_LOCAL_TOOL}"; then
+          if command ls -l "$(nvm_command_info "${NVM_LOCAL_TOOL}" | command awk '{print $1}')" | command grep -q busybox; then
+            NVM_LOCAL_TOOL_VERSION="$(command "${NVM_LOCAL_TOOL}" --help 2>&1 | command head -n 1)"
           else
-            LOCAL_NVM_TOOL_VERSION="$(command "${LOCAL_NVM_TOOL}" --version 2>&1 | command head -n 1)"
+            NVM_LOCAL_TOOL_VERSION="$(command "${NVM_LOCAL_TOOL}" --version 2>&1 | command head -n 1)"
           fi
-          nvm_err "${LOCAL_NVM_TOOL}: $(nvm_command_info "${LOCAL_NVM_TOOL}"), ${LOCAL_NVM_TOOL_VERSION}"
+          nvm_err "${NVM_LOCAL_TOOL}: $(nvm_command_info "${NVM_LOCAL_TOOL}"), ${NVM_LOCAL_TOOL_VERSION}"
         else
-          nvm_err "${LOCAL_NVM_TOOL}: not found"
+          nvm_err "${NVM_LOCAL_TOOL}: not found"
         fi
-        unset LOCAL_NVM_TOOL_VERSION
+        unset NVM_LOCAL_TOOL_VERSION
       done
-      unset LOCAL_NVM_TEST_TOOLS
-      unset LOCAL_NVM_ADD_TEST_TOOLS
+      unset NVM_LOCAL_TEST_TOOLS
+      unset NVM_LOCAL_ADD_TEST_TOOLS
 
-      local LOCAL_NVM_DEBUG_OUTPUT
+      local NVM_LOCAL_DEBUG_OUTPUT
       for NVM_DEBUG_COMMAND in 'nvm current' 'which node' 'which iojs' 'which npm' 'npm config get prefix' 'npm root -g'; do
-        LOCAL_NVM_DEBUG_OUTPUT="$(${NVM_DEBUG_COMMAND} 2>&1)"
-        nvm_err "${NVM_DEBUG_COMMAND}: $(nvm_sanitize_path "${LOCAL_NVM_DEBUG_OUTPUT}")"
+        NVM_LOCAL_DEBUG_OUTPUT="$(${NVM_DEBUG_COMMAND} 2>&1)"
+        nvm_err "${NVM_DEBUG_COMMAND}: $(nvm_sanitize_path "${NVM_LOCAL_DEBUG_OUTPUT}")"
       done
       return 42
     ;;
 
     "install" | "i")
-      local LOCAL_NVM_VERSION_NOT_PROVIDED
-      LOCAL_NVM_VERSION_NOT_PROVIDED=0
-      local LOCAL_NVM_OS
-      LOCAL_NVM_OS="$(nvm_get_os)"
+      local NVM_LOCAL_VERSION_NOT_PROVIDED
+      NVM_LOCAL_VERSION_NOT_PROVIDED=0
+      local NVM_LOCAL_OS
+      NVM_LOCAL_OS="$(nvm_get_os)"
 
       if ! nvm_has "curl" && ! nvm_has "wget"; then
         nvm_err 'nvm needs curl or wget to proceed.'
@@ -3041,24 +3041,24 @@ nvm() {
       fi
 
       if [ $# -lt 1 ]; then
-        LOCAL_NVM_VERSION_NOT_PROVIDED=1
+        NVM_LOCAL_VERSION_NOT_PROVIDED=1
       fi
 
-      local LOCAL_NVM_NOBINARY
-      local LOCAL_NVM_NOSOURCE
-      local LOCAL_NVM_NOPROGRESS
-      LOCAL_NVM_NOBINARY=0
-      LOCAL_NVM_NOPROGRESS=0
-      LOCAL_NVM_NOSOURCE=0
-      local LOCAL_NVM_LTS
-      local LOCAL_NVM_ALIAS
-      local LOCAL_NVM_UPGRADE_NPM
-      LOCAL_NVM_UPGRADE_NPM=0
+      local NVM_LOCAL_NOBINARY
+      local NVM_LOCAL_NOSOURCE
+      local NVM_LOCAL_NOPROGRESS
+      NVM_LOCAL_NOBINARY=0
+      NVM_LOCAL_NOPROGRESS=0
+      NVM_LOCAL_NOSOURCE=0
+      local NVM_LOCAL_LTS
+      local NVM_LOCAL_ALIAS
+      local NVM_LOCAL_UPGRADE_NPM
+      NVM_LOCAL_UPGRADE_NPM=0
 
-      local LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM
-      local LOCAL_NVM_REINSTALL_PACKAGES_FROM
-      local LOCAL_NVM_SKIP_DEFAULT_PACKAGES
-      local LOCAL_NVM_DEFAULT_PACKAGES
+      local NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM
+      local NVM_LOCAL_REINSTALL_PACKAGES_FROM
+      local NVM_LOCAL_SKIP_DEFAULT_PACKAGES
+      local NVM_LOCAL_DEFAULT_PACKAGES
 
       while [ $# -ne 0 ]; do
         case "$1" in
@@ -3068,16 +3068,16 @@ nvm() {
           ;;
           -s)
             shift # consume "-s"
-            LOCAL_NVM_NOBINARY=1
-            if [ ${LOCAL_NVM_NOSOURCE} -eq 1 ]; then
+            NVM_LOCAL_NOBINARY=1
+            if [ ${NVM_LOCAL_NOSOURCE} -eq 1 ]; then
                 nvm err '-s and -b cannot be set together since they would skip install from both binary and source'
                 return 6
             fi
           ;;
           -b)
             shift # consume "-b"
-            LOCAL_NVM_NOSOURCE=1
-            if [ ${LOCAL_NVM_NOBINARY} -eq 1 ]; then
+            NVM_LOCAL_NOSOURCE=1
+            if [ ${NVM_LOCAL_NOBINARY} -eq 1 ]; then
                 nvm err '-s and -b cannot be set together since they would skip install from both binary and source'
                 return 6
             fi
@@ -3088,61 +3088,61 @@ nvm() {
             shift # consume job count
           ;;
           --no-progress)
-            LOCAL_NVM_NOPROGRESS=1
+            NVM_LOCAL_NOPROGRESS=1
             shift
           ;;
           --lts)
-            LOCAL_NVM_LTS='*'
+            NVM_LOCAL_LTS='*'
             shift
           ;;
           --lts=*)
-            LOCAL_NVM_LTS="${1##--lts=}"
+            NVM_LOCAL_LTS="${1##--lts=}"
             shift
           ;;
           --latest-npm)
-            LOCAL_NVM_UPGRADE_NPM=1
+            NVM_LOCAL_UPGRADE_NPM=1
             shift
           ;;
           --default)
-            if [ -n "${LOCAL_NVM_ALIAS-}" ]; then
+            if [ -n "${NVM_LOCAL_ALIAS-}" ]; then
               nvm_err '--default and --alias are mutually exclusive, and may not be provided more than once'
               return 6
             fi
-            LOCAL_NVM_ALIAS='default'
+            NVM_LOCAL_ALIAS='default'
             shift
           ;;
           --alias=*)
-            if [ -n "${LOCAL_NVM_ALIAS-}" ]; then
+            if [ -n "${NVM_LOCAL_ALIAS-}" ]; then
               nvm_err '--default and --alias are mutually exclusive, and may not be provided more than once'
               return 6
             fi
-            LOCAL_NVM_ALIAS="${1##--alias=}"
+            NVM_LOCAL_ALIAS="${1##--alias=}"
             shift
           ;;
           --reinstall-packages-from=*)
-            if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
+            if [ -n "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
               nvm_err '--reinstall-packages-from may not be provided more than once'
               return 6
             fi
-            LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 27-)"
-            if [ -z "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
+            NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 27-)"
+            if [ -z "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
               nvm_err 'If --reinstall-packages-from is provided, it must point to an installed version of node.'
               return 6
             fi
-            LOCAL_NVM_REINSTALL_PACKAGES_FROM="$(nvm_version "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
+            NVM_LOCAL_REINSTALL_PACKAGES_FROM="$(nvm_version "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
             shift
           ;;
           --copy-packages-from=*)
-            if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
+            if [ -n "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
               nvm_err '--reinstall-packages-from may not be provided more than once, or combined with `--copy-packages-from`'
               return 6
             fi
-            LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 22-)"
-            if [ -z "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
+            NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 22-)"
+            if [ -z "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
               nvm_err 'If --copy-packages-from is provided, it must point to an installed version of node.'
               return 6
             fi
-            LOCAL_NVM_REINSTALL_PACKAGES_FROM="$(nvm_version "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
+            NVM_LOCAL_REINSTALL_PACKAGES_FROM="$(nvm_version "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
             shift
           ;;
           --reinstall-packages-from | --copy-packages-from)
@@ -3150,7 +3150,7 @@ nvm() {
             return 6
           ;;
           --skip-default-packages)
-            LOCAL_NVM_SKIP_DEFAULT_PACKAGES=true
+            NVM_LOCAL_SKIP_DEFAULT_PACKAGES=true
             shift
           ;;
           *)
@@ -3159,236 +3159,236 @@ nvm() {
         esac
       done
 
-      local LOCAL_NVM_PROVIDED_VERSION
-      LOCAL_NVM_PROVIDED_VERSION="${1-}"
+      local NVM_LOCAL_PROVIDED_VERSION
+      NVM_LOCAL_PROVIDED_VERSION="${1-}"
 
-      if [ -z "${LOCAL_NVM_PROVIDED_VERSION}" ]; then
-        if [ "_${LOCAL_NVM_LTS-}" = '_*' ]; then
+      if [ -z "${NVM_LOCAL_PROVIDED_VERSION}" ]; then
+        if [ "_${NVM_LOCAL_LTS-}" = '_*' ]; then
           nvm_echo 'Installing latest LTS version.'
           if [ $# -gt 0 ]; then
             shift
           fi
-        elif [ "_${LOCAL_NVM_LTS-}" != '_' ]; then
-          nvm_echo "Installing with latest version of LTS line: ${LOCAL_NVM_LTS}"
+        elif [ "_${NVM_LOCAL_LTS-}" != '_' ]; then
+          nvm_echo "Installing with latest version of LTS line: ${NVM_LOCAL_LTS}"
           if [ $# -gt 0 ]; then
             shift
           fi
         else
           nvm_rc_version
-          if [ ${LOCAL_NVM_VERSION_NOT_PROVIDED} -eq 1 ] && [ -z "${NVM_RC_VERSION}" ]; then
+          if [ ${NVM_LOCAL_VERSION_NOT_PROVIDED} -eq 1 ] && [ -z "${NVM_RC_VERSION}" ]; then
             unset NVM_RC_VERSION
             >&2 nvm --help
             return 127
           fi
-          LOCAL_NVM_PROVIDED_VERSION="${NVM_RC_VERSION}"
+          NVM_LOCAL_PROVIDED_VERSION="${NVM_RC_VERSION}"
           unset NVM_RC_VERSION
         fi
       elif [ $# -gt 0 ]; then
         shift
       fi
 
-      case "${LOCAL_NVM_PROVIDED_VERSION}" in
+      case "${NVM_LOCAL_PROVIDED_VERSION}" in
         'lts/*')
-          LOCAL_NVM_LTS='*'
-          LOCAL_NVM_PROVIDED_VERSION=''
+          NVM_LOCAL_LTS='*'
+          NVM_LOCAL_PROVIDED_VERSION=''
         ;;
         lts/*)
-          LOCAL_NVM_LTS="${LOCAL_NVM_PROVIDED_VERSION##lts/}"
-          LOCAL_NVM_PROVIDED_VERSION=''
+          NVM_LOCAL_LTS="${NVM_LOCAL_PROVIDED_VERSION##lts/}"
+          NVM_LOCAL_PROVIDED_VERSION=''
         ;;
       esac
 
-      LOCAL_NVM_VERSION="$(NVM_VERSION_ONLY=true NVM_LTS="${LOCAL_NVM_LTS-}" nvm_remote_version "${LOCAL_NVM_PROVIDED_VERSION}")"
+      NVM_LOCAL_VERSION="$(NVM_VERSION_ONLY=true NVM_LTS="${NVM_LOCAL_LTS-}" nvm_remote_version "${NVM_LOCAL_PROVIDED_VERSION}")"
 
-      if [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
-        local LOCAL_NVM_LTS_MSG
-        local LOCAL_NVM_REMOTE_CMD
-        if [ "${LOCAL_NVM_LTS-}" = '*' ]; then
-          LOCAL_NVM_LTS_MSG='(with LTS filter) '
-          LOCAL_NVM_REMOTE_CMD='nvm ls-remote --lts'
-        elif [ -n "${LOCAL_NVM_LTS-}" ]; then
-          LOCAL_NVM_LTS_MSG="(with LTS filter '${LOCAL_NVM_LTS}') "
-          LOCAL_NVM_REMOTE_CMD="nvm ls-remote --lts=${LOCAL_NVM_LTS}"
+      if [ "${NVM_LOCAL_VERSION}" = 'N/A' ]; then
+        local NVM_LOCAL_LTS_MSG
+        local NVM_LOCAL_REMOTE_CMD
+        if [ "${NVM_LOCAL_LTS-}" = '*' ]; then
+          NVM_LOCAL_LTS_MSG='(with LTS filter) '
+          NVM_LOCAL_REMOTE_CMD='nvm ls-remote --lts'
+        elif [ -n "${NVM_LOCAL_LTS-}" ]; then
+          NVM_LOCAL_LTS_MSG="(with LTS filter '${NVM_LOCAL_LTS}') "
+          NVM_LOCAL_REMOTE_CMD="nvm ls-remote --lts=${NVM_LOCAL_LTS}"
         else
-          LOCAL_NVM_REMOTE_CMD='nvm ls-remote'
+          NVM_LOCAL_REMOTE_CMD='nvm ls-remote'
         fi
-        nvm_err "Version '${LOCAL_NVM_PROVIDED_VERSION}' ${LOCAL_NVM_LTS_MSG-}not found - try \`${LOCAL_NVM_REMOTE_CMD}\` to browse available versions."
+        nvm_err "Version '${NVM_LOCAL_PROVIDED_VERSION}' ${NVM_LOCAL_LTS_MSG-}not found - try \`${NVM_LOCAL_REMOTE_CMD}\` to browse available versions."
         return 3
       fi
 
-      LOCAL_NVM_ADDITIONAL_PARAMETERS=''
+      NVM_LOCAL_ADDITIONAL_PARAMETERS=''
 
       while [ $# -ne 0 ]; do
         case "$1" in
           --reinstall-packages-from=*)
-            if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
+            if [ -n "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
               nvm_err '--reinstall-packages-from may not be provided more than once'
               return 6
             fi
-            LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 27-)"
-            if [ -z "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
+            NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 27-)"
+            if [ -z "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
               nvm_err 'If --reinstall-packages-from is provided, it must point to an installed version of node.'
               return 6
             fi
-            LOCAL_NVM_REINSTALL_PACKAGES_FROM="$(nvm_version "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
+            NVM_LOCAL_REINSTALL_PACKAGES_FROM="$(nvm_version "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
           ;;
           --copy-packages-from=*)
-            if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
+            if [ -n "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM-}" ]; then
               nvm_err '--reinstall-packages-from may not be provided more than once, or combined with `--copy-packages-from`'
               return 6
             fi
-            LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 22-)"
-            if [ -z "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
+            NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM="$(nvm_echo "$1" | command cut -c 22-)"
+            if [ -z "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM}" ]; then
               nvm_err 'If --copy-packages-from is provided, it must point to an installed version of node.'
               return 6
             fi
-            LOCAL_NVM_REINSTALL_PACKAGES_FROM="$(nvm_version "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
+            NVM_LOCAL_REINSTALL_PACKAGES_FROM="$(nvm_version "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM}")" ||:
           ;;
           --reinstall-packages-from | --copy-packages-from)
             nvm_err "If ${1} is provided, it must point to an installed version of node using \`=\`."
             return 6
           ;;
           --skip-default-packages)
-            LOCAL_NVM_SKIP_DEFAULT_PACKAGES=true
+            NVM_LOCAL_SKIP_DEFAULT_PACKAGES=true
           ;;
           *)
-            LOCAL_NVM_ADDITIONAL_PARAMETERS="${LOCAL_NVM_ADDITIONAL_PARAMETERS} $1"
+            NVM_LOCAL_ADDITIONAL_PARAMETERS="${NVM_LOCAL_ADDITIONAL_PARAMETERS} $1"
           ;;
         esac
         shift
       done
 
-      local LOCAL_NVM_EXIT_CODE
-      if [ -z "${LOCAL_NVM_SKIP_DEFAULT_PACKAGES-}" ]; then
-        LOCAL_NVM_DEFAULT_PACKAGES="$(nvm_get_default_packages)"
-        LOCAL_NVM_EXIT_CODE=$?
-        if [ ${LOCAL_NVM_EXIT_CODE} -ne 0 ]; then
-          return ${LOCAL_NVM_EXIT_CODE}
+      local NVM_LOCAL_EXIT_CODE
+      if [ -z "${NVM_LOCAL_SKIP_DEFAULT_PACKAGES-}" ]; then
+        NVM_LOCAL_DEFAULT_PACKAGES="$(nvm_get_default_packages)"
+        NVM_LOCAL_EXIT_CODE=$?
+        if [ ${NVM_LOCAL_EXIT_CODE} -ne 0 ]; then
+          return ${NVM_LOCAL_EXIT_CODE}
         fi
       fi
 
-      if [ -n "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM-}" ] && [ "$(nvm_ensure_version_prefix "${LOCAL_NVM_PROVIDED_REINSTALL_PACKAGES_FROM}")" = "${LOCAL_NVM_VERSION}" ]; then
+      if [ -n "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM-}" ] && [ "$(nvm_ensure_version_prefix "${NVM_LOCAL_PROVIDED_REINSTALL_PACKAGES_FROM}")" = "${NVM_LOCAL_VERSION}" ]; then
         nvm_err "You can't reinstall global packages from the same version of node you're installing."
         return 4
-      elif [ "${LOCAL_NVM_REINSTALL_PACKAGES_FROM-}" = 'N/A' ]; then
+      elif [ "${NVM_LOCAL_REINSTALL_PACKAGES_FROM-}" = 'N/A' ]; then
         nvm_err "If --reinstall-packages-from is provided, it must point to an installed version of node."
         return 5
       fi
 
-      local LOCAL_NVM_FLAVOR
-      if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
-        LOCAL_NVM_FLAVOR="$(nvm_iojs_prefix)"
+      local NVM_LOCAL_FLAVOR
+      if nvm_is_iojs_version "${NVM_LOCAL_VERSION}"; then
+        NVM_LOCAL_FLAVOR="$(nvm_iojs_prefix)"
       else
-        LOCAL_NVM_FLAVOR="$(nvm_node_prefix)"
+        NVM_LOCAL_FLAVOR="$(nvm_node_prefix)"
       fi
 
-      if nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
-        nvm_err "${LOCAL_NVM_VERSION} is already installed."
-        if nvm use "${LOCAL_NVM_VERSION}"; then
-          if [ "${LOCAL_NVM_UPGRADE_NPM}" = 1 ]; then
+      if nvm_is_version_installed "${NVM_LOCAL_VERSION}"; then
+        nvm_err "${NVM_LOCAL_VERSION} is already installed."
+        if nvm use "${NVM_LOCAL_VERSION}"; then
+          if [ "${NVM_LOCAL_UPGRADE_NPM}" = 1 ]; then
             nvm install-latest-npm
           fi
-          if [ -z "${LOCAL_NVM_SKIP_DEFAULT_PACKAGES-}" ] && [ -n "${LOCAL_NVM_DEFAULT_PACKAGES-}" ]; then
-            nvm_install_default_packages "${LOCAL_NVM_DEFAULT_PACKAGES}"
+          if [ -z "${NVM_LOCAL_SKIP_DEFAULT_PACKAGES-}" ] && [ -n "${NVM_LOCAL_DEFAULT_PACKAGES-}" ]; then
+            nvm_install_default_packages "${NVM_LOCAL_DEFAULT_PACKAGES}"
           fi
-          if [ -n "${LOCAL_NVM_REINSTALL_PACKAGES_FROM-}" ] && [ "_${LOCAL_NVM_REINSTALL_PACKAGES_FROM}" != "_N/A" ]; then
-            nvm reinstall-packages "${LOCAL_NVM_REINSTALL_PACKAGES_FROM}"
+          if [ -n "${NVM_LOCAL_REINSTALL_PACKAGES_FROM-}" ] && [ "_${NVM_LOCAL_REINSTALL_PACKAGES_FROM}" != "_N/A" ]; then
+            nvm reinstall-packages "${NVM_LOCAL_REINSTALL_PACKAGES_FROM}"
           fi
         fi
-        if [ -n "${LOCAL_NVM_LTS-}" ]; then
-          LOCAL_NVM_LTS="$(echo "${LOCAL_NVM_LTS}" | tr '[:upper:]' '[:lower:]')"
-          nvm_ensure_default_set "lts/${LOCAL_NVM_LTS}"
+        if [ -n "${NVM_LOCAL_LTS-}" ]; then
+          NVM_LOCAL_LTS="$(echo "${NVM_LOCAL_LTS}" | tr '[:upper:]' '[:lower:]')"
+          nvm_ensure_default_set "lts/${NVM_LOCAL_LTS}"
         else
-          nvm_ensure_default_set "${LOCAL_NVM_PROVIDED_VERSION}"
+          nvm_ensure_default_set "${NVM_LOCAL_PROVIDED_VERSION}"
         fi
 
-        if [ -n "${LOCAL_NVM_ALIAS-}" ]; then
-          nvm alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_PROVIDED_VERSION}"
+        if [ -n "${NVM_LOCAL_ALIAS-}" ]; then
+          nvm alias "${NVM_LOCAL_ALIAS}" "${NVM_LOCAL_PROVIDED_VERSION}"
         fi
 
         return $?
       fi
 
-      LOCAL_NVM_EXIT_CODE=-1
+      NVM_LOCAL_EXIT_CODE=-1
       if [ -n "${NVM_INSTALL_THIRD_PARTY_HOOK-}" ]; then
         nvm_err '** ${NVM_INSTALL_THIRD_PARTY_HOOK} env var set; dispatching to third-party installation method **'
-        local LOCAL_NVM_METHOD_PREFERENCE
-        LOCAL_NVM_METHOD_PREFERENCE='binary'
-        if [ ${LOCAL_NVM_NOBINARY} -eq 1 ]; then
-          LOCAL_NVM_METHOD_PREFERENCE='source'
+        local NVM_LOCAL_METHOD_PREFERENCE
+        NVM_LOCAL_METHOD_PREFERENCE='binary'
+        if [ ${NVM_LOCAL_NOBINARY} -eq 1 ]; then
+          NVM_LOCAL_METHOD_PREFERENCE='source'
         fi
-        local LOCAL_NVM_VERSION_PATH
-        LOCAL_NVM_VERSION_PATH="$(nvm_version_path "${LOCAL_NVM_VERSION}")"
-        "${NVM_INSTALL_THIRD_PARTY_HOOK}" "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_FLAVOR}" std "${LOCAL_NVM_METHOD_PREFERENCE}" "${LOCAL_NVM_VERSION_PATH}" || {
-          LOCAL_NVM_EXIT_CODE=$?
+        local NVM_LOCAL_VERSION_PATH
+        NVM_LOCAL_VERSION_PATH="$(nvm_version_path "${NVM_LOCAL_VERSION}")"
+        "${NVM_INSTALL_THIRD_PARTY_HOOK}" "${NVM_LOCAL_VERSION}" "${NVM_LOCAL_FLAVOR}" std "${NVM_LOCAL_METHOD_PREFERENCE}" "${NVM_LOCAL_VERSION_PATH}" || {
+          NVM_LOCAL_EXIT_CODE=$?
           nvm_err '*** Third-party ${NVM_INSTALL_THIRD_PARTY_HOOK} env var failed to install! ***'
-          return ${LOCAL_NVM_EXIT_CODE}
+          return ${NVM_LOCAL_EXIT_CODE}
         }
-        if ! nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
+        if ! nvm_is_version_installed "${NVM_LOCAL_VERSION}"; then
           nvm_err '*** Third-party ${NVM_INSTALL_THIRD_PARTY_HOOK} env var claimed to succeed, but failed to install! ***'
           return 33
         fi
-        LOCAL_NVM_EXIT_CODE=0
+        NVM_LOCAL_EXIT_CODE=0
       else
 
-        if [ "_${LOCAL_NVM_OS}" = "_freebsd" ]; then
+        if [ "_${NVM_LOCAL_OS}" = "_freebsd" ]; then
           # node.js and io.js do not have a FreeBSD binary
-          LOCAL_NVM_NOBINARY=1
+          NVM_LOCAL_NOBINARY=1
           nvm_err "Currently, there is no binary for FreeBSD"
-        elif [ "_${LOCAL_NVM_OS}" = "_openbsd" ]; then
+        elif [ "_${NVM_LOCAL_OS}" = "_openbsd" ]; then
           # node.js and io.js do not have a OpenBSD binary
-          LOCAL_NVM_NOBINARY=1
+          NVM_LOCAL_NOBINARY=1
           nvm_err "Currently, there is no binary for OpenBSD"
-        elif [ "_${LOCAL_NVM_OS}" = "_sunos" ]; then
+        elif [ "_${NVM_LOCAL_OS}" = "_sunos" ]; then
           # Not all node/io.js versions have a Solaris binary
-          if ! nvm_has_solaris_binary "${LOCAL_NVM_VERSION}"; then
-            LOCAL_NVM_NOBINARY=1
-            nvm_err "Currently, there is no binary of version ${LOCAL_NVM_VERSION} for SunOS"
+          if ! nvm_has_solaris_binary "${NVM_LOCAL_VERSION}"; then
+            NVM_LOCAL_NOBINARY=1
+            nvm_err "Currently, there is no binary of version ${NVM_LOCAL_VERSION} for SunOS"
           fi
         fi
 
-        # skip binary install if "LOCAL_NVM_NOBINARY" option specified.
-        if [ ${LOCAL_NVM_NOBINARY} -ne 1 ] && nvm_binary_available "${LOCAL_NVM_VERSION}"; then
-          NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${LOCAL_NVM_NOPROGRESS}}" nvm_install_binary "${LOCAL_NVM_FLAVOR}" std "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_NOSOURCE}"
-          LOCAL_NVM_EXIT_CODE=$?
+        # skip binary install if "NVM_LOCAL_NOBINARY" option specified.
+        if [ ${NVM_LOCAL_NOBINARY} -ne 1 ] && nvm_binary_available "${NVM_LOCAL_VERSION}"; then
+          NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${NVM_LOCAL_NOPROGRESS}}" nvm_install_binary "${NVM_LOCAL_FLAVOR}" std "${NVM_LOCAL_VERSION}" "${NVM_LOCAL_NOSOURCE}"
+          NVM_LOCAL_EXIT_CODE=$?
         fi
-        if [ ${LOCAL_NVM_EXIT_CODE} -ne 0 ]; then
-          if [ -z "${LOCAL_NVM_MAKE_JOBS-}" ]; then
+        if [ ${NVM_LOCAL_EXIT_CODE} -ne 0 ]; then
+          if [ -z "${NVM_LOCAL_MAKE_JOBS-}" ]; then
             nvm_get_make_jobs
           fi
 
-          if [ "_${LOCAL_NVM_OS}" = "_win" ]; then
+          if [ "_${NVM_LOCAL_OS}" = "_win" ]; then
             nvm_err 'Installing from source on non-WSL Windows is not supported'
-            LOCAL_NVM_EXIT_CODE=87
+            NVM_LOCAL_EXIT_CODE=87
           else
-            NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${LOCAL_NVM_NOPROGRESS}}" nvm_install_source "${LOCAL_NVM_FLAVOR}" std "${LOCAL_NVM_VERSION}" "${LOCAL_NVM_MAKE_JOBS}" "${LOCAL_NVM_ADDITIONAL_PARAMETERS}"
-            LOCAL_NVM_EXIT_CODE=$?
+            NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${NVM_LOCAL_NOPROGRESS}}" nvm_install_source "${NVM_LOCAL_FLAVOR}" std "${NVM_LOCAL_VERSION}" "${NVM_LOCAL_MAKE_JOBS}" "${NVM_LOCAL_ADDITIONAL_PARAMETERS}"
+            NVM_LOCAL_EXIT_CODE=$?
           fi
         fi
 
       fi
 
-      if [ ${LOCAL_NVM_EXIT_CODE} -eq 0 ] && nvm_use_if_needed "${LOCAL_NVM_VERSION}" && nvm_install_npm_if_needed "${LOCAL_NVM_VERSION}"; then
-        if [ -n "${LOCAL_NVM_LTS-}" ]; then
-          nvm_ensure_default_set "lts/${LOCAL_NVM_LTS}"
+      if [ ${NVM_LOCAL_EXIT_CODE} -eq 0 ] && nvm_use_if_needed "${NVM_LOCAL_VERSION}" && nvm_install_npm_if_needed "${NVM_LOCAL_VERSION}"; then
+        if [ -n "${NVM_LOCAL_LTS-}" ]; then
+          nvm_ensure_default_set "lts/${NVM_LOCAL_LTS}"
         else
-          nvm_ensure_default_set "${LOCAL_NVM_PROVIDED_VERSION}"
+          nvm_ensure_default_set "${NVM_LOCAL_PROVIDED_VERSION}"
         fi
-        if [ "${LOCAL_NVM_UPGRADE_NPM}" = 1 ]; then
+        if [ "${NVM_LOCAL_UPGRADE_NPM}" = 1 ]; then
           nvm install-latest-npm
-          LOCAL_NVM_EXIT_CODE=$?
+          NVM_LOCAL_EXIT_CODE=$?
         fi
-        if [ -z "${LOCAL_NVM_SKIP_DEFAULT_PACKAGES-}" ] && [ -n "${LOCAL_NVM_DEFAULT_PACKAGES-}" ]; then
-          nvm_install_default_packages "${LOCAL_NVM_DEFAULT_PACKAGES}"
+        if [ -z "${NVM_LOCAL_SKIP_DEFAULT_PACKAGES-}" ] && [ -n "${NVM_LOCAL_DEFAULT_PACKAGES-}" ]; then
+          nvm_install_default_packages "${NVM_LOCAL_DEFAULT_PACKAGES}"
         fi
-        if [ -n "${LOCAL_NVM_REINSTALL_PACKAGES_FROM-}" ] && [ "_${LOCAL_NVM_REINSTALL_PACKAGES_FROM}" != "_N/A" ]; then
-          nvm reinstall-packages "${LOCAL_NVM_REINSTALL_PACKAGES_FROM}"
-          LOCAL_NVM_EXIT_CODE=$?
+        if [ -n "${NVM_LOCAL_REINSTALL_PACKAGES_FROM-}" ] && [ "_${NVM_LOCAL_REINSTALL_PACKAGES_FROM}" != "_N/A" ]; then
+          nvm reinstall-packages "${NVM_LOCAL_REINSTALL_PACKAGES_FROM}"
+          NVM_LOCAL_EXIT_CODE=$?
         fi
       else
-        LOCAL_NVM_EXIT_CODE=$?
+        NVM_LOCAL_EXIT_CODE=$?
       fi
-      return ${LOCAL_NVM_EXIT_CODE}
+      return ${NVM_LOCAL_EXIT_CODE}
     ;;
     "uninstall")
       if [ $# -ne 1 ]; then
@@ -3396,122 +3396,122 @@ nvm() {
         return 127
       fi
 
-      local LOCAL_NVM_PATTERN
-      LOCAL_NVM_PATTERN="${1-}"
-      case "${LOCAL_NVM_PATTERN-}" in
+      local NVM_LOCAL_PATTERN
+      NVM_LOCAL_PATTERN="${1-}"
+      case "${NVM_LOCAL_PATTERN-}" in
         --) ;;
         --lts | 'lts/*')
-          LOCAL_NVM_VERSION="$(nvm_match_version "lts/*")"
+          NVM_LOCAL_VERSION="$(nvm_match_version "lts/*")"
         ;;
         lts/*)
-          LOCAL_NVM_VERSION="$(nvm_match_version "lts/${LOCAL_NVM_PATTERN##lts/}")"
+          NVM_LOCAL_VERSION="$(nvm_match_version "lts/${NVM_LOCAL_PATTERN##lts/}")"
         ;;
         --lts=*)
-          LOCAL_NVM_VERSION="$(nvm_match_version "lts/${LOCAL_NVM_PATTERN##--lts=}")"
+          NVM_LOCAL_VERSION="$(nvm_match_version "lts/${NVM_LOCAL_PATTERN##--lts=}")"
         ;;
         *)
-          LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PATTERN}")"
+          NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_PATTERN}")"
         ;;
       esac
 
-      if [ "_${LOCAL_NVM_VERSION}" = "_$(nvm_ls_current)" ]; then
-        if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
-          nvm_err "nvm: Cannot uninstall currently-active io.js version, ${LOCAL_NVM_VERSION} (inferred from ${LOCAL_NVM_PATTERN})."
+      if [ "_${NVM_LOCAL_VERSION}" = "_$(nvm_ls_current)" ]; then
+        if nvm_is_iojs_version "${NVM_LOCAL_VERSION}"; then
+          nvm_err "nvm: Cannot uninstall currently-active io.js version, ${NVM_LOCAL_VERSION} (inferred from ${NVM_LOCAL_PATTERN})."
         else
-          nvm_err "nvm: Cannot uninstall currently-active node version, ${LOCAL_NVM_VERSION} (inferred from ${LOCAL_NVM_PATTERN})."
+          nvm_err "nvm: Cannot uninstall currently-active node version, ${NVM_LOCAL_VERSION} (inferred from ${NVM_LOCAL_PATTERN})."
         fi
         return 1
       fi
 
-      if ! nvm_is_version_installed "${LOCAL_NVM_VERSION}"; then
-        nvm_err "${LOCAL_NVM_VERSION} version is not installed..."
+      if ! nvm_is_version_installed "${NVM_LOCAL_VERSION}"; then
+        nvm_err "${NVM_LOCAL_VERSION} version is not installed..."
         return
       fi
 
-      local LOCAL_NVM_SLUG_BINARY
-      local LOCAL_NVM_SLUG_SOURCE
-      if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
-        LOCAL_NVM_SLUG_BINARY="$(nvm_get_download_slug iojs binary std "${LOCAL_NVM_VERSION}")"
-        LOCAL_NVM_SLUG_SOURCE="$(nvm_get_download_slug iojs source std "${LOCAL_NVM_VERSION}")"
+      local NVM_LOCAL_SLUG_BINARY
+      local NVM_LOCAL_SLUG_SOURCE
+      if nvm_is_iojs_version "${NVM_LOCAL_VERSION}"; then
+        NVM_LOCAL_SLUG_BINARY="$(nvm_get_download_slug iojs binary std "${NVM_LOCAL_VERSION}")"
+        NVM_LOCAL_SLUG_SOURCE="$(nvm_get_download_slug iojs source std "${NVM_LOCAL_VERSION}")"
       else
-        LOCAL_NVM_SLUG_BINARY="$(nvm_get_download_slug node binary std "${LOCAL_NVM_VERSION}")"
-        LOCAL_NVM_SLUG_SOURCE="$(nvm_get_download_slug node source std "${LOCAL_NVM_VERSION}")"
+        NVM_LOCAL_SLUG_BINARY="$(nvm_get_download_slug node binary std "${NVM_LOCAL_VERSION}")"
+        NVM_LOCAL_SLUG_SOURCE="$(nvm_get_download_slug node source std "${NVM_LOCAL_VERSION}")"
       fi
 
-      local LOCAL_NVM_SUCCESS_MSG
-      if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
-        LOCAL_NVM_SUCCESS_MSG="Uninstalled io.js $(nvm_strip_iojs_prefix "${LOCAL_NVM_VERSION}")"
+      local NVM_LOCAL_SUCCESS_MSG
+      if nvm_is_iojs_version "${NVM_LOCAL_VERSION}"; then
+        NVM_LOCAL_SUCCESS_MSG="Uninstalled io.js $(nvm_strip_iojs_prefix "${NVM_LOCAL_VERSION}")"
       else
-        LOCAL_NVM_SUCCESS_MSG="Uninstalled node ${LOCAL_NVM_VERSION}"
+        NVM_LOCAL_SUCCESS_MSG="Uninstalled node ${NVM_LOCAL_VERSION}"
       fi
 
-      local LOCAL_NVM_VERSION_PATH
-      LOCAL_NVM_VERSION_PATH="$(nvm_version_path "${LOCAL_NVM_VERSION}")"
-      if ! nvm_check_file_permissions "${LOCAL_NVM_VERSION_PATH}"; then
+      local NVM_LOCAL_VERSION_PATH
+      NVM_LOCAL_VERSION_PATH="$(nvm_version_path "${NVM_LOCAL_VERSION}")"
+      if ! nvm_check_file_permissions "${NVM_LOCAL_VERSION_PATH}"; then
         nvm_err 'Cannot uninstall, incorrect permissions on installation folder.'
         nvm_err 'This is usually caused by running `npm install -g` as root. Run the following commands as root to fix the permissions and then try again.'
         nvm_err
-        nvm_err "  chown -R $(whoami) \"$(nvm_sanitize_path "${LOCAL_NVM_VERSION_PATH}")\""
-        nvm_err "  chmod -R u+w \"$(nvm_sanitize_path "${LOCAL_NVM_VERSION_PATH}")\""
+        nvm_err "  chown -R $(whoami) \"$(nvm_sanitize_path "${NVM_LOCAL_VERSION_PATH}")\""
+        nvm_err "  chmod -R u+w \"$(nvm_sanitize_path "${NVM_LOCAL_VERSION_PATH}")\""
         return 1
       fi
 
       # Delete all files related to target version.
-      local LOCAL_NVM_CACHE_DIR
-      LOCAL_NVM_CACHE_DIR="$(nvm_cache_dir)"
+      local NVM_LOCAL_CACHE_DIR
+      NVM_LOCAL_CACHE_DIR="$(nvm_cache_dir)"
       command rm -rf \
-        "${LOCAL_NVM_CACHE_DIR}/bin/${LOCAL_NVM_SLUG_BINARY}/files" \
-        "${LOCAL_NVM_CACHE_DIR}/src/${LOCAL_NVM_SLUG_SOURCE}/files" \
-        "${LOCAL_NVM_VERSION_PATH}" 2>/dev/null
-      nvm_echo "${LOCAL_NVM_SUCCESS_MSG}"
+        "${NVM_LOCAL_CACHE_DIR}/bin/${NVM_LOCAL_SLUG_BINARY}/files" \
+        "${NVM_LOCAL_CACHE_DIR}/src/${NVM_LOCAL_SLUG_SOURCE}/files" \
+        "${NVM_LOCAL_VERSION_PATH}" 2>/dev/null
+      nvm_echo "${NVM_LOCAL_SUCCESS_MSG}"
 
       # rm any aliases that point to uninstalled version.
-      for LOCAL_NVM_FOR_ALIAS in $(nvm_grep -l "${LOCAL_NVM_VERSION}" "$(nvm_alias_path)/*" 2>/dev/null); do
-        nvm unalias "$(command basename "${LOCAL_NVM_FOR_ALIAS}")"
+      for NVM_LOCAL_FOR_ALIAS in $(nvm_grep -l "${NVM_LOCAL_VERSION}" "$(nvm_alias_path)/*" 2>/dev/null); do
+        nvm unalias "$(command basename "${NVM_LOCAL_FOR_ALIAS}")"
       done
     ;;
     "deactivate")
-      local LOCAL_NVM_SILENT
+      local NVM_LOCAL_SILENT
       while [ $# -ne 0 ]; do
         case "${1}" in
-          --silent) LOCAL_NVM_SILENT=1 ;;
+          --silent) NVM_LOCAL_SILENT=1 ;;
           --) ;;
         esac
         shift
       done
-      local LOCAL_NVM_NEWPATH
-      LOCAL_NVM_NEWPATH="$(nvm_strip_path "${PATH}" "/bin")"
-      if [ "_${PATH}" = "_${LOCAL_NVM_NEWPATH}" ]; then
-        if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+      local NVM_LOCAL_NEWPATH
+      NVM_LOCAL_NEWPATH="$(nvm_strip_path "${PATH}" "/bin")"
+      if [ "_${PATH}" = "_${NVM_LOCAL_NEWPATH}" ]; then
+        if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
           nvm_err "Could not find ${NVM_DIR}/*/bin in \${PATH}"
         fi
       else
-        export PATH="${LOCAL_NVM_NEWPATH}"
+        export PATH="${NVM_LOCAL_NEWPATH}"
         hash -r
-        if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+        if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
           nvm_echo "${NVM_DIR}/*/bin removed from \${PATH}"
         fi
       fi
 
       if [ -n "${MANPATH-}" ]; then
-        LOCAL_NVM_NEWPATH="$(nvm_strip_path "${MANPATH}" "/share/man")"
-        if [ "_${MANPATH}" = "_${LOCAL_NVM_NEWPATH}" ]; then
-          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+        NVM_LOCAL_NEWPATH="$(nvm_strip_path "${MANPATH}" "/share/man")"
+        if [ "_${MANPATH}" = "_${NVM_LOCAL_NEWPATH}" ]; then
+          if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
             nvm_err "Could not find ${NVM_DIR}/*/share/man in \${MANPATH}"
           fi
         else
-          export MANPATH="${LOCAL_NVM_NEWPATH}"
-          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+          export MANPATH="${NVM_LOCAL_NEWPATH}"
+          if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
             nvm_echo "${NVM_DIR}/*/share/man removed from \${MANPATH}"
           fi
         fi
       fi
 
       if [ -n "${NODE_PATH-}" ]; then
-        LOCAL_NVM_NEWPATH="$(nvm_strip_path "${NODE_PATH}" "/lib/node_modules")"
-        if [ "_${NODE_PATH}" != "_${LOCAL_NVM_NEWPATH}" ]; then
-          export NODE_PATH="${LOCAL_NVM_NEWPATH}"
-          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+        NVM_LOCAL_NEWPATH="$(nvm_strip_path "${NODE_PATH}" "/lib/node_modules")"
+        if [ "_${NODE_PATH}" != "_${NVM_LOCAL_NEWPATH}" ]; then
+          export NODE_PATH="${NVM_LOCAL_NEWPATH}"
+          if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
             nvm_echo "${NVM_DIR}/*/lib/node_modules removed from \${NODE_PATH}"
           fi
         fi
@@ -3520,154 +3520,154 @@ nvm() {
       unset NVM_INC
     ;;
     "use")
-      local LOCAL_NVM_PROVIDED_VERSION
-      local LOCAL_NVM_SILENT
-      local LOCAL_NVM_SILENT_ARG
-      local LOCAL_NVM_DELETE_PREFIX
-      LOCAL_NVM_DELETE_PREFIX=0
-      local LOCAL_NVM_LTS
+      local NVM_LOCAL_PROVIDED_VERSION
+      local NVM_LOCAL_SILENT
+      local NVM_LOCAL_SILENT_ARG
+      local NVM_LOCAL_DELETE_PREFIX
+      NVM_LOCAL_DELETE_PREFIX=0
+      local NVM_LOCAL_LTS
 
       while [ $# -ne 0 ]; do
         case "$1" in
           --silent)
-            LOCAL_NVM_SILENT=1
-            LOCAL_NVM_SILENT_ARG='--silent'
+            NVM_LOCAL_SILENT=1
+            NVM_LOCAL_SILENT_ARG='--silent'
           ;;
-          --delete-prefix) LOCAL_NVM_DELETE_PREFIX=1 ;;
+          --delete-prefix) NVM_LOCAL_DELETE_PREFIX=1 ;;
           --) ;;
-          --lts) LOCAL_NVM_LTS='*' ;;
-          --lts=*) LOCAL_NVM_LTS="${1##--lts=}" ;;
+          --lts) NVM_LOCAL_LTS='*' ;;
+          --lts=*) NVM_LOCAL_LTS="${1##--lts=}" ;;
           --*) ;;
           *)
             if [ -n "${1-}" ]; then
-              LOCAL_NVM_PROVIDED_VERSION="$1"
+              NVM_LOCAL_PROVIDED_VERSION="$1"
             fi
           ;;
         esac
         shift
       done
 
-      if [ -n "${LOCAL_NVM_LTS-}" ]; then
-        LOCAL_NVM_VERSION="$(nvm_match_version "lts/${LOCAL_NVM_LTS:-*}")"
-      elif [ -z "${LOCAL_NVM_PROVIDED_VERSION-}" ]; then
-        LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version
+      if [ -n "${NVM_LOCAL_LTS-}" ]; then
+        NVM_LOCAL_VERSION="$(nvm_match_version "lts/${NVM_LOCAL_LTS:-*}")"
+      elif [ -z "${NVM_LOCAL_PROVIDED_VERSION-}" ]; then
+        NVM_LOCAL_SILENT="${NVM_LOCAL_SILENT:-0}" nvm_rc_version
         if [ -n "${NVM_RC_VERSION-}" ]; then
-          LOCAL_NVM_PROVIDED_VERSION="${NVM_RC_VERSION}"
-          LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")"
+          NVM_LOCAL_PROVIDED_VERSION="${NVM_RC_VERSION}"
+          NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_PROVIDED_VERSION}")"
         fi
         unset NVM_RC_VERSION
-        if [ -z "${LOCAL_NVM_VERSION}" ]; then
+        if [ -z "${NVM_LOCAL_VERSION}" ]; then
           nvm_err 'Please see `nvm --help` or https://github.com/nvm-sh/nvm#nvmrc for more information.'
           return 127
         fi
       else
-        LOCAL_NVM_VERSION="$(nvm_match_version "${LOCAL_NVM_PROVIDED_VERSION}")"
+        NVM_LOCAL_VERSION="$(nvm_match_version "${NVM_LOCAL_PROVIDED_VERSION}")"
       fi
 
-      if [ -z "${LOCAL_NVM_VERSION}" ]; then
+      if [ -z "${NVM_LOCAL_VERSION}" ]; then
         >&2 nvm --help
         return 127
       fi
 
-      if [ "_${LOCAL_NVM_VERSION}" = '_system' ]; then
-        if nvm_has_system_node && nvm deactivate "${LOCAL_NVM_SILENT_ARG-}" >/dev/null 2>&1; then
-          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+      if [ "_${NVM_LOCAL_VERSION}" = '_system' ]; then
+        if nvm_has_system_node && nvm deactivate "${NVM_LOCAL_SILENT_ARG-}" >/dev/null 2>&1; then
+          if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
             nvm_echo "Now using system version of node: $(node -v 2>/dev/null)$(nvm_print_npm_version)"
           fi
           return
-        elif nvm_has_system_iojs && nvm deactivate "${LOCAL_NVM_SILENT_ARG-}" >/dev/null 2>&1; then
-          if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+        elif nvm_has_system_iojs && nvm deactivate "${NVM_LOCAL_SILENT_ARG-}" >/dev/null 2>&1; then
+          if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
             nvm_echo "Now using system version of io.js: $(iojs --version 2>/dev/null)$(nvm_print_npm_version)"
           fi
           return
-        elif [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
+        elif [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
           nvm_err 'System version of node not found.'
         fi
         return 127
-      elif [ "_${LOCAL_NVM_VERSION}" = "_∞" ]; then
-        if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
-          nvm_err "The alias \"${LOCAL_NVM_PROVIDED_VERSION}\" leads to an infinite loop. Aborting."
+      elif [ "_${NVM_LOCAL_VERSION}" = "_∞" ]; then
+        if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
+          nvm_err "The alias \"${NVM_LOCAL_PROVIDED_VERSION}\" leads to an infinite loop. Aborting."
         fi
         return 8
       fi
-      if [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
-        if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
-          nvm_err "N/A: version \"${LOCAL_NVM_PROVIDED_VERSION} -> ${LOCAL_NVM_VERSION}\" is not yet installed."
+      if [ "${NVM_LOCAL_VERSION}" = 'N/A' ]; then
+        if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
+          nvm_err "N/A: version \"${NVM_LOCAL_PROVIDED_VERSION} -> ${NVM_LOCAL_VERSION}\" is not yet installed."
           nvm_err ""
-          nvm_err "You need to run \"nvm install ${LOCAL_NVM_PROVIDED_VERSION}\" to install it before using it."
+          nvm_err "You need to run \"nvm install ${NVM_LOCAL_PROVIDED_VERSION}\" to install it before using it."
         fi
         return 3
       # This nvm_ensure_version_installed call can be a performance bottleneck
       # on shell startup. Perhaps we can optimize it away or make it faster.
-      elif ! nvm_ensure_version_installed "${LOCAL_NVM_VERSION}"; then
+      elif ! nvm_ensure_version_installed "${NVM_LOCAL_VERSION}"; then
         return $?
       fi
 
-      local LOCAL_NVM_VERSION_DIR
-      LOCAL_NVM_VERSION_DIR="$(nvm_version_path "${LOCAL_NVM_VERSION}")"
+      local NVM_LOCAL_VERSION_DIR
+      NVM_LOCAL_VERSION_DIR="$(nvm_version_path "${NVM_LOCAL_VERSION}")"
 
       # Change current version
-      PATH="$(nvm_change_path "${PATH}" "/bin" "${LOCAL_NVM_VERSION_DIR}")"
+      PATH="$(nvm_change_path "${PATH}" "/bin" "${NVM_LOCAL_VERSION_DIR}")"
       if nvm_has manpath; then
         if [ -z "${MANPATH-}" ]; then
           local MANPATH
           MANPATH=$(manpath)
         fi
         # Change current version
-        MANPATH="$(nvm_change_path "${MANPATH}" "/share/man" "${LOCAL_NVM_VERSION_DIR}")"
+        MANPATH="$(nvm_change_path "${MANPATH}" "/share/man" "${NVM_LOCAL_VERSION_DIR}")"
         export MANPATH
       fi
       export PATH
       hash -r
-      export NVM_BIN="${LOCAL_NVM_VERSION_DIR}/bin"
-      export NVM_INC="${LOCAL_NVM_VERSION_DIR}/include/node"
+      export NVM_BIN="${NVM_LOCAL_VERSION_DIR}/bin"
+      export NVM_INC="${NVM_LOCAL_VERSION_DIR}/include/node"
       if [ "${NVM_SYMLINK_CURRENT-}" = true ]; then
-        command rm -f "${NVM_DIR}/current" && ln -s "${LOCAL_NVM_VERSION_DIR}" "${NVM_DIR}/current"
+        command rm -f "${NVM_DIR}/current" && ln -s "${NVM_LOCAL_VERSION_DIR}" "${NVM_DIR}/current"
       fi
-      local LOCAL_NVM_USE_OUTPUT
-      LOCAL_NVM_USE_OUTPUT=''
-      if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
-        if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
-          LOCAL_NVM_USE_OUTPUT="Now using io.js $(nvm_strip_iojs_prefix "${LOCAL_NVM_VERSION}")$(nvm_print_npm_version)"
+      local NVM_LOCAL_USE_OUTPUT
+      NVM_LOCAL_USE_OUTPUT=''
+      if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
+        if nvm_is_iojs_version "${NVM_LOCAL_VERSION}"; then
+          NVM_LOCAL_USE_OUTPUT="Now using io.js $(nvm_strip_iojs_prefix "${NVM_LOCAL_VERSION}")$(nvm_print_npm_version)"
         else
-          LOCAL_NVM_USE_OUTPUT="Now using node ${LOCAL_NVM_VERSION}$(nvm_print_npm_version)"
+          NVM_LOCAL_USE_OUTPUT="Now using node ${NVM_LOCAL_VERSION}$(nvm_print_npm_version)"
         fi
       fi
-      if [ "_${LOCAL_NVM_VERSION}" != "_system" ]; then
-        local LOCAL_NVM_USE_CMD
-        LOCAL_NVM_USE_CMD="nvm use --delete-prefix"
-        if [ -n "${LOCAL_NVM_PROVIDED_VERSION}" ]; then
-          LOCAL_NVM_USE_CMD="${LOCAL_NVM_USE_CMD} ${LOCAL_NVM_VERSION}"
+      if [ "_${NVM_LOCAL_VERSION}" != "_system" ]; then
+        local NVM_LOCAL_USE_CMD
+        NVM_LOCAL_USE_CMD="nvm use --delete-prefix"
+        if [ -n "${NVM_LOCAL_PROVIDED_VERSION}" ]; then
+          NVM_LOCAL_USE_CMD="${NVM_LOCAL_USE_CMD} ${NVM_LOCAL_VERSION}"
         fi
-        if [ "${LOCAL_NVM_SILENT:-0}" -eq 1 ]; then
-          LOCAL_NVM_USE_CMD="${LOCAL_NVM_USE_CMD} --silent"
+        if [ "${NVM_LOCAL_SILENT:-0}" -eq 1 ]; then
+          NVM_LOCAL_USE_CMD="${NVM_LOCAL_USE_CMD} --silent"
         fi
-        if ! nvm_die_on_prefix "${LOCAL_NVM_DELETE_PREFIX}" "${LOCAL_NVM_USE_CMD}" "${LOCAL_NVM_VERSION_DIR}"; then
+        if ! nvm_die_on_prefix "${NVM_LOCAL_DELETE_PREFIX}" "${NVM_LOCAL_USE_CMD}" "${NVM_LOCAL_VERSION_DIR}"; then
           return 11
         fi
       fi
-      if [ -n "${LOCAL_NVM_USE_OUTPUT-}" ] && [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
-        nvm_echo "${LOCAL_NVM_USE_OUTPUT}"
+      if [ -n "${NVM_LOCAL_USE_OUTPUT-}" ] && [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
+        nvm_echo "${NVM_LOCAL_USE_OUTPUT}"
       fi
     ;;
     "run")
-      local LOCAL_NVM_PROVIDED_VERSION
-      local LOCAL_NVM_HAS_CHECKED_NVMRC
-      LOCAL_NVM_HAS_CHECKED_NVMRC=0
+      local NVM_LOCAL_PROVIDED_VERSION
+      local NVM_LOCAL_HAS_CHECKED_NVMRC
+      NVM_LOCAL_HAS_CHECKED_NVMRC=0
       # run given version of node
 
-      local LOCAL_NVM_SILENT
-      local LOCAL_NVM_SILENT_ARG
-      local LOCAL_NVM_LTS
+      local NVM_LOCAL_SILENT
+      local NVM_LOCAL_SILENT_ARG
+      local NVM_LOCAL_LTS
       while [ $# -gt 0 ]; do
         case "$1" in
           --silent)
-            LOCAL_NVM_SILENT=1
-            LOCAL_NVM_SILENT_ARG='--silent'
+            NVM_LOCAL_SILENT=1
+            NVM_LOCAL_SILENT_ARG='--silent'
             shift
           ;;
-          --lts) LOCAL_NVM_LTS='*' ; shift ;;
-          --lts=*) LOCAL_NVM_LTS="${1##--lts=}" ; shift ;;
+          --lts) NVM_LOCAL_LTS='*' ; shift ;;
+          --lts=*) NVM_LOCAL_LTS="${1##--lts=}" ; shift ;;
           *)
             if [ -n "$1" ]; then
               break
@@ -3678,28 +3678,28 @@ nvm() {
         esac
       done
 
-      if [ $# -lt 1 ] && [ -z "${LOCAL_NVM_LTS-}" ]; then
-        LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version && LOCAL_NVM_HAS_CHECKED_NVMRC=1
+      if [ $# -lt 1 ] && [ -z "${NVM_LOCAL_LTS-}" ]; then
+        NVM_LOCAL_SILENT="${NVM_LOCAL_SILENT:-0}" nvm_rc_version && NVM_LOCAL_HAS_CHECKED_NVMRC=1
         if [ -n "${NVM_RC_VERSION-}" ]; then
-          LOCAL_NVM_VERSION="$(nvm_version "${NVM_RC_VERSION-}")" ||:
+          NVM_LOCAL_VERSION="$(nvm_version "${NVM_RC_VERSION-}")" ||:
         fi
         unset NVM_RC_VERSION
-        if [ "${LOCAL_NVM_VERSION:-N/A}" = 'N/A' ]; then
+        if [ "${NVM_LOCAL_VERSION:-N/A}" = 'N/A' ]; then
           >&2 nvm --help
           return 127
         fi
       fi
 
-      if [ -z "${LOCAL_NVM_LTS-}" ]; then
-        LOCAL_NVM_PROVIDED_VERSION="$1"
-        if [ -n "${LOCAL_NVM_PROVIDED_VERSION}" ]; then
-          LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
-          if [ "_${LOCAL_NVM_VERSION:-N/A}" = '_N/A' ] && ! nvm_is_valid_version "${LOCAL_NVM_PROVIDED_VERSION}"; then
-            LOCAL_NVM_PROVIDED_VERSION=''
-            if [ ${LOCAL_NVM_HAS_CHECKED_NVMRC} -ne 1 ]; then
-              LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version && LOCAL_NVM_HAS_CHECKED_NVMRC=1
+      if [ -z "${NVM_LOCAL_LTS-}" ]; then
+        NVM_LOCAL_PROVIDED_VERSION="$1"
+        if [ -n "${NVM_LOCAL_PROVIDED_VERSION}" ]; then
+          NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_PROVIDED_VERSION}")" ||:
+          if [ "_${NVM_LOCAL_VERSION:-N/A}" = '_N/A' ] && ! nvm_is_valid_version "${NVM_LOCAL_PROVIDED_VERSION}"; then
+            NVM_LOCAL_PROVIDED_VERSION=''
+            if [ ${NVM_LOCAL_HAS_CHECKED_NVMRC} -ne 1 ]; then
+              NVM_LOCAL_SILENT="${NVM_LOCAL_SILENT:-0}" nvm_rc_version && NVM_LOCAL_HAS_CHECKED_NVMRC=1
             fi
-            LOCAL_NVM_VERSION="$(nvm_version "${NVM_RC_VERSION}")" ||:
+            NVM_LOCAL_VERSION="$(nvm_version "${NVM_RC_VERSION}")" ||:
             unset NVM_RC_VERSION
           else
             shift
@@ -3707,37 +3707,37 @@ nvm() {
         fi
       fi
 
-      local LOCAL_NVM_IOJS
-      if nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
-        LOCAL_NVM_IOJS=true
+      local NVM_LOCAL_IOJS
+      if nvm_is_iojs_version "${NVM_LOCAL_VERSION}"; then
+        NVM_LOCAL_IOJS=true
       fi
 
-      local LOCAL_NVM_EXIT_CODE
+      local NVM_LOCAL_EXIT_CODE
 
       nvm_is_zsh && setopt local_options shwordsplit
-      local LOCAL_NVM_LTS_ARG
-      if [ -n "${LOCAL_NVM_LTS-}" ]; then
-        LOCAL_NVM_LTS_ARG="--lts=${LOCAL_NVM_LTS-}"
-        LOCAL_NVM_VERSION=''
+      local NVM_LOCAL_LTS_ARG
+      if [ -n "${NVM_LOCAL_LTS-}" ]; then
+        NVM_LOCAL_LTS_ARG="--lts=${NVM_LOCAL_LTS-}"
+        NVM_LOCAL_VERSION=''
       fi
-      if [ "_${LOCAL_NVM_VERSION}" = "_N/A" ]; then
-        nvm_ensure_version_installed "${LOCAL_NVM_PROVIDED_VERSION}"
-      elif [ "${LOCAL_NVM_IOJS}" = true ]; then
-        nvm exec "${LOCAL_NVM_SILENT_ARG-}" "${LOCAL_NVM_LTS_ARG-}" "${LOCAL_NVM_VERSION}" iojs "$@"
+      if [ "_${NVM_LOCAL_VERSION}" = "_N/A" ]; then
+        nvm_ensure_version_installed "${NVM_LOCAL_PROVIDED_VERSION}"
+      elif [ "${NVM_LOCAL_IOJS}" = true ]; then
+        nvm exec "${NVM_LOCAL_SILENT_ARG-}" "${NVM_LOCAL_LTS_ARG-}" "${NVM_LOCAL_VERSION}" iojs "$@"
       else
-        nvm exec "${LOCAL_NVM_SILENT_ARG-}" "${LOCAL_NVM_LTS_ARG-}" "${LOCAL_NVM_VERSION}" node "$@"
+        nvm exec "${NVM_LOCAL_SILENT_ARG-}" "${NVM_LOCAL_LTS_ARG-}" "${NVM_LOCAL_VERSION}" node "$@"
       fi
-      LOCAL_NVM_EXIT_CODE="$?"
-      return ${LOCAL_NVM_EXIT_CODE}
+      NVM_LOCAL_EXIT_CODE="$?"
+      return ${NVM_LOCAL_EXIT_CODE}
     ;;
     "exec")
-      local LOCAL_NVM_SILENT
-      local LOCAL_NVM_LTS
+      local NVM_LOCAL_SILENT
+      local NVM_LOCAL_LTS
       while [ $# -gt 0 ]; do
         case "$1" in
-          --silent) LOCAL_NVM_SILENT=1 ; shift ;;
-          --lts) LOCAL_NVM_LTS='*' ; shift ;;
-          --lts=*) LOCAL_NVM_LTS="${1##--lts=}" ; shift ;;
+          --silent) NVM_LOCAL_SILENT=1 ; shift ;;
+          --lts) NVM_LOCAL_LTS='*' ; shift ;;
+          --lts=*) NVM_LOCAL_LTS="${1##--lts=}" ; shift ;;
           --) break ;;
           --*)
             nvm_err "Unsupported option \"$1\"."
@@ -3753,112 +3753,112 @@ nvm() {
         esac
       done
 
-      local LOCAL_NVM_PROVIDED_VERSION
-      LOCAL_NVM_PROVIDED_VERSION="$1"
-      if [ "${LOCAL_NVM_LTS-}" != '' ]; then
-        LOCAL_NVM_PROVIDED_VERSION="lts/${LOCAL_NVM_LTS:-*}"
-        LOCAL_NVM_VERSION="${LOCAL_NVM_PROVIDED_VERSION}"
-      elif [ -n "${LOCAL_NVM_PROVIDED_VERSION}" ]; then
-        LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
-        if [ "_${LOCAL_NVM_VERSION}" = '_N/A' ] && ! nvm_is_valid_version "${LOCAL_NVM_PROVIDED_VERSION}"; then
-          LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version && LOCAL_NVM_HAS_CHECKED_NVMRC=1
-          LOCAL_NVM_PROVIDED_VERSION="${NVM_RC_VERSION}"
+      local NVM_LOCAL_PROVIDED_VERSION
+      NVM_LOCAL_PROVIDED_VERSION="$1"
+      if [ "${NVM_LOCAL_LTS-}" != '' ]; then
+        NVM_LOCAL_PROVIDED_VERSION="lts/${NVM_LOCAL_LTS:-*}"
+        NVM_LOCAL_VERSION="${NVM_LOCAL_PROVIDED_VERSION}"
+      elif [ -n "${NVM_LOCAL_PROVIDED_VERSION}" ]; then
+        NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_PROVIDED_VERSION}")" ||:
+        if [ "_${NVM_LOCAL_VERSION}" = '_N/A' ] && ! nvm_is_valid_version "${NVM_LOCAL_PROVIDED_VERSION}"; then
+          NVM_LOCAL_SILENT="${NVM_LOCAL_SILENT:-0}" nvm_rc_version && NVM_LOCAL_HAS_CHECKED_NVMRC=1
+          NVM_LOCAL_PROVIDED_VERSION="${NVM_RC_VERSION}"
           unset NVM_RC_VERSION
-          LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
+          NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_PROVIDED_VERSION}")" ||:
         else
           shift
         fi
       fi
 
-      local LOCAL_NVM_EXIT_CODE
-      nvm_ensure_version_installed "${LOCAL_NVM_PROVIDED_VERSION}"
-      LOCAL_NVM_EXIT_CODE=$?
-      if [ "${LOCAL_NVM_EXIT_CODE}" != "0" ]; then
-        return ${LOCAL_NVM_EXIT_CODE}
+      local NVM_LOCAL_EXIT_CODE
+      nvm_ensure_version_installed "${NVM_LOCAL_PROVIDED_VERSION}"
+      NVM_LOCAL_EXIT_CODE=$?
+      if [ "${NVM_LOCAL_EXIT_CODE}" != "0" ]; then
+        return ${NVM_LOCAL_EXIT_CODE}
       fi
 
-      if [ "${LOCAL_NVM_SILENT:-0}" -ne 1 ]; then
-        if [ "${LOCAL_NVM_LTS-}" = '*' ]; then
-          nvm_echo "Running node latest LTS -> $(nvm_version "${LOCAL_NVM_VERSION}")$(nvm use --silent "${LOCAL_NVM_VERSION}" && nvm_print_npm_version)"
-        elif [ -n "${LOCAL_NVM_LTS-}" ]; then
-          nvm_echo "Running node LTS \"${LOCAL_NVM_LTS-}\" -> $(nvm_version "${LOCAL_NVM_VERSION}")$(nvm use --silent "${LOCAL_NVM_VERSION}" && nvm_print_npm_version)"
-        elif nvm_is_iojs_version "${LOCAL_NVM_VERSION}"; then
-          nvm_echo "Running io.js $(nvm_strip_iojs_prefix "${LOCAL_NVM_VERSION}")$(nvm use --silent "${LOCAL_NVM_VERSION}" && nvm_print_npm_version)"
+      if [ "${NVM_LOCAL_SILENT:-0}" -ne 1 ]; then
+        if [ "${NVM_LOCAL_LTS-}" = '*' ]; then
+          nvm_echo "Running node latest LTS -> $(nvm_version "${NVM_LOCAL_VERSION}")$(nvm use --silent "${NVM_LOCAL_VERSION}" && nvm_print_npm_version)"
+        elif [ -n "${NVM_LOCAL_LTS-}" ]; then
+          nvm_echo "Running node LTS \"${NVM_LOCAL_LTS-}\" -> $(nvm_version "${NVM_LOCAL_VERSION}")$(nvm use --silent "${NVM_LOCAL_VERSION}" && nvm_print_npm_version)"
+        elif nvm_is_iojs_version "${NVM_LOCAL_VERSION}"; then
+          nvm_echo "Running io.js $(nvm_strip_iojs_prefix "${NVM_LOCAL_VERSION}")$(nvm use --silent "${NVM_LOCAL_VERSION}" && nvm_print_npm_version)"
         else
-          nvm_echo "Running node ${LOCAL_NVM_VERSION}$(nvm use --silent "${LOCAL_NVM_VERSION}" && nvm_print_npm_version)"
+          nvm_echo "Running node ${NVM_LOCAL_VERSION}$(nvm use --silent "${NVM_LOCAL_VERSION}" && nvm_print_npm_version)"
         fi
       fi
-      NODE_VERSION="${LOCAL_NVM_VERSION}" "${NVM_DIR}/nvm-exec" "$@"
+      NODE_VERSION="${NVM_LOCAL_VERSION}" "${NVM_DIR}/nvm-exec" "$@"
     ;;
     "ls" | "list")
-      local LOCAL_NVM_PATTERN
-      local LOCAL_NVM_NO_COLORS
-      local LOCAL_NVM_NO_ALIAS
+      local NVM_LOCAL_PATTERN
+      local NVM_LOCAL_NO_COLORS
+      local NVM_LOCAL_NO_ALIAS
 
       while [ $# -gt 0 ]; do
         case "${1}" in
           --) ;;
-          --no-colors) LOCAL_NVM_NO_COLORS="${1}" ;;
-          --no-alias) LOCAL_NVM_NO_ALIAS="${1}" ;;
+          --no-colors) NVM_LOCAL_NO_COLORS="${1}" ;;
+          --no-alias) NVM_LOCAL_NO_ALIAS="${1}" ;;
           --*)
             nvm_err "Unsupported option \"${1}\"."
             return 55
           ;;
           *)
-            LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN:-$1}"
+            NVM_LOCAL_PATTERN="${NVM_LOCAL_PATTERN:-$1}"
           ;;
         esac
         shift
       done
-      if [ -n "${LOCAL_NVM_PATTERN-}" ] && [ -n "${LOCAL_NVM_NO_ALIAS-}" ]; then
+      if [ -n "${NVM_LOCAL_PATTERN-}" ] && [ -n "${NVM_LOCAL_NO_ALIAS-}" ]; then
         nvm_err '`--no-alias` is not supported when a pattern is provided.'
         return 55
       fi
-      local LOCAL_NVM_LS_OUTPUT
-      local LOCAL_NVM_LS_EXIT_CODE
-      LOCAL_NVM_LS_OUTPUT=$(nvm_ls "${LOCAL_NVM_PATTERN-}")
-      LOCAL_NVM_LS_EXIT_CODE=$?
-      LOCAL_NVM_NO_COLORS="${LOCAL_NVM_NO_COLORS-}" nvm_print_versions "${LOCAL_NVM_LS_OUTPUT}"
-      if [ -z "${LOCAL_NVM_NO_ALIAS-}" ] && [ -z "${LOCAL_NVM_PATTERN-}" ]; then
-        if [ -n "${LOCAL_NVM_NO_COLORS-}" ]; then
+      local NVM_LOCAL_LS_OUTPUT
+      local NVM_LOCAL_LS_EXIT_CODE
+      NVM_LOCAL_LS_OUTPUT=$(nvm_ls "${NVM_LOCAL_PATTERN-}")
+      NVM_LOCAL_LS_EXIT_CODE=$?
+      NVM_LOCAL_NO_COLORS="${NVM_LOCAL_NO_COLORS-}" nvm_print_versions "${NVM_LOCAL_LS_OUTPUT}"
+      if [ -z "${NVM_LOCAL_NO_ALIAS-}" ] && [ -z "${NVM_LOCAL_PATTERN-}" ]; then
+        if [ -n "${NVM_LOCAL_NO_COLORS-}" ]; then
           nvm alias --no-colors
         else
           nvm alias
         fi
       fi
-      return ${LOCAL_NVM_LS_EXIT_CODE}
+      return ${NVM_LOCAL_LS_EXIT_CODE}
     ;;
     "ls-remote" | "list-remote")
-      local LOCAL_NVM_LTS
-      local LOCAL_NVM_PATTERN
-      local LOCAL_NVM_NO_COLORS
+      local NVM_LOCAL_LTS
+      local NVM_LOCAL_PATTERN
+      local NVM_LOCAL_NO_COLORS
 
       while [ $# -gt 0 ]; do
         case "${1-}" in
           --) ;;
           --lts)
-            LOCAL_NVM_LTS='*'
+            NVM_LOCAL_LTS='*'
           ;;
           --lts=*)
-            LOCAL_NVM_LTS="${1##--lts=}"
+            NVM_LOCAL_LTS="${1##--lts=}"
           ;;
-          --no-colors) LOCAL_NVM_NO_COLORS="${1}" ;;
+          --no-colors) NVM_LOCAL_NO_COLORS="${1}" ;;
           --*)
             nvm_err "Unsupported option \"${1}\"."
             return 55
           ;;
           *)
-            if [ -z "${LOCAL_NVM_PATTERN-}" ]; then
-              LOCAL_NVM_PATTERN="${1-}"
-              if [ -z "${LOCAL_NVM_LTS-}" ]; then
-                case "${LOCAL_NVM_PATTERN}" in
+            if [ -z "${NVM_LOCAL_PATTERN-}" ]; then
+              NVM_LOCAL_PATTERN="${1-}"
+              if [ -z "${NVM_LOCAL_LTS-}" ]; then
+                case "${NVM_LOCAL_PATTERN}" in
                   'lts/*')
-                    LOCAL_NVM_LTS='*'
-                    LOCAL_NVM_PATTERN=''
+                    NVM_LOCAL_LTS='*'
+                    NVM_LOCAL_PATTERN=''
                   ;;
                   lts/*)
-                    LOCAL_NVM_LTS="${LOCAL_NVM_PATTERN##lts/}"
-                    LOCAL_NVM_PATTERN=''
+                    NVM_LOCAL_LTS="${NVM_LOCAL_PATTERN##lts/}"
+                    NVM_LOCAL_PATTERN=''
                   ;;
                 esac
               fi
@@ -3868,137 +3868,137 @@ nvm() {
         shift
       done
 
-      local LOCAL_NVM_OUTPUT
-      local LOCAL_NVM_EXIT_CODE
-      LOCAL_NVM_OUTPUT="$(LOCAL_NVM_LTS="${LOCAL_NVM_LTS-}" nvm_remote_versions "${LOCAL_NVM_PATTERN}" &&:)"
-      LOCAL_NVM_EXIT_CODE=$?
-      if [ -n "${LOCAL_NVM_OUTPUT}" ]; then
-        LOCAL_NVM_NO_COLORS="${LOCAL_NVM_NO_COLORS-}" nvm_print_versions "${LOCAL_NVM_OUTPUT}"
-        return ${LOCAL_NVM_EXIT_CODE}
+      local NVM_LOCAL_OUTPUT
+      local NVM_LOCAL_EXIT_CODE
+      NVM_LOCAL_OUTPUT="$(NVM_LOCAL_LTS="${NVM_LOCAL_LTS-}" nvm_remote_versions "${NVM_LOCAL_PATTERN}" &&:)"
+      NVM_LOCAL_EXIT_CODE=$?
+      if [ -n "${NVM_LOCAL_OUTPUT}" ]; then
+        NVM_LOCAL_NO_COLORS="${NVM_LOCAL_NO_COLORS-}" nvm_print_versions "${NVM_LOCAL_OUTPUT}"
+        return ${NVM_LOCAL_EXIT_CODE}
       fi
-      LOCAL_NVM_NO_COLORS="${LOCAL_NVM_NO_COLORS-}" nvm_print_versions "N/A"
+      NVM_LOCAL_NO_COLORS="${NVM_LOCAL_NO_COLORS-}" nvm_print_versions "N/A"
       return 3
     ;;
     "current")
       nvm_version current
     ;;
     "which")
-      local LOCAL_NVM_SILENT
-      local LOCAL_NVM_PROVIDED_VERSION
+      local NVM_LOCAL_SILENT
+      local NVM_LOCAL_PROVIDED_VERSION
       while [ $# -ne 0 ]; do
         case "${1}" in
-          --silent) LOCAL_NVM_SILENT=1 ;;
+          --silent) NVM_LOCAL_SILENT=1 ;;
           --) ;;
-          *) LOCAL_NVM_PROVIDED_VERSION="${1-}" ;;
+          *) NVM_LOCAL_PROVIDED_VERSION="${1-}" ;;
         esac
         shift
       done
-      if [ -z "${LOCAL_NVM_PROVIDED_VERSION-}" ]; then
-        LOCAL_NVM_SILENT="${LOCAL_NVM_SILENT:-0}" nvm_rc_version
+      if [ -z "${NVM_LOCAL_PROVIDED_VERSION-}" ]; then
+        NVM_LOCAL_SILENT="${NVM_LOCAL_SILENT:-0}" nvm_rc_version
         if [ -n "${NVM_RC_VERSION}" ]; then
-          LOCAL_NVM_PROVIDED_VERSION="${NVM_RC_VERSION}"
-          LOCAL_NVM_VERSION=$(nvm_version "${NVM_RC_VERSION}") ||:
+          NVM_LOCAL_PROVIDED_VERSION="${NVM_RC_VERSION}"
+          NVM_LOCAL_VERSION=$(nvm_version "${NVM_RC_VERSION}") ||:
         fi
         unset NVM_RC_VERSION
-      elif [ "${LOCAL_NVM_PROVIDED_VERSION}" != 'system' ]; then
-        LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
+      elif [ "${NVM_LOCAL_PROVIDED_VERSION}" != 'system' ]; then
+        NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_PROVIDED_VERSION}")" ||:
       else
-        LOCAL_NVM_VERSION="${LOCAL_NVM_PROVIDED_VERSION-}"
+        NVM_LOCAL_VERSION="${NVM_LOCAL_PROVIDED_VERSION-}"
       fi
-      if [ -z "${LOCAL_NVM_VERSION}" ]; then
+      if [ -z "${NVM_LOCAL_VERSION}" ]; then
         >&2 nvm --help
         return 127
       fi
 
-      if [ "_${LOCAL_NVM_VERSION}" = '_system' ]; then
+      if [ "_${NVM_LOCAL_VERSION}" = '_system' ]; then
         if nvm_has_system_iojs >/dev/null 2>&1 || nvm_has_system_node >/dev/null 2>&1; then
-          local LOCAL_NVM_BIN
-          LOCAL_NVM_BIN="$(nvm use system >/dev/null 2>&1 && command which node)"
-          if [ -n "${LOCAL_NVM_BIN}" ]; then
-            nvm_echo "${LOCAL_NVM_BIN}"
+          local NVM_LOCAL_BIN
+          NVM_LOCAL_BIN="$(nvm use system >/dev/null 2>&1 && command which node)"
+          if [ -n "${NVM_LOCAL_BIN}" ]; then
+            nvm_echo "${NVM_LOCAL_BIN}"
             return
           fi
           return 1
         fi
         nvm_err 'System version of node not found.'
         return 127
-      elif [ "${LOCAL_NVM_VERSION}" = '∞' ]; then
+      elif [ "${NVM_LOCAL_VERSION}" = '∞' ]; then
         nvm_err "The alias \"${2}\" leads to an infinite loop. Aborting."
         return 8
       fi
 
-      local LOCAL_NVM_EXIT_CODE
-      nvm_ensure_version_installed "${LOCAL_NVM_PROVIDED_VERSION}"
-      LOCAL_NVM_EXIT_CODE=$?
-      if [ "${LOCAL_NVM_EXIT_CODE}" != "0" ]; then
-        return ${LOCAL_NVM_EXIT_CODE}
+      local NVM_LOCAL_EXIT_CODE
+      nvm_ensure_version_installed "${NVM_LOCAL_PROVIDED_VERSION}"
+      NVM_LOCAL_EXIT_CODE=$?
+      if [ "${NVM_LOCAL_EXIT_CODE}" != "0" ]; then
+        return ${NVM_LOCAL_EXIT_CODE}
       fi
-      local LOCAL_NVM_VERSION_DIR
-      LOCAL_NVM_VERSION_DIR="$(nvm_version_path "${LOCAL_NVM_VERSION}")"
-      nvm_echo "${LOCAL_NVM_VERSION_DIR}/bin/node"
+      local NVM_LOCAL_VERSION_DIR
+      NVM_LOCAL_VERSION_DIR="$(nvm_version_path "${NVM_LOCAL_VERSION}")"
+      nvm_echo "${NVM_LOCAL_VERSION_DIR}/bin/node"
     ;;
     "alias")
-      local LOCAL_NVM_ALIAS_DIR
-      LOCAL_NVM_ALIAS_DIR="$(nvm_alias_path)"
-      local LOCAL_NVM_CURRENT
-      LOCAL_NVM_CURRENT="$(nvm_ls_current)"
+      local NVM_LOCAL_ALIAS_DIR
+      NVM_LOCAL_ALIAS_DIR="$(nvm_alias_path)"
+      local NVM_LOCAL_CURRENT
+      NVM_LOCAL_CURRENT="$(nvm_ls_current)"
 
-      command mkdir -p "${LOCAL_NVM_ALIAS_DIR}/lts"
+      command mkdir -p "${NVM_LOCAL_ALIAS_DIR}/lts"
 
-      local LOCAL_NVM_ALIAS
-      local LOCAL_NVM_TARGET
-      local LOCAL_NVM_NO_COLORS
-      LOCAL_NVM_ALIAS='--'
-      LOCAL_NVM_TARGET='--'
+      local NVM_LOCAL_ALIAS
+      local NVM_LOCAL_TARGET
+      local NVM_LOCAL_NO_COLORS
+      NVM_LOCAL_ALIAS='--'
+      NVM_LOCAL_TARGET='--'
 
       while [ $# -gt 0 ]; do
         case "${1-}" in
           --) ;;
-          --no-colors) LOCAL_NVM_NO_COLORS="${1}" ;;
+          --no-colors) NVM_LOCAL_NO_COLORS="${1}" ;;
           --*)
             nvm_err "Unsupported option \"${1}\"."
             return 55
           ;;
           *)
-            if [ "${LOCAL_NVM_ALIAS}" = '--' ]; then
-              LOCAL_NVM_ALIAS="${1-}"
-            elif [ "${LOCAL_NVM_TARGET}" = '--' ]; then
-              LOCAL_NVM_TARGET="${1-}"
+            if [ "${NVM_LOCAL_ALIAS}" = '--' ]; then
+              NVM_LOCAL_ALIAS="${1-}"
+            elif [ "${NVM_LOCAL_TARGET}" = '--' ]; then
+              NVM_LOCAL_TARGET="${1-}"
             fi
           ;;
         esac
         shift
       done
 
-      if [ -z "${LOCAL_NVM_TARGET}" ]; then
+      if [ -z "${NVM_LOCAL_TARGET}" ]; then
         # for some reason the empty string was explicitly passed as the target
         # so, unalias it.
-        nvm unalias "${LOCAL_NVM_ALIAS}"
+        nvm unalias "${NVM_LOCAL_ALIAS}"
         return $?
-      elif [ "${LOCAL_NVM_TARGET}" != '--' ]; then
+      elif [ "${NVM_LOCAL_TARGET}" != '--' ]; then
         # a target was passed: create an alias
-        if [ "${LOCAL_NVM_ALIAS#*\/}" != "${LOCAL_NVM_ALIAS}" ]; then
+        if [ "${NVM_LOCAL_ALIAS#*\/}" != "${NVM_LOCAL_ALIAS}" ]; then
           nvm_err 'Aliases in subdirectories are not supported.'
           return 1
         fi
-        LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_TARGET}")" ||:
-        if [ "${LOCAL_NVM_VERSION}" = 'N/A' ]; then
-          nvm_err "! WARNING: Version '${LOCAL_NVM_TARGET}' does not exist."
+        NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_TARGET}")" ||:
+        if [ "${NVM_LOCAL_VERSION}" = 'N/A' ]; then
+          nvm_err "! WARNING: Version '${NVM_LOCAL_TARGET}' does not exist."
         fi
-        nvm_make_alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_TARGET}"
-        LOCAL_NVM_NO_COLORS="${LOCAL_NVM_NO_COLORS-}" LOCAL_NVM_CURRENT="${LOCAL_NVM_CURRENT-}" NVM_DEFAULT=false nvm_print_formatted_alias "${LOCAL_NVM_ALIAS}" "${LOCAL_NVM_TARGET}" "${LOCAL_NVM_VERSION}"
+        nvm_make_alias "${NVM_LOCAL_ALIAS}" "${NVM_LOCAL_TARGET}"
+        NVM_LOCAL_NO_COLORS="${NVM_LOCAL_NO_COLORS-}" NVM_LOCAL_CURRENT="${NVM_LOCAL_CURRENT-}" NVM_DEFAULT=false nvm_print_formatted_alias "${NVM_LOCAL_ALIAS}" "${NVM_LOCAL_TARGET}" "${NVM_LOCAL_VERSION}"
       else
-        if [ "${LOCAL_NVM_ALIAS-}" = '--' ]; then
-          unset LOCAL_NVM_ALIAS
+        if [ "${NVM_LOCAL_ALIAS-}" = '--' ]; then
+          unset NVM_LOCAL_ALIAS
         fi
 
-        nvm_list_aliases "${LOCAL_NVM_ALIAS-}"
+        nvm_list_aliases "${NVM_LOCAL_ALIAS-}"
       fi
     ;;
     "unalias")
-      local LOCAL_NVM_ALIAS_DIR
-      LOCAL_NVM_ALIAS_DIR="$(nvm_alias_path)"
-      command mkdir -p "${LOCAL_NVM_ALIAS_DIR}"
+      local NVM_LOCAL_ALIAS_DIR
+      NVM_LOCAL_ALIAS_DIR="$(nvm_alias_path)"
+      command mkdir -p "${NVM_LOCAL_ALIAS_DIR}"
       if [ $# -ne 1 ]; then
         >&2 nvm --help
         return 127
@@ -4008,19 +4008,19 @@ nvm() {
         return 1
       fi
 
-      local LOCAL_NVM_IOJS_PREFIX
-      local LOCAL_NVM_NODE_PREFIX
-      LOCAL_NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"
-      LOCAL_NVM_NODE_PREFIX="$(nvm_node_prefix)"
-      local LOCAL_NVM_ALIAS_EXISTS
-      LOCAL_NVM_ALIAS_EXISTS=0
-      if [ -f "${LOCAL_NVM_ALIAS_DIR}/${1-}" ]; then
-        LOCAL_NVM_ALIAS_EXISTS=1
+      local NVM_LOCAL_IOJS_PREFIX
+      local NVM_LOCAL_NODE_PREFIX
+      NVM_LOCAL_IOJS_PREFIX="$(nvm_iojs_prefix)"
+      NVM_LOCAL_NODE_PREFIX="$(nvm_node_prefix)"
+      local NVM_LOCAL_ALIAS_EXISTS
+      NVM_LOCAL_ALIAS_EXISTS=0
+      if [ -f "${NVM_LOCAL_ALIAS_DIR}/${1-}" ]; then
+        NVM_LOCAL_ALIAS_EXISTS=1
       fi
 
-      if [ ${LOCAL_NVM_ALIAS_EXISTS} -eq 0 ]; then
+      if [ ${NVM_LOCAL_ALIAS_EXISTS} -eq 0 ]; then
         case "$1" in
-          "stable" | "unstable" | "${LOCAL_NVM_IOJS_PREFIX}" | "${LOCAL_NVM_NODE_PREFIX}" | "system")
+          "stable" | "unstable" | "${NVM_LOCAL_IOJS_PREFIX}" | "${NVM_LOCAL_NODE_PREFIX}" | "system")
             nvm_err "${1-} is a default (built-in) alias and cannot be deleted."
             return 1
           ;;
@@ -4030,10 +4030,10 @@ nvm() {
         return
       fi
 
-      local LOCAL_NVM_ALIAS_ORIGINAL
-      LOCAL_NVM_ALIAS_ORIGINAL="$(nvm_alias "${1}")"
-      command rm -f "${LOCAL_NVM_ALIAS_DIR}/${1}"
-      nvm_echo "Deleted alias ${1} - restore it with \`nvm alias \"${1}\" \"${LOCAL_NVM_ALIAS_ORIGINAL}\"\`"
+      local NVM_LOCAL_ALIAS_ORIGINAL
+      NVM_LOCAL_ALIAS_ORIGINAL="$(nvm_alias "${1}")"
+      command rm -f "${NVM_LOCAL_ALIAS_DIR}/${1}"
+      nvm_echo "Deleted alias ${1} - restore it with \`nvm alias \"${1}\" \"${NVM_LOCAL_ALIAS_ORIGINAL}\"\`"
     ;;
     "install-latest-npm")
       if [ $# -ne 0 ]; then
@@ -4049,45 +4049,45 @@ nvm() {
         return 127
       fi
 
-      local LOCAL_NVM_PROVIDED_VERSION
-      LOCAL_NVM_PROVIDED_VERSION="${1-}"
+      local NVM_LOCAL_PROVIDED_VERSION
+      NVM_LOCAL_PROVIDED_VERSION="${1-}"
 
-      if [ "${LOCAL_NVM_PROVIDED_VERSION}" = "$(nvm_ls_current)" ] || [ "$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}" ||:)" = "$(nvm_ls_current)" ]; then
+      if [ "${NVM_LOCAL_PROVIDED_VERSION}" = "$(nvm_ls_current)" ] || [ "$(nvm_version "${NVM_LOCAL_PROVIDED_VERSION}" ||:)" = "$(nvm_ls_current)" ]; then
         nvm_err 'Can not reinstall packages from the current version of node.'
         return 2
       fi
 
-      local LOCAL_NVM_VERSION
-      if [ "_${LOCAL_NVM_PROVIDED_VERSION}" = "_system" ]; then
+      local NVM_LOCAL_VERSION
+      if [ "_${NVM_LOCAL_PROVIDED_VERSION}" = "_system" ]; then
         if ! nvm_has_system_node && ! nvm_has_system_iojs; then
           nvm_err 'No system version of node or io.js detected.'
           return 3
         fi
-        LOCAL_NVM_VERSION="system"
+        NVM_LOCAL_VERSION="system"
       else
-        LOCAL_NVM_VERSION="$(nvm_version "${LOCAL_NVM_PROVIDED_VERSION}")" ||:
+        NVM_LOCAL_VERSION="$(nvm_version "${NVM_LOCAL_PROVIDED_VERSION}")" ||:
       fi
 
-      local LOCAL_NVM_NPMLIST
-      LOCAL_NVM_NPMLIST="$(nvm_npm_global_modules "${LOCAL_NVM_VERSION}")"
-      local LOCAL_NVM_INSTALLS
-      local LOCAL_NVM_LINKS
-      LOCAL_NVM_INSTALLS="${LOCAL_NVM_NPMLIST%% //// *}"
-      LOCAL_NVM_LINKS="${LOCAL_NVM_NPMLIST##* //// }"
+      local NVM_LOCAL_NPMLIST
+      NVM_LOCAL_NPMLIST="$(nvm_npm_global_modules "${NVM_LOCAL_VERSION}")"
+      local NVM_LOCAL_INSTALLS
+      local NVM_LOCAL_LINKS
+      NVM_LOCAL_INSTALLS="${NVM_LOCAL_NPMLIST%% //// *}"
+      NVM_LOCAL_LINKS="${NVM_LOCAL_NPMLIST##* //// }"
 
-      nvm_echo "Reinstalling global packages from ${LOCAL_NVM_VERSION}..."
-      if [ -n "${LOCAL_NVM_INSTALLS}" ]; then
-        nvm_echo "${LOCAL_NVM_INSTALLS}" | command xargs npm install -g --quiet
+      nvm_echo "Reinstalling global packages from ${NVM_LOCAL_VERSION}..."
+      if [ -n "${NVM_LOCAL_INSTALLS}" ]; then
+        nvm_echo "${NVM_LOCAL_INSTALLS}" | command xargs npm install -g --quiet
       else
         nvm_echo "No installed global packages found..."
       fi
 
-      nvm_echo "Linking global packages from ${LOCAL_NVM_VERSION}..."
-      if [ -n "${LOCAL_NVM_LINKS}" ]; then
+      nvm_echo "Linking global packages from ${NVM_LOCAL_VERSION}..."
+      if [ -n "${NVM_LOCAL_LINKS}" ]; then
         (
           set -f; IFS='
 ' # necessary to turn off variable expansion except for newlines
-          for LINK in ${LOCAL_NVM_LINKS}; do
+          for LINK in ${NVM_LOCAL_LINKS}; do
             set +f; unset IFS # restore variable expansion
             if [ -n "${LINK}" ]; then
               case "${LINK}" in
@@ -4109,38 +4109,38 @@ nvm() {
       nvm_version "${1}"
     ;;
     "version-remote")
-      local LOCAL_NVM_LTS
-      local LOCAL_NVM_PATTERN
+      local NVM_LOCAL_LTS
+      local NVM_LOCAL_PATTERN
       while [ $# -gt 0 ]; do
         case "${1-}" in
           --) ;;
           --lts)
-            LOCAL_NVM_LTS='*'
+            NVM_LOCAL_LTS='*'
           ;;
           --lts=*)
-            LOCAL_NVM_LTS="${1##--lts=}"
+            NVM_LOCAL_LTS="${1##--lts=}"
           ;;
           --*)
             nvm_err "Unsupported option \"${1}\"."
             return 55
           ;;
           *)
-            LOCAL_NVM_PATTERN="${LOCAL_NVM_PATTERN:-${1}}"
+            NVM_LOCAL_PATTERN="${NVM_LOCAL_PATTERN:-${1}}"
           ;;
         esac
         shift
       done
-      case "${LOCAL_NVM_PATTERN-}" in
+      case "${NVM_LOCAL_PATTERN-}" in
         'lts/*')
-          LOCAL_NVM_LTS='*'
-          unset LOCAL_NVM_PATTERN
+          NVM_LOCAL_LTS='*'
+          unset NVM_LOCAL_PATTERN
         ;;
         lts/*)
-          LOCAL_NVM_LTS="${LOCAL_NVM_PATTERN##lts/}"
-          unset LOCAL_NVM_PATTERN
+          NVM_LOCAL_LTS="${NVM_LOCAL_PATTERN##lts/}"
+          unset NVM_LOCAL_PATTERN
         ;;
       esac
-      NVM_VERSION_ONLY=true LOCAL_NVM_LTS="${LOCAL_NVM_LTS-}" nvm_remote_version "${LOCAL_NVM_PATTERN:-node}"
+      NVM_VERSION_ONLY=true NVM_LOCAL_LTS="${NVM_LOCAL_LTS-}" nvm_remote_version "${NVM_LOCAL_PATTERN:-node}"
     ;;
     "--version" | "-v")
       nvm_echo '0.39.1'
@@ -4190,16 +4190,16 @@ nvm() {
         nvm_get_artifact_compression nvm_install_binary_extract nvm_extract_tarball \
         >/dev/null 2>&1
       unset NVM_RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR NVM_DIR \
-        NVM_CD_FLAGS NVM_BIN NVM_INC LOCAL_NVM_MAKE_JOBS \
-        NVM_COLORS LOCAL_NVM_INSTALLED_COLOR LOCAL_NVM_SYSTEM_COLOR \
-        LOCAL_NVM_CURRENT_COLOR LOCAL_NVM_NOT_INSTALLED_COLOR LOCAL_NVM_DEFAULT_COLOR LOCAL_NVM_LTS_COLOR \
+        NVM_CD_FLAGS NVM_BIN NVM_INC NVM_LOCAL_MAKE_JOBS \
+        NVM_COLORS NVM_LOCAL_INSTALLED_COLOR NVM_LOCAL_SYSTEM_COLOR \
+        NVM_LOCAL_CURRENT_COLOR NVM_LOCAL_NOT_INSTALLED_COLOR NVM_LOCAL_DEFAULT_COLOR NVM_LOCAL_LTS_COLOR \
         >/dev/null 2>&1
     ;;
     "set-colors")
-      local LOCAL_NVM_EXIT_CODE
+      local NVM_LOCAL_EXIT_CODE
       nvm_set_colors "${1-}"
-      LOCAL_NVM_EXIT_CODE=$?
-      if [ "${LOCAL_NVM_EXIT_CODE}" -eq 17 ]; then
+      NVM_LOCAL_EXIT_CODE=$?
+      if [ "${NVM_LOCAL_EXIT_CODE}" -eq 17 ]; then
         >&2 nvm --help
         nvm_echo
         nvm_err_with_colors "\033[1;37mPlease pass in five \033[1;31mvalid color codes\033[1;37m. Choose from: rRgGbBcCyYmMkKeW\033[0m"
@@ -4213,37 +4213,37 @@ nvm() {
 }
 
 nvm_get_default_packages() {
-  local LOCAL_NVM_DEFAULT_PACKAGE_FILE="${NVM_DIR}/default-packages"
-  if [ -f "${LOCAL_NVM_DEFAULT_PACKAGE_FILE}" ]; then
-    local LOCAL_NVM_DEFAULT_PACKAGES
-    LOCAL_NVM_DEFAULT_PACKAGES=''
+  local NVM_LOCAL_DEFAULT_PACKAGE_FILE="${NVM_DIR}/default-packages"
+  if [ -f "${NVM_LOCAL_DEFAULT_PACKAGE_FILE}" ]; then
+    local NVM_LOCAL_DEFAULT_PACKAGES
+    NVM_LOCAL_DEFAULT_PACKAGES=''
 
     # Read lines from ${NVM_DIR}/default-packages
-    local LOCAL_NVM_LINE
+    local NVM_LOCAL_LINE
     # ensure a trailing newline
     WORK=$(mktemp -d) || exit $?
     # shellcheck disable=SC2064
     trap "command rm -rf '${WORK}'" EXIT
     # shellcheck disable=SC1003
-    sed -e '$a\' "${LOCAL_NVM_DEFAULT_PACKAGE_FILE}" > "${WORK}/default-packages"
-    while IFS=' ' read -r LOCAL_NVM_LINE; do
+    sed -e '$a\' "${NVM_LOCAL_DEFAULT_PACKAGE_FILE}" > "${WORK}/default-packages"
+    while IFS=' ' read -r NVM_LOCAL_LINE; do
       # Skip empty lines.
-      [ -n "${LOCAL_NVM_LINE-}" ] || continue
+      [ -n "${NVM_LOCAL_LINE-}" ] || continue
 
       # Skip comment lines that begin with `#`.
-      [ "$(nvm_echo "${LOCAL_NVM_LINE}" | command cut -c1)" != "#" ] || continue
+      [ "$(nvm_echo "${NVM_LOCAL_LINE}" | command cut -c1)" != "#" ] || continue
 
       # Fail on lines that have multiple space-separated words
-      case ${LOCAL_NVM_LINE} in
+      case ${NVM_LOCAL_LINE} in
         *\ *)
           nvm_err "Only one package per line is allowed in the ${NVM_DIR}/default-packages file. Please remove any lines with multiple space-separated values."
           return 1
         ;;
       esac
 
-      LOCAL_NVM_DEFAULT_PACKAGES="${LOCAL_NVM_DEFAULT_PACKAGES}${LOCAL_NVM_LINE} "
+      NVM_LOCAL_DEFAULT_PACKAGES="${NVM_LOCAL_DEFAULT_PACKAGES}${NVM_LOCAL_LINE} "
     done < "${WORK}/default-packages"
-    echo "${LOCAL_NVM_DEFAULT_PACKAGES}" | command xargs
+    echo "${NVM_LOCAL_DEFAULT_PACKAGES}" | command xargs
   fi
 }
 
@@ -4262,16 +4262,16 @@ nvm_supports_xz() {
     return 1
   fi
 
-  local LOCAL_NVM_OS
-  LOCAL_NVM_OS="$(nvm_get_os)"
-  if [ "_${LOCAL_NVM_OS}" = '_darwin' ]; then
-    local LOCAL_NVM_MACOS_VERSION
-    LOCAL_NVM_MACOS_VERSION="$(sw_vers -productVersion)"
-    if nvm_version_greater "10.9.0" "${LOCAL_NVM_MACOS_VERSION}"; then
+  local NVM_LOCAL_OS
+  NVM_LOCAL_OS="$(nvm_get_os)"
+  if [ "_${NVM_LOCAL_OS}" = '_darwin' ]; then
+    local NVM_LOCAL_MACOS_VERSION
+    NVM_LOCAL_MACOS_VERSION="$(sw_vers -productVersion)"
+    if nvm_version_greater "10.9.0" "${NVM_LOCAL_MACOS_VERSION}"; then
       # macOS 10.8 and earlier doesn't support extracting xz-compressed tarballs with tar
       return 1
     fi
-  elif [ "_${LOCAL_NVM_OS}" = '_freebsd' ]; then
+  elif [ "_${NVM_LOCAL_OS}" = '_freebsd' ]; then
     if ! [ -e '/usr/lib/liblzma.so' ]; then
       # FreeBSD without /usr/lib/liblzma.so doesn't support extracting xz-compressed tarballs with tar
       return 1
@@ -4299,7 +4299,7 @@ nvm_supports_xz() {
     return 0
   fi
 
-  case "${LOCAL_NVM_OS}" in
+  case "${NVM_LOCAL_OS}" in
     darwin)
       # darwin only has xz for io.js v2.3.2 and later
       nvm_version_greater_than_or_equal_to "${1}" "2.3.2"
@@ -4312,46 +4312,46 @@ nvm_supports_xz() {
 }
 
 nvm_auto() {
-  local LOCAL_NVM_MODE
-  LOCAL_NVM_MODE="${1-}"
-  local LOCAL_NVM_VERSION
-  local LOCAL_NVM_CURRENT
-  if [ "_${LOCAL_NVM_MODE}" = '_install' ]; then
-    LOCAL_NVM_VERSION="$(nvm_alias default 2>/dev/null || nvm_echo)"
-    if [ -n "${LOCAL_NVM_VERSION}" ]; then
-      nvm install "${LOCAL_NVM_VERSION}" >/dev/null
+  local NVM_LOCAL_MODE
+  NVM_LOCAL_MODE="${1-}"
+  local NVM_LOCAL_VERSION
+  local NVM_LOCAL_CURRENT
+  if [ "_${NVM_LOCAL_MODE}" = '_install' ]; then
+    NVM_LOCAL_VERSION="$(nvm_alias default 2>/dev/null || nvm_echo)"
+    if [ -n "${NVM_LOCAL_VERSION}" ]; then
+      nvm install "${NVM_LOCAL_VERSION}" >/dev/null
     elif nvm_rc_version >/dev/null 2>&1; then
       nvm install >/dev/null
     fi
-  elif [ "_${LOCAL_NVM_MODE}" = '_use' ]; then
-    LOCAL_NVM_CURRENT="$(nvm_ls_current)"
-    if [ "_${LOCAL_NVM_CURRENT}" = '_none' ] || [ "_${LOCAL_NVM_CURRENT}" = '_system' ]; then
-      LOCAL_NVM_VERSION="$(nvm_resolve_local_alias default 2>/dev/null || nvm_echo)"
-      if [ -n "${LOCAL_NVM_VERSION}" ]; then
-        nvm use --silent "${LOCAL_NVM_VERSION}" >/dev/null
+  elif [ "_${NVM_LOCAL_MODE}" = '_use' ]; then
+    NVM_LOCAL_CURRENT="$(nvm_ls_current)"
+    if [ "_${NVM_LOCAL_CURRENT}" = '_none' ] || [ "_${NVM_LOCAL_CURRENT}" = '_system' ]; then
+      NVM_LOCAL_VERSION="$(nvm_resolve_local_alias default 2>/dev/null || nvm_echo)"
+      if [ -n "${NVM_LOCAL_VERSION}" ]; then
+        nvm use --silent "${NVM_LOCAL_VERSION}" >/dev/null
       elif nvm_rc_version >/dev/null 2>&1; then
         nvm use --silent >/dev/null
       fi
     else
-      nvm use --silent "${LOCAL_NVM_CURRENT}" >/dev/null
+      nvm use --silent "${NVM_LOCAL_CURRENT}" >/dev/null
     fi
-  elif [ "_${LOCAL_NVM_MODE}" != '_none' ]; then
+  elif [ "_${NVM_LOCAL_MODE}" != '_none' ]; then
     nvm_err 'Invalid auto mode supplied.'
     return 1
   fi
 }
 
 nvm_process_parameters() {
-  local LOCAL_NVM_AUTO_MODE
-  LOCAL_NVM_AUTO_MODE='use'
+  local NVM_LOCAL_AUTO_MODE
+  NVM_LOCAL_AUTO_MODE='use'
   while [ "$#" -ne 0 ]; do
     case "$1" in
-      --install) LOCAL_NVM_AUTO_MODE='install' ;;
-      --no-use) LOCAL_NVM_AUTO_MODE='none' ;;
+      --install) NVM_LOCAL_AUTO_MODE='install' ;;
+      --no-use) NVM_LOCAL_AUTO_MODE='none' ;;
     esac
     shift
   done
-  nvm_auto "${LOCAL_NVM_AUTO_MODE}"
+  nvm_auto "${NVM_LOCAL_AUTO_MODE}"
 }
 
 nvm_process_parameters "$@"


### PR DESCRIPTION
Sourcing so many universal variables is dangerous and has led to problems for me. If all variables are 'uniqe', nvm.sh can be sourced globally with 'set -a'. In my case, I had a problem before with the variable 'VERSION' which had the version of the Docker image as value.