### PR TITLE
[perf] `nvm_print_versions`: re-implement using awk

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1642,12 +1642,8 @@ nvm_get_checksum() {
 }
 
 nvm_print_versions() {
-  local VERSION
-  local LTS
-  local FORMAT
   local NVM_CURRENT
-  local NVM_LATEST_LTS_COLOR
-  local NVM_OLD_LTS_COLOR
+  NVM_CURRENT=$(nvm_ls_current)
 
   local INSTALLED_COLOR
   local SYSTEM_COLOR
@@ -1655,6 +1651,7 @@ nvm_print_versions() {
   local NOT_INSTALLED_COLOR
   local DEFAULT_COLOR
   local LTS_COLOR
+  local NVM_HAS_COLORS
 
   INSTALLED_COLOR=$(nvm_get_colors 1)
   SYSTEM_COLOR=$(nvm_get_colors 2)
@@ -1663,67 +1660,72 @@ nvm_print_versions() {
   DEFAULT_COLOR=$(nvm_get_colors 5)
   LTS_COLOR=$(nvm_get_colors 6)
 
-  NVM_CURRENT=$(nvm_ls_current)
-  NVM_LATEST_LTS_COLOR=$(nvm_echo "${CURRENT_COLOR}" | command tr '0;' '1;')
-  NVM_OLD_LTS_COLOR="${DEFAULT_COLOR}"
-  local NVM_HAS_COLORS
   if [ -z "${NVM_NO_COLORS-}" ] && nvm_has_colors; then
     NVM_HAS_COLORS=1
   fi
-  local LTS_LENGTH
-  local LTS_FORMAT
-  nvm_echo "${1-}" \
-  | command sed '1!G;h;$!d' \
-  | command awk '{ if ($2 && $3 && $3 == "*") { print $1, "(Latest LTS: " $2 ")" } else if ($2) { print $1, "(LTS: " $2 ")" } else { print $1 } }' \
-  | command sed '1!G;h;$!d' \
-  | while read -r VERSION_LINE; do
-    VERSION="${VERSION_LINE%% *}"
-    LTS="${VERSION_LINE#* }"
-    FORMAT='%15s'
-    if [ "_${VERSION}" = "_${NVM_CURRENT}" ]; then
-      if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-        FORMAT="\033[${CURRENT_COLOR}-> %12s\033[0m"
-      else
-        FORMAT='-> %12s *'
-      fi
-    elif [ "${VERSION}" = "system" ]; then
-      if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-        FORMAT="\033[${SYSTEM_COLOR}%15s\033[0m"
-      else
-        FORMAT='%15s *'
-      fi
-    elif nvm_is_version_installed "${VERSION}"; then
-      if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-        FORMAT="\033[${INSTALLED_COLOR}%15s\033[0m"
-      else
-        FORMAT='%15s *'
-      fi
-    fi
-    if [ "${LTS}" != "${VERSION}" ]; then
-      case "${LTS}" in
-        *Latest*)
-          LTS="${LTS##Latest }"
-          LTS_LENGTH="${#LTS}"
-          if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-            LTS_FORMAT="  \\033[${NVM_LATEST_LTS_COLOR}%${LTS_LENGTH}s\\033[0m"
-          else
-            LTS_FORMAT="  %${LTS_LENGTH}s"
-          fi
-        ;;
-        *)
-          LTS_LENGTH="${#LTS}"
-          if [ "${NVM_HAS_COLORS-}" = '1' ]; then
-            LTS_FORMAT="  \\033[${NVM_OLD_LTS_COLOR}%${LTS_LENGTH}s\\033[0m"
-          else
-            LTS_FORMAT="  %${LTS_LENGTH}s"
-          fi
-        ;;
-      esac
-      command printf -- "${FORMAT}${LTS_FORMAT}\\n" "${VERSION}" " ${LTS}"
-    else
-      command printf -- "${FORMAT}\\n" "${VERSION}"
-    fi
-  done
+
+  command awk \
+    -v remote_versions="$(printf '%s' "${1-}" | tr '\n' '|')" \
+    -v installed_versions="$(nvm_ls | tr '\n' '|')" -v current="$NVM_CURRENT" \
+    -v installed_color="$INSTALLED_COLOR" -v system_color="$SYSTEM_COLOR" \
+    -v current_color="$CURRENT_COLOR" -v default_color="$DEFAULT_COLOR" \
+    -v old_lts_color="$DEFAULT_COLOR" -v has_colors="$NVM_HAS_COLORS" '
+BEGIN {
+  fmt_installed = has_colors ? ("\033[" installed_color "%15s\033[0m") : "%15s *";
+  fmt_system = has_colors ? ("\033[" system_color "%15s\033[0m") : "%15s *";
+  fmt_current = has_colors ? ("\033[" current_color "->%13s\033[0m") : "->%13s *";
+
+  latest_lts_color = current_color;
+  sub(/0;/, "1;", latest_lts_color);
+
+  fmt_latest_lts = has_colors ? ("\033[" latest_lts_color " (Latest LTS: %s)\033[0m") : " (Latest LTS: %s)";
+  fmt_old_lts = has_colors ? ("\033[" old_lts_color " (LTS: %s)\033[0m") : " (LTS: %s)";
+
+  split(remote_versions, lines, "|");
+  split(installed_versions, installed, "|");
+  rows = length(lines);
+
+  for (n = 1; n <= rows; n++) {
+    split(lines[n], fields, "[[:blank:]]+");
+    cols = length(fields);
+    version = fields[1];
+    is_installed = 0;
+
+    for (i in installed) {
+      if (version == installed[i]) {
+        is_installed = 1;
+        break;
+      }
+    }
+
+    fmt_version = "%15s";
+    if (version == current) {
+      fmt_version = fmt_current;
+    } else if (version == "system") {
+      fmt_version = fmt_system;
+    } else if (is_installed) {
+      fmt_version = fmt_installed;
+    }
+
+    padding = (!has_colors && is_installed) ? "" : "  ";
+
+    if (cols == 1) {
+      formatted = sprintf(fmt_version, version);
+    } else if (cols == 2) {
+      formatted = sprintf((fmt_version padding fmt_old_lts), version, fields[2]);
+    } else if (cols == 3 && fields[3] == "*") {
+      formatted = sprintf((fmt_version padding fmt_latest_lts), version, fields[2]);
+    }
+
+    output[n] = formatted;
+  }
+
+  for (n = 1; n <= rows; n++) {
+    print output[n]
+  }
+
+  exit
+}'
 }
 
 nvm_validate_implicit_alias() {


### PR DESCRIPTION
As of now there are about 700 node versions according to `nvm_remote_versions`, for which `nvm ls-remote` might take up to 20 seconds to print the versions in a slightly formatted form.

We can get a significant performance improvement by replacing the major part of `nvm_print_versions` with a awk based implementation:

<table>
<tr><th></th><th>Before</th><th>After</th></tr>
<tr><td>Main loop</td><td><code>
real    17.163s
user    6.635s
sys     6.675s
</code></td></td> </td><td><code>
real    0.183s
user    0.108s
sys     0.098s
</code></td></td></tr>
<tr><td>Overall</td><td><code>
real    18.555s
user    6.984s
sys     6.958s
</code></td></td> </td><td><code>
real    1.671s
user    0.508s
sys     0.414s
</code></td></td></tr>
</table>
