### PR TITLE
[Fix] grep: warning: stray \ before /

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -70,7 +70,7 @@ nvm_command_info() {
   elif type "${COMMAND}" | nvm_grep -q "^${COMMAND} is an alias for"; then
     # shellcheck disable=SC2230
     INFO="$(which "${COMMAND}") ($(type "${COMMAND}" | command awk '{ $1=$2=$3=$4=$5="" ;print }' | command sed 's/^\ *//g'))"
-  elif type "${COMMAND}" | nvm_grep -q "^${COMMAND} is \\/"; then
+  elif type "${COMMAND}" | nvm_grep -q "^${COMMAND} is /"; then
     INFO="$(type "${COMMAND}" | command awk '{print $3}')"
   else
     INFO="$(type "${COMMAND}")"


### PR DESCRIPTION
No need to escape the `/` char in a grep pattern.
This is to fix the below error when using newer grep with `nvm_command_info`

> $ nvm_command_info curl
> grep: warning: stray \ before /
> /usr/bin/curl

This happens with at least GNU grep 3.8 version.