### PR TITLE
[readme] cdnvm(): handle failed dir change

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ Put the following at the end of your `$HOME/.bashrc`:
 
 ```bash
 cdnvm() {
-    command cd "$@";
+    command cd "$@" || return $?
     nvm_path=$(nvm_find_up .nvmrc | tr -d '\n')
 
     # If there are no .nvmrc file, use the default nvm version


### PR DESCRIPTION
If cd command fails, return whatever cd returned, instead of marching ahead