### PR TITLE
[Docs] fix fish load_nvm variable interpolations

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ function load_nvm --on-variable="PWD"
     set -l nvmrc_node_version (nvm version (cat $nvmrc_path))
     if test "$nvmrc_node_version" = "N/A"
       nvm install (cat $nvmrc_path)
-    else if test nvmrc_node_version != node_version
+    else if test "$nvmrc_node_version" != "$node_version"
       nvm use $nvmrc_node_version
     end
   else if test "$node_version" != "$default_node_version"


### PR DESCRIPTION
Variables in test arguments must be interpolated, or the test always fails and leading to reloading of nvm, which is way slower.