### PR TITLE
Send output from `load_nvm` to `/dev/stderr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ end
 
 # ~/.config/fish/config.fish
 # You must call it on initialization or listening to directory switching won't work
-load_nvm
+load_nvm > /dev/stderr
 ```
 
 ## Running Tests


### PR DESCRIPTION
Fixes #2782