### PR TITLE
[New] `nvm use`/`nvm install`: add `--save` option

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ test/bak
 .urchin.log
 .urchin_stdout
 test/**/test_output
+test/**/.nvmrc
 
 node_modules/
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test/bak
 .urchin.log
 .urchin_stdout
 test/**/test_output
+test/**/.nvmrc
 
 node_modules/
 npm-debug.log

--- a/test/fast/Unit tests/Running 'nvm install --save' works as expected'
+++ b/test/fast/Unit tests/Running 'nvm install --save' works as expected'
@@ -1,0 +1,43 @@
+#!/bin/sh
+\. ../../../nvm.sh
+\. ../../common.sh
+
+set -e
+
+TEST_VERSION="v0.2.4"
+
+if [ -f .nvmrc ]; then mv .nvmrc .nvmrc.orig; fi
+
+cleanup () {
+  nvm cache clear
+  nvm deactivate
+  nvm unalias default
+  rm -rf ${NVM_DIR}/v* .nvmrc
+  if [ -f .nvmrc.orig ]; then mv .nvmrc.orig .nvmrc; fi
+  unset -f nvm_ls_remote nvm_ls_remote_iojs
+}
+
+die () {
+  echo "$@"
+  cleanup
+  exit 1
+}
+
+REMOTE="$PWD/mocks/nvm_ls_remote.txt"
+nvm_ls_remote() {
+  cat "$REMOTE"
+}
+REMOTE_IOJS="$PWD/mocks/nvm_ls_remote_iojs.txt"
+nvm_ls_remote_iojs() {
+  cat "$REMOTE_IOJS"
+}
+
+make_fake_node "$TEST_VERSION"
+
+nvm install --save "$TEST_VERSION" || die "\`nvm install --save $TEST_VERSION\` failed"
+OUTPUT="$(cat .nvmrc)"
+
+nvm_is_valid_version "$(cat .nvmrc)" \
+  || die "\`nvm install --save $TEST_VERSION\`+ \`cat .nvmrc\` outputted invalid version: got '${OUTPUT}'"
+
+cleanup

--- a/test/fast/Unit tests/Running 'nvm use --save' works with a .nvmrc in the parent dir
+++ b/test/fast/Unit tests/Running 'nvm use --save' works with a .nvmrc in the parent dir
@@ -1,0 +1,57 @@
+#!/bin/sh
+\. ../../../nvm.sh
+\. ../../common.sh
+
+set -e
+
+TEST_VERSION="v0.2.4"
+
+if [ -f .nvmrc ]; then mv .nvmrc .nvmrc.orig; fi
+if [ -f ../.nvmrc ]; then mv ../.nvmrc ../.nvmrc.orig; fi
+
+del_nvmrc () {
+  rm -f .nvmrc ../.nvmrc
+}
+
+cleanup () {
+  del_nvmrc
+  nvm cache clear
+  nvm deactivate
+  nvm unalias default
+  rm -rf ${NVM_DIR}/v*
+  if [ -f .nvmrc.orig ]; then mv .nvmrc.orig .nvmrc; fi
+  if [ -f ../.nvmrc.orig ]; then mv ../.nvmrc.orig ../.nvmrc; fi
+  unset -f nvm_ls_remote nvm_ls_remote_iojs
+}
+
+die () {
+  echo "$@"
+  cleanup
+  exit 1
+}
+
+REMOTE="$PWD/mocks/nvm_ls_remote.txt"
+nvm_ls_remote() {
+  cat "$REMOTE"
+}
+REMOTE_IOJS="$PWD/mocks/nvm_ls_remote_iojs.txt"
+nvm_ls_remote_iojs() {
+  cat "$REMOTE_IOJS"
+}
+
+del_nvmrc
+make_fake_node "$TEST_VERSION"
+
+(cd ..
+nvm use --save "$TEST_VERSION" || die "\`nvm use --save $TEST_VERSION\` failed in the parent dir")
+nvm use --save || die "\`nvm use --save\` failed"
+
+[ -f ../.nvmrc ] && [ -f .nvmrc ] || die "expected two .nvmrc files to be generated"
+
+OUTPUT=$(cat .nvmrc)
+EXPECTED_OUTPUT="$(cat ../.nvmrc)"
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "invalid \`nvm use --save \` output: expected '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+
+cleanup

--- a/test/fast/Unit tests/Running 'nvm use --silent --save' doesn't output anything
+++ b/test/fast/Unit tests/Running 'nvm use --silent --save' doesn't output anything
@@ -1,0 +1,43 @@
+#!/bin/sh
+\. ../../../nvm.sh
+\. ../../common.sh
+
+set -e
+
+TEST_VERSION="v0.2.4"
+
+if [ -f .nvmrc ]; then mv .nvmrc .nvmrc.orig; fi
+
+cleanup () {
+  nvm cache clear
+  nvm deactivate
+  nvm unalias default
+  rm -rf ${NVM_DIR}/v* .nvmrc
+  if [ -f .nvmrc.orig ]; then mv .nvmrc.orig .nvmrc; fi
+  unset -f nvm_ls_remote nvm_ls_remote_iojs
+}
+
+die () {
+  echo "$@"
+  cleanup
+  exit 1
+}
+
+REMOTE="$PWD/mocks/nvm_ls_remote.txt"
+nvm_ls_remote() {
+  cat "$REMOTE"
+}
+REMOTE_IOJS="$PWD/mocks/nvm_ls_remote_iojs.txt"
+nvm_ls_remote_iojs() {
+  cat "$REMOTE_IOJS"
+}
+
+make_fake_node "$TEST_VERSION"
+
+OUTPUT=$(nvm use --save --silent "$TEST_VERSION" || die "\`nvm use --save --silent $TEST_VERSION\` failed")
+EXPECTED_OUTPUT=""
+
+[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "\`nvm use --save --silent $TEST_VERSION\` output was not silenced to '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+
+cleanup

--- a/test/fast/Unit tests/Running 'nvm use -w' works as expected'
+++ b/test/fast/Unit tests/Running 'nvm use -w' works as expected'
@@ -1,0 +1,62 @@
+#!/bin/sh
+\. ../../../nvm.sh
+
+set -e
+
+if [ -f .nvmrc ]; then mv .nvmrc .nvmrc.orig; fi
+
+TEST_VERSION="v0.2.4"
+
+cleanup () {
+  nvm cache clear
+  nvm deactivate
+  nvm unalias default
+  rm -rf ${NVM_DIR}/v* .nvmrc
+  if [ -f .nvmrc.orig ]; then mv .nvmrc.orig .nvmrc; fi
+  unset -f nvm_ls_remote nvm_ls_remote_iojs
+}
+
+die () {
+  echo "$@"
+  cleanup
+  exit 1
+}
+
+nvm deactivate 2>/dev/null || die 'unable to deactivate'
+
+\. ../../common.sh
+
+REMOTE="$PWD/mocks/nvm_ls_remote.txt"
+nvm_ls_remote() {
+  cat "$REMOTE"
+}
+REMOTE_IOJS="$PWD/mocks/nvm_ls_remote_iojs.txt"
+nvm_ls_remote_iojs() {
+  cat "$REMOTE_IOJS"
+}
+
+make_fake_node "$TEST_VERSION"
+
+# 1. install
+
+nvm install -w "$TEST_VERSION" || die "\`nvm install -w $TEST_VERSION\` failed"
+OUTPUT="$(cat .nvmrc)"
+
+nvm_is_valid_version "$(cat .nvmrc)" \
+  || die "\`nvm install -w $TEST_VERSION\`+ \`cat .nvmrc\` outputted invalid version: got '${OUTPUT}'"
+
+#
+
+unset OUTPUT
+
+# 2. use
+
+nvm use -w "$TEST_VERSION" || die "\`nvm use -w $TEST_VERSION\` failed"
+OUTPUT="$(cat .nvmrc)"
+
+nvm_is_valid_version "$(cat .nvmrc)" \
+  || die "\`nvm use -w $TEST_VERSION\`+ \`cat .nvmrc\` outputted invalid version: got '${OUTPUT}'"
+
+#
+
+cleanup

--- a/test/fast/Unit tests/nvm_write_nvmrc
+++ b/test/fast/Unit tests/nvm_write_nvmrc
@@ -1,0 +1,86 @@
+#!/bin/sh
+\. ../../../nvm.sh
+\. ../../common.sh
+
+set -e
+
+TEST_VERSION="v0.2.4"
+
+if [ -f .nvmrc ]; then mv .nvmrc .nvmrc.orig; fi
+
+del_nvmrc () {
+  rm -f .nvmrc
+}
+
+del_alias () {
+  nvm unalias test >/dev/null 2>&1
+}
+
+cleanup () {
+  del_nvmrc
+  del_alias
+  nvm cache clear
+  nvm deactivate
+  nvm unalias default
+  rm -rf ${NVM_DIR}/v*
+  if [ -f .nvmrc.orig ]; then mv .nvmrc.orig .nvmrc; fi
+  unset -f nvm_ls_remote nvm_ls_remote_iojs
+}
+
+die () {
+  echo "$@"
+  cleanup
+  exit 1
+}
+
+REMOTE="$PWD/mocks/nvm_ls_remote.txt"
+nvm_ls_remote() {
+  cat "$REMOTE"
+}
+REMOTE_IOJS="$PWD/mocks/nvm_ls_remote_iojs.txt"
+nvm_ls_remote_iojs() {
+  cat "$REMOTE_IOJS"
+}
+
+make_fake_node "$TEST_VERSION"
+
+test_version () {
+  del_nvmrc
+  VERSION_STRING=${1-}
+  make_fake_node "$VERSION_STRING"
+
+  nvm_write_nvmrc $VERSION_STRING || die "\`nvm_write_nvmrc ${VERSION_STRING}\` failed"
+  OUTPUT="$(cat .nvmrc)"
+
+  nvm_is_valid_version "$(cat .nvmrc)" \
+    || die "\`nvm install --save ${VERSION_STRING}\`+ \`cat .nvmrc\` outputted invalid version: got '${OUTPUT}'"
+}
+
+# 1.
+
+test_version "$TEST_VERSION" || die
+
+# 2. with an alias
+del_alias
+nvm alias test "$TEST_VERSION"
+test_version test || die
+
+# 3. fails with invalid permissions
+del_nvmrc
+touch .nvmrc
+chmod 0 .nvmrc
+nvm_write_nvmrc $TEST_VERSION 2>/dev/null && die "\`nvm_write_nvmrc $TEST_VERSION\` did not fail with invalid permissions"
+del_nvmrc
+
+# 4. respects NVM_SILENT=1
+export NVM_SILENT=1
+[ "$(nvm_write_nvmrc $TEST_VERSION)" = "" ] || die "\`nvm_write_nvmrc $TEST_VERSION\` was not silenced by NVM_SILENT=1"
+unset NVM_SILENT
+
+# 5. fails with an invalid version number
+TEST_VERSION="not_a_node_version"
+nvm_write_nvmrc $TEST_VERSION 2>/dev/null && die "\`nvm_write_nvmrc $TEST_VERSION\` did not fail"
+
+#
+
+cleanup


### PR DESCRIPTION
In this PR I've:

 - added a `--save` option as per #2849 
 - implemented it for both `nvm use` and `nvm install` (which actually just carries over the option)
 - manually tested it in `bash`, `sh` and `zsh`
 - written one test, however I can't get the slow tests to run on my system so hopefully it runs okay :crossed_fingers: (if someone would be able to check that, that'd be great)

![image](https://user-images.githubusercontent.com/16228305/187242534-306fe814-c428-4181-a185-69a1355f8609.png)
![image](https://user-images.githubusercontent.com/16228305/187242305-0590d90c-5023-47b4-95a7-7e435beb2a2f.png)

Fixes #2849