### PR TITLE
[readme] Update Alpine Linux Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@
   - [Usage](#usage-1)
 - [Compatibility Issues](#compatibility-issues)
 - [Installing nvm on Alpine Linux](#installing-nvm-on-alpine-linux)
+  - [Alpine Linux 3.13+](#alpine-linux-313)
+  - [Alpine Linux 3.5 - 3.12](#alpine-linux-35---312)
 - [Uninstalling / Removal](#uninstalling--removal)
   - [Manual Uninstall](#manual-uninstall)
 - [Docker For Development Environment](#docker-for-development-environment)
@@ -786,12 +788,21 @@ Alpine Linux, unlike mainstream/traditional Linux distributions, is based on [Bu
 
 There is a `-s` flag for `nvm install` which requests nvm download Node source and compile it locally.
 
-If installing nvm on Alpine Linux *is* still what you want or need to do, you should be able to achieve this by running the following from you Alpine Linux shell:
+If installing nvm on Alpine Linux *is* still what you want or need to do, you should be able to achieve this by running the following from you Alpine Linux shell, depending on which version you are using:
 
+### Alpine Linux 3.13+
+```sh
+apk add -U curl bash ca-certificates openssl ncurses coreutils python3 make gcc g++ libgcc linux-headers grep util-linux binutils findutils
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+```
+
+### Alpine Linux 3.5 - 3.12
 ```sh
 apk add -U curl bash ca-certificates openssl ncurses coreutils python2 make gcc g++ libgcc linux-headers grep util-linux binutils findutils
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
+
+_Note: Alpine 3.5 can only install NodeJS versions up to v6.9.5, Alpine 3.6 can only install versions up to v6.10.3, Alpine 3.7 installs versions up to v8.9.3, Alpine 3.8 installs versions up to v8.14.0, Alpine 3.9 installs versions up to v10.19.0, Alpine 3.10 installs versions up to v10.24.1, Alpine 3.11 installs versions up to v12.22.6, Alpine 3.12 installs versions up to v12.22.12, Alpine 3.13 & 3.14 install versions up to v14.20.0, Alpine 3.15 & 3.16 install versions up to v16.16.0 (**These are all versions on the main branch**). Alpine 3.5 - 3.12 required the package `python2` to build NodeJS, as they are older versions to build. Alpine 3.13+ requires `python3` to successfully build newer NodeJS versions, but you can use `python2` with Alpine 3.13+ if you need to build versions of node supported in Alpine 3.5 - 3.15, you just need to specify what version of NodeJS you need to install in the package install script._
 
 The Node project has some desire but no concrete plans (due to the overheads of building, testing and support) to offer Alpine-compatible binaries.
 


### PR DESCRIPTION
# PR Changes
## Commit 1f2e567
- Update install directions to include `python3`, instead of `python2`, which is deprecated since Alpine 3.13.

## Commit da6ba1e
- Add both install scripts, depending on different Alpine versions being ran, at request
- Added a side note for users wanting to run Alpine 3.5 - 3.12 regarding older versions of NodeJS

## Commit 3f682a5 & af32ff1
- Update the note regarding Alpine versions supporting which NodeJS versions

Fixes #2895.