### PR TITLE
[Fix] `nvm install`: show proper version in `.nvmrc` install instructions

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -506,6 +506,8 @@ nvm_version_path() {
 nvm_ensure_version_installed() {
   local PROVIDED_VERSION
   PROVIDED_VERSION="${1-}"
+  local IS_VERSION_FROM_NVMRC
+  IS_VERSION_FROM_NVMRC="${2-}"
   if [ "${PROVIDED_VERSION}" = 'system' ]; then
     if nvm_has_system_iojs || nvm_has_system_node; then
       return 0
@@ -527,7 +529,11 @@ nvm_ensure_version_installed() {
       nvm_err "N/A: version \"${PREFIXED_VERSION:-$PROVIDED_VERSION}\" is not yet installed."
     fi
     nvm_err ""
-    nvm_err "You need to run \"nvm install ${PROVIDED_VERSION}\" to install it before using it."
+    if [ "${IS_VERSION_FROM_NVMRC}" != '1' ]; then
+        nvm_err "You need to run \`nvm install ${PROVIDED_VERSION}\` to install and use it."
+      else
+        nvm_err 'You need to run `nvm install` to install and use the node version specified in `.nvmrc`.'
+    fi
     return 1
   fi
 }
@@ -3522,6 +3528,8 @@ nvm() {
       local NVM_DELETE_PREFIX
       NVM_DELETE_PREFIX=0
       local NVM_LTS
+      local IS_VERSION_FROM_NVMRC
+      IS_VERSION_FROM_NVMRC=0
 
       while [ $# -ne 0 ]; do
         case "$1" in
@@ -3549,6 +3557,7 @@ nvm() {
         NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version
         if [ -n "${NVM_RC_VERSION-}" ]; then
           PROVIDED_VERSION="${NVM_RC_VERSION}"
+          IS_VERSION_FROM_NVMRC=1
           VERSION="$(nvm_version "${PROVIDED_VERSION}")"
         fi
         unset NVM_RC_VERSION
@@ -3588,14 +3597,12 @@ nvm() {
       fi
       if [ "${VERSION}" = 'N/A' ]; then
         if [ "${NVM_SILENT:-0}" -ne 1 ]; then
-          nvm_err "N/A: version \"${PROVIDED_VERSION} -> ${VERSION}\" is not yet installed."
-          nvm_err ""
-          nvm_err "You need to run \"nvm install ${PROVIDED_VERSION}\" to install it before using it."
+          nvm_ensure_version_installed "${PROVIDED_VERSION}" "${IS_VERSION_FROM_NVMRC}"
         fi
         return 3
       # This nvm_ensure_version_installed call can be a performance bottleneck
       # on shell startup. Perhaps we can optimize it away or make it faster.
-      elif ! nvm_ensure_version_installed "${VERSION}"; then
+      elif ! nvm_ensure_version_installed "${VERSION}" "${IS_VERSION_FROM_NVMRC}"; then
         return $?
       fi
 
@@ -3650,6 +3657,8 @@ nvm() {
       local provided_version
       local has_checked_nvmrc
       has_checked_nvmrc=0
+      local IS_VERSION_FROM_NVMRC
+      IS_VERSION_FROM_NVMRC=0
       # run given version of node
 
       local NVM_SILENT
@@ -3695,6 +3704,8 @@ nvm() {
             if [ $has_checked_nvmrc -ne 1 ]; then
               NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
             fi
+            provided_version="${NVM_RC_VERSION}"
+            IS_VERSION_FROM_NVMRC=1
             VERSION="$(nvm_version "${NVM_RC_VERSION}")" ||:
             unset NVM_RC_VERSION
           else
@@ -3717,7 +3728,7 @@ nvm() {
         VERSION=''
       fi
       if [ "_${VERSION}" = "_N/A" ]; then
-        nvm_ensure_version_installed "${provided_version}"
+        nvm_ensure_version_installed "${provided_version}" "${IS_VERSION_FROM_NVMRC}"
       elif [ "${NVM_IOJS}" = true ]; then
         nvm exec "${NVM_SILENT_ARG-}" "${LTS_ARG-}" "${VERSION}" iojs "$@"
       else

--- a/test/fast/Unit tests/nvm_ensure_version_installed
+++ b/test/fast/Unit tests/nvm_ensure_version_installed
@@ -15,7 +15,16 @@ OUTPUT="$(nvm_ensure_version_installed foo 2>&1)"
 EXIT_CODE=$?
 EXPECTED_OUTPUT='N/A: version "foo" is not yet installed.
 
-You need to run "nvm install foo" to install it before using it.'
+You need to run `nvm install foo` to install and use it.'
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "expected 'nvm_ensure_version_installed foo' to give $EXPECTED_OUTPUT, got $OUTPUT"
+[ "_$EXIT_CODE" = "_1" ] || die "expected 'nvm_ensure_version_installed foo' to exit with 1, got $EXIT_CODE"
+
+# Case when .nvmrc file is opened, we should be skip showing the version
+OUTPUT="$(nvm_ensure_version_installed foo 1 2>&1)"
+EXIT_CODE=$?
+EXPECTED_OUTPUT='N/A: version "foo" is not yet installed.
+
+You need to run `nvm install` to install and use the node version specified in `.nvmrc`.'
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "expected 'nvm_ensure_version_installed foo' to give $EXPECTED_OUTPUT, got $OUTPUT"
 [ "_$EXIT_CODE" = "_1" ] || die "expected 'nvm_ensure_version_installed foo' to exit with 1, got $EXIT_CODE"
 
@@ -29,7 +38,7 @@ OUTPUT="$(nvm_ensure_version_installed iojs 2>&1)"
 EXIT_CODE=$?
 EXPECTED_OUTPUT='N/A: version "iojs" is not yet installed.
 
-You need to run "nvm install iojs" to install it before using it.'
+You need to run `nvm install iojs` to install and use it.'
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "expected 'nvm_ensure_version_installed iojs' to give $EXPECTED_OUTPUT, got $OUTPUT"
 [ "_$EXIT_CODE" = "_1" ] || die "expected 'nvm_ensure_version_installed iojs' to exit with 1, got $EXIT_CODE"
 

--- a/test/slow/nvm run/Running 'nvm run 0.x' should error out sensibly when 0.x is not installed
+++ b/test/slow/nvm run/Running 'nvm run 0.x' should error out sensibly when 0.x is not installed
@@ -7,10 +7,10 @@ die () { echo "$@" ; exit 1; }
 
 EXPECTED_OUTPUT='N/A: version "v0.2" is not yet installed.
 
-You need to run "nvm install 0.2" to install it before using it.'
+You need to run `nvm install 0.2` to install and use it.'
 [ "_$(nvm run 0.2 --version 2>&1)" = "_$EXPECTED_OUTPUT" ] || die "\`nvm run\` with an uninstalled node version failed to error out correctly"
 
 EXPECTED_OUTPUT='N/A: version "iojs-v0.2" is not yet installed.
 
-You need to run "nvm install iojs-0.2" to install it before using it.'
+You need to run `nvm install iojs-0.2` to install and use it.'
 [ "_$(nvm run iojs-0.2 --version 2>&1)" = "_$EXPECTED_OUTPUT" ] || die "\`nvm run\` with an uninstalled iojs version failed to error out correctly"

--- a/test/slow/nvm run/Running 'nvm run' should pick up .nvmrc version
+++ b/test/slow/nvm run/Running 'nvm run' should pick up .nvmrc version
@@ -10,3 +10,16 @@ echo "0.10.7" > .nvmrc
 [ "$(nvm run --version | tail -1)" = "v0.10.7" ] || die "\`nvm run\` failed to run with the .nvmrc version"
 
 [ "$(nvm run --version | head -1)" = "Found '$PWD/.nvmrc' with version <0.10.7>" ] || die "\`nvm run\` failed to print out the \"found in .nvmrc\" message"
+
+
+echo "foo" > .nvmrc
+
+# running nvm run with .nvmrc should not print the version information when not installed
+OUTPUT="$(nvm run --version 2>&1)"
+EXIT_CODE=$?
+EXPECTED_OUTPUT="Found '$PWD/.nvmrc' with version <foo>
+N/A: version \"foo\" is not yet installed.
+
+You need to run \`nvm install\` to install and use the node version specified in \`.nvmrc\`."
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "expected 'nvm use' with nvmrc to give $EXPECTED_OUTPUT, got $OUTPUT"
+[ "_$EXIT_CODE" = "_1" ] || die "expected 'nvm use' with nvmrc to exit with 1, got $EXIT_CODE"

--- a/test/slow/nvm use/Running 'nvm use' with nvmrc containing not intalled version
+++ b/test/slow/nvm use/Running 'nvm use' with nvmrc containing not intalled version
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+nvm deactivate 2>&1 >/dev/null || die 'deactivate failed'
+
+echo "foo" > .nvmrc
+
+# running nvm use with .nvmrc should not print the version information
+OUTPUT="$(nvm use 2>&1)"
+EXIT_CODE=$?
+EXPECTED_OUTPUT="Found '$PWD/.nvmrc' with version <foo>
+N/A: version \"foo\" is not yet installed.
+
+You need to run \`nvm install\` to install and use the node version specified in \`.nvmrc\`."
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "expected 'nvm use' with nvmrc to give $EXPECTED_OUTPUT, got $OUTPUT"
+[ "_$EXIT_CODE" = "_3" ] || die "expected 'nvm use' with nvmrc to exit with 3, got $EXIT_CODE"
+
+# --silent should not print anything
+OUTPUT=$(nvm use --silent)
+EXPECTED_OUTPUT=""
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use --silent' output was not silenced to '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+
+rm .nvmrc


### PR DESCRIPTION
We skip showing version only if we have `.nvmrc` with value and runs `nvm use` or `nvm run`.  If `nvm use v17` or `nvm run v17 app.js` is used we still show the version as seen in the screenshot:

nvm use:

<img width="729" alt="Screen Shot 2022-03-22 at 8 17 57 PM" src="https://user-images.githubusercontent.com/20895544/159509518-a2370844-1b3f-4cdc-879b-a1fe421e088d.png">

nvm run:

<img width="758" alt="Screen Shot 2022-03-29 at 8 22 16 AM" src="https://user-images.githubusercontent.com/20895544/160523523-565efdb2-7f25-4abf-8d72-9cb4546e8bec.png">



Fixes #2701, #2775