### PR TITLE
[readme] optimize calling of `nvm version` in zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,6 @@ Put this into your `$HOME/.zshrc` to call `nvm use` automatically whenever you e
 # place this after nvm initialization!
 autoload -U add-zsh-hook
 load-nvmrc() {
-  local node_version="$(nvm version)"
   local nvmrc_path="$(nvm_find_nvmrc)"
 
   if [ -n "$nvmrc_path" ]; then
@@ -621,10 +620,10 @@ load-nvmrc() {
 
     if [ "$nvmrc_node_version" = "N/A" ]; then
       nvm install
-    elif [ "$nvmrc_node_version" != "$node_version" ]; then
+    elif [ "$nvmrc_node_version" != "$(nvm version)" ]; then
       nvm use
     fi
-  elif [ "$node_version" != "$(nvm version default)" ]; then
+  elif [ -n "$(PWD=$OLDPWD nvm_find_nvmrc)" ] && [ "$(nvm version)" != "$(nvm version default)" ]; then
     echo "Reverting to nvm default version"
     nvm use default
   fi


### PR DESCRIPTION
The zsh hook in the readme causes `cd` to take unnecessarily long when working in directory tress without `.nvmrc` files due to always calling `nvm version` and `nvm version default`. 

```sh
$ time (nvm version)
( nvm version; )  0.01s user 0.02s system 46% cpu 0.052 total
$ time (nvm version default)
( nvm version default; )  0.07s user 0.12s system 87% cpu 0.213 total
```

We should only call `nvm version` and `nvm version default` if we _left_ a directory with a `.nvmrc` file.
`nvm_find_nvmrc` and `nvm_find_up` are fast, so by creating a similar search, but with `OLDPWD`, unneeded calls to `nvm version` and `nvm version default` are eliminated.
