### PR TITLE
[Fix] `install.sh`: support `~/.zprofile`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ nvm_profile_is_bash_or_zsh() {
   local TEST_PROFILE
   TEST_PROFILE="${1-}"
   case "${TEST_PROFILE-}" in
-    *"/.bashrc" | *"/.bash_profile" | *"/.zshrc")
+    *"/.bashrc" | *"/.bash_profile" | *"/.zshrc" | *"/.zprofile")
       return
     ;;
     *)
@@ -282,11 +282,13 @@ nvm_detect_profile() {
   elif [ "${SHELL#*zsh}" != "$SHELL" ]; then
     if [ -f "$HOME/.zshrc" ]; then
       DETECTED_PROFILE="$HOME/.zshrc"
+    elif [ -f "$HOME/.zprofile" ]; then
+      DETECTED_PROFILE="$HOME/.zprofile"
     fi
   fi
 
   if [ -z "$DETECTED_PROFILE" ]; then
-    for EACH_PROFILE in ".profile" ".bashrc" ".bash_profile" ".zshrc"
+    for EACH_PROFILE in ".profile" ".bashrc" ".bash_profile" ".zprofile" ".zshrc"
     do
       if DETECTED_PROFILE="$(nvm_try_profile "${HOME}/${EACH_PROFILE}")"; then
         break
@@ -415,7 +417,7 @@ nvm_do_install() {
     if [ -n "${PROFILE}" ]; then
       TRIED_PROFILE="${NVM_PROFILE} (as defined in \$PROFILE), "
     fi
-    nvm_echo "=> Profile not found. Tried ${TRIED_PROFILE-}~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile."
+    nvm_echo "=> Profile not found. Tried ${TRIED_PROFILE-}~/.bashrc, ~/.bash_profile, ~/.zprofile, ~/.zshrc, and ~/.profile."
     nvm_echo "=> Create one of them and run this script again"
     nvm_echo "   OR"
     nvm_echo "=> Append the following lines to the correct file yourself:"

--- a/test/install_script/nvm_detect_profile
+++ b/test/install_script/nvm_detect_profile
@@ -5,6 +5,7 @@ setup () {
   NVM_ENV=testing \. ../../install.sh
   touch ".bashrc"
   touch ".bash_profile"
+  touch ".zprofile"
   touch ".zshrc"
   touch ".profile"
   touch "test_profile"
@@ -16,7 +17,7 @@ cleanup () {
   unset NVM_DETECT_PROFILE
   unset SHELL
   unset -f setup cleanup die
-  rm -f ".bashrc" ".bash_profile" ".zshrc" ".profile" "test_profile" > "/dev/null" 2>&1
+  rm -f ".bashrc" ".bash_profile" ".zprofile" ".zshrc" ".profile" "test_profile" > "/dev/null" 2>&1
 }
 
 die () { echo "$@" '$NVM_DETECT_PROFILE:' "$NVM_DETECT_PROFILE"; cleanup; exit 1; }
@@ -77,7 +78,7 @@ fi
 
 #
 # When profile detection fails via both $PROFILE and $SHELL, profile detection should select based on the existence of
-# one of the following files is the following order: .profile, .bashrc, .bash_profile, .zshrc and
+# one of the following files is the following order: .profile, .bashrc, .bash_profile, .zprofile, .zshrc and
 # return an empty value if everything fails
 #
 
@@ -101,8 +102,15 @@ if [ "$NVM_DETECT_PROFILE" != "$HOME/.bash_profile" ]; then
   die "nvm_detect_profile should have selected .bash_profile"
 fi
 
-# Otherwise, it should favor .zshrc if file exists
+# Otherwise, it should favor .zprofile if file exists
 rm ".bash_profile"
+NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
+if [ "$NVM_DETECT_PROFILE" != "$HOME/.zprofile" ]; then
+  die "nvm_detect_profile should have selected .zprofile"
+fi
+
+# Otherwise, it should favor .zshrc if file exists
+rm ".zprofile"
 NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.zshrc" ]; then
   die "nvm_detect_profile should have selected .zshrc"

--- a/test/install_script/nvm_profile_is_bash_or_zsh
+++ b/test/install_script/nvm_profile_is_bash_or_zsh
@@ -9,5 +9,6 @@ type nvm_profile_is_bash_or_zsh > /dev/null 2>&1 || die 'nvm_profile_is_bash_or_
 nvm_profile_is_bash_or_zsh "/home/nvm/.bashrc"   || die '/home/nvm/.bashrc is bash profile'
 nvm_profile_is_bash_or_zsh "/home/nvm/.bash_profile"   || die '/home/nvm/.bash_profile is bash profile'
 nvm_profile_is_bash_or_zsh "/home/nvm/.zshrc"    || die '/home/nvm/.zshrc is zsh profile'
+nvm_profile_is_bash_or_zsh "/home/nvm/.zprofile" || die '/home/nvm/.zprofile is zsh profile'
 if nvm_profile_is_bash_or_zsh "/home/nvm/.bash"; then die '/home/nvm/.bash is not bash nor zsh profile'; fi
 if nvm_profile_is_bash_or_zsh "/home/nvm/.zsh" ; then die '/home/nvm/.zsh is not bash nor zsh profile'; fi


### PR DESCRIPTION
Hi there.

I tried to install nvm on my new Macbook air m2 and failed due to the `"Profile not found. Tried ~/.bashrc, ~/.bash_profile, ~/.zshrc, and ~/.profile."` error

I checked my home directory and there was only a `~/.zprofile` file

This PR adds support for `~/.zprofile`

<img width="878" alt="Screenshot 2022-09-21 at 22 43 42" src="https://user-images.githubusercontent.com/26428493/191606652-4ec2c578-7382-45e2-8049-97be4962efc9.png">
