### PR TITLE
[Fix] 'nvm exec' no longer prints error about '-q' being an invalid option

### DIFF
--- a/nvm-exec
+++ b/nvm-exec
@@ -2,6 +2,8 @@
 
 DIR="$(command cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+unset NVM_CD_FLAGS
+
 # shellcheck disable=SC1090,SC1091
 \. "$DIR/nvm.sh" --no-use
 


### PR DESCRIPTION
the `nvm.sh` file assigns and exports an `NVM_CD_FLAGS` variable if it
was sourced from a zsh shell. the fact that it's exported means that
it'll be assigned in all child processes, including the `nvm-exec`
script, which uses bash as the interpreter.

Bash's `cd` command doesn't have a `-q` flag, so if the `NVM_CD_FLAGS`
is assigned `-q`, the script will error out and incorrectly claim that
the node version isn't installed.

this also manifests itself in the `nvm exec` command.

Example:

```console
$ nvm exec 16.14.0 npm --version
Running node v16.14.0 (npm v8.3.1)
/Users/<ME>/.nvm/nvm.sh: line 28: cd: -q: invalid option
cd: usage: cd [-L|[-P [-e]] [-@]] [dir]
both the tree and the node path are required
N/A: version "v16.14.0 -> N/A" is not yet installed.

You need to run "nvm install v16.14.0" to install it before using it.
```

To address this, we unset the `NVM_CD_FLAGS` at the start of the
`nvm-exec` script, before loading `nvm.sh`.
