### PR TITLE
bypass aliased curl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,18 @@ nvm_has() {
   type "$1" > /dev/null 2>&1
 }
 
+# resolves like `command "${1}"` does: only executables on the PATH,
+# ignoring shell functions and aliases
+nvm_has_executable() {
+  (
+    # `|| true` so that shells with errexit-style options (eg, zsh's ERR_RETURN)
+    # do not abort the subshell when the name is not an alias or a function
+    unalias "${1-}" 2>/dev/null || true
+    unset -f "${1-}" 2>/dev/null || true
+    command -v "${1-}" > /dev/null 2>&1
+  )
+}
+
 nvm_echo() {
   command printf %s\\n "$*" 2>/dev/null
 }
@@ -105,9 +117,9 @@ nvm_node_version() {
 }
 
 nvm_download() {
-  if nvm_has "curl"; then
+  if nvm_has_executable "curl"; then
     curl --fail --compressed -q "$@"
-  elif nvm_has "wget"; then
+  elif nvm_has_executable "wget"; then
     # Emulate curl with wget
     ARGS=$(nvm_echo "$@" | command sed -e 's/--progress-bar /--progress=bar /' \
                             -e 's/--compressed //' \
@@ -401,7 +413,7 @@ nvm_do_install() {
     # Autodetect install method
     if nvm_has git; then
       install_nvm_from_git
-    elif nvm_has curl || nvm_has wget; then
+    elif nvm_has_executable curl || nvm_has_executable wget; then
       install_nvm_as_script
     else
       nvm_echo >&2 'You need git, curl, or wget to install nvm'
@@ -414,7 +426,7 @@ nvm_do_install() {
     fi
     install_nvm_from_git
   elif [ "${METHOD}" = 'script' ]; then
-    if ! nvm_has curl && ! nvm_has wget; then
+    if ! nvm_has_executable curl && ! nvm_has_executable wget; then
       nvm_echo >&2 "You need curl or wget to install nvm"
       exit 1
     fi
@@ -496,7 +508,7 @@ nvm_do_install() {
 # during the execution of the install script
 #
 nvm_reset() {
-  unset -f nvm_has nvm_install_dir nvm_latest_version nvm_profile_is_bash_or_zsh \
+  unset -f nvm_has nvm_has_executable nvm_install_dir nvm_latest_version nvm_profile_is_bash_or_zsh \
     nvm_source nvm_node_version nvm_download install_nvm_from_git nvm_install_node \
     install_nvm_as_script nvm_try_profile nvm_detect_profile nvm_check_global_modules \
     nvm_do_install nvm_reset nvm_default_install_dir nvm_grep

--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ nvm_node_version() {
 
 nvm_download() {
   if nvm_has_executable "curl"; then
-    curl --fail --compressed -q "$@"
+    command curl --fail --compressed -q "$@"
   elif nvm_has_executable "wget"; then
     # Emulate curl with wget
     ARGS=$(nvm_echo "$@" | command sed -e 's/--progress-bar /--progress=bar /' \

--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,7 @@ nvm_download() {
                             -e 's/-o /-O /' \
                             -e 's/-C - /-c /')
     # shellcheck disable=SC2086
-    eval wget $ARGS
+    eval command wget $ARGS
   fi
 }
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -87,7 +87,7 @@ nvm_has_colors() {
 }
 
 nvm_curl_libz_support() {
-  curl -V 2>/dev/null | nvm_grep "^Features:" | nvm_grep -q "libz"
+  command curl -V 2>/dev/null | nvm_grep "^Features:" | nvm_grep -q "libz"
 }
 
 nvm_curl_use_compression() {
@@ -103,7 +103,7 @@ nvm_get_latest() {
     fi
     NVM_LATEST_URL="$(curl ${CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S https://latest.nvm.sh -o /dev/null)"
   elif nvm_has "wget"; then
-    NVM_LATEST_URL="$(wget -q https://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
+    NVM_LATEST_URL="$(command wget -q https://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
   else
     nvm_err 'nvm needs curl or wget to proceed.'
     return 1
@@ -170,7 +170,7 @@ nvm_download() {
     set -- "$@" --header "Authorization: ${sanitized_header}"
   fi
 
-  "${NVM_DOWNLOADER}" "$@"
+  command "${NVM_DOWNLOADER}" "$@"
 }
 
 nvm_sanitize_auth_header() {
@@ -649,7 +649,7 @@ nvm_clang_version() {
 }
 
 nvm_curl_version() {
-  curl -V | command awk '{ if ($1 == "curl") print $2 }' | command sed 's/-.*$//g'
+  command curl -V | command awk '{ if ($1 == "curl") print $2 }' | command sed 's/-.*$//g'
 }
 
 nvm_version_greater() {

--- a/nvm.sh
+++ b/nvm.sh
@@ -49,6 +49,18 @@ nvm_has() {
   type "${1-}" >/dev/null 2>&1
 }
 
+# resolves like `command "${1}"` does: only executables on the PATH,
+# ignoring shell functions and aliases
+nvm_has_executable() {
+  (
+    # `|| true` so that shells with errexit-style options (eg, zsh's ERR_RETURN)
+    # do not abort the subshell when the name is not an alias or a function
+    unalias "${1-}" 2>/dev/null || true
+    unset -f "${1-}" 2>/dev/null || true
+    command -v "${1-}" >/dev/null 2>&1
+  )
+}
+
 nvm_has_non_aliased() {
   nvm_has "${1-}" && ! nvm_is_alias "${1-}"
 }
@@ -97,12 +109,12 @@ nvm_curl_use_compression() {
 nvm_get_latest() {
   local NVM_LATEST_URL
   local CURL_COMPRESSED_FLAG
-  if nvm_has "curl"; then
+  if nvm_has_executable "curl"; then
     if nvm_curl_use_compression; then
       CURL_COMPRESSED_FLAG="--compressed"
     fi
     NVM_LATEST_URL="$(curl ${CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S https://latest.nvm.sh -o /dev/null)"
-  elif nvm_has "wget"; then
+  elif nvm_has_executable "wget"; then
     NVM_LATEST_URL="$(command wget -q https://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
   else
     nvm_err 'nvm needs curl or wget to proceed.'
@@ -127,13 +139,13 @@ nvm_download() {
 
   local NVM_DOWNLOADER
   NVM_DOWNLOADER=''
-  if nvm_has "curl"; then
+  if nvm_has_executable "curl"; then
     NVM_DOWNLOADER='curl'
     set -- -q --fail "$@"
     if nvm_curl_use_compression; then
       set -- --compressed "$@"
     fi
-  elif nvm_has "wget"; then
+  elif nvm_has_executable "wget"; then
     NVM_DOWNLOADER='wget'
     # Emulate curl with wget
     local NVM_DOWNLOAD_WGET_COUNT
@@ -3569,7 +3581,7 @@ nvm() {
         esac
       done
 
-      if [ "${NVM_OFFLINE}" != 1 ] && ! nvm_has "curl" && ! nvm_has "wget"; then
+      if [ "${NVM_OFFLINE}" != 1 ] && ! nvm_has_executable "curl" && ! nvm_has_executable "wget"; then
         nvm_err 'nvm needs curl or wget to proceed.'
         return 1
       fi
@@ -4688,7 +4700,7 @@ nvm() {
         nvm_version_greater nvm_version_greater_than_or_equal_to \
         nvm_print_npm_version nvm_install_latest_npm nvm_npm_global_modules \
         nvm_has_system_node nvm_has_system_iojs \
-        nvm_download nvm_get_latest nvm_has nvm_install_default_packages nvm_get_default_packages \
+        nvm_download nvm_get_latest nvm_has nvm_has_executable nvm_install_default_packages nvm_get_default_packages \
         nvm_curl_use_compression nvm_curl_version \
         nvm_auto nvm_supports_xz \
         nvm_echo nvm_err nvm_grep nvm_cd \

--- a/nvm.sh
+++ b/nvm.sh
@@ -113,7 +113,7 @@ nvm_get_latest() {
     if nvm_curl_use_compression; then
       CURL_COMPRESSED_FLAG="--compressed"
     fi
-    NVM_LATEST_URL="$(curl ${CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S https://latest.nvm.sh -o /dev/null)"
+    NVM_LATEST_URL="$(command curl ${CURL_COMPRESSED_FLAG:-} -q -w "%{url_effective}\\n" -L -s -S https://latest.nvm.sh -o /dev/null)"
   elif nvm_has_executable "wget"; then
     NVM_LATEST_URL="$(command wget -q https://latest.nvm.sh --server-response -O /dev/null 2>&1 | command awk '/^  Location: /{DEST=$2} END{ print DEST }')"
   else

--- a/test/common.sh
+++ b/test/common.sh
@@ -50,6 +50,39 @@ make_echo() {
   chmod a+x "$1"
 }
 
+# `command curl` bypasses shell functions and aliases, so tests that mock curl
+# must provide an actual executable on the PATH: this creates one in the given
+# directory. Invoked as `curl -V`, it prints ${VERSION_MESSAGE} (exported here
+# on the mock's behalf); any other invocation runs the body given as the
+# second argument, or fails.
+make_fake_curl() {
+  local FAKE_BIN_DIR
+  FAKE_BIN_DIR="${1-}"
+  [ -n "${FAKE_BIN_DIR}" ] || return 1
+
+  local FAKE_CURL_BODY
+  FAKE_CURL_BODY="${2-}"
+  if [ -z "${FAKE_CURL_BODY}" ]; then
+    FAKE_CURL_BODY='echo >&2 "This fake curl only takes one parameter, -V"
+exit 1'
+  fi
+
+  mkdir -p "${FAKE_BIN_DIR}" || return 2
+
+  {
+    echo '#!/bin/sh'
+    echo 'if [ "$#" -eq 1 ] && [ "$1" = "-V" ]; then'
+    echo '  echo "${VERSION_MESSAGE}"'
+    echo '  exit 0'
+    echo 'fi'
+    printf '%s\n' "${FAKE_CURL_BODY}"
+  } > "${FAKE_BIN_DIR}/curl"
+  chmod +x "${FAKE_BIN_DIR}/curl"
+
+  # the fake curl reads VERSION_MESSAGE from the environment
+  export VERSION_MESSAGE
+}
+
 make_fake_node() {
   local VERSION
   VERSION="${1-}"

--- a/test/fast/Unit tests/nvm install --offline
+++ b/test/fast/Unit tests/nvm install --offline
@@ -30,9 +30,10 @@ nvm_echo "$CAPTURED_STDERR" | nvm_grep -q "${EXPECTED_ERR}" \
 
 # --offline should not require curl or wget
 nvm_has() { return 1; }
+nvm_has_executable() { return 1; }
 try_err nvm install --offline 999.999.999
 # Should fail with "not found" not "nvm needs curl or wget"
 nvm_echo "$CAPTURED_STDERR" | nvm_grep -q "curl or wget" \
   && die "nvm install --offline should not require curl or wget"
 alias nvm_has='\nvm_has'
-unset -f nvm_has
+unset -f nvm_has nvm_has_executable

--- a/test/fast/Unit tests/nvm_curl_libz_support
+++ b/test/fast/Unit tests/nvm_curl_libz_support
@@ -1,7 +1,11 @@
 #!/bin/sh
 
+WORK="$PWD/nvm_curl_libz_support-work.$$"
+TEST_BIN="$WORK/bin"
+
 cleanup() {
-  unset -f curl
+  rm -rf "$WORK"
+  export PATH="$OLDPATH"
 }
 
 die() { cleanup; echo "$@" ; exit 1; }
@@ -9,32 +13,28 @@ die() { cleanup; echo "$@" ; exit 1; }
 : nvm.sh
 \. ../../../nvm.sh
 
-curl() {
-    # curl with libz feature
-    if [ $# -ne 1 ] || [ "$1" != "-V" ]; then
-        die "This fake curl only takes one parameter -V"
-    fi
-    echo "
+\. ../../common.sh
+
+OLDPATH="$PATH"
+
+make_fake_curl "$TEST_BIN"
+
+export PATH="$TEST_BIN:$OLDPATH"
+
+# curl with libz feature
+VERSION_MESSAGE="
 curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3
 Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smb smbs smtp smtps telnet tftp
 Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP UnixSockets"
-}
 
 nvm_curl_libz_support || die "nvm_curl_libz_support should return 0"
 
-unset -f curl
-
-curl() {
-    # curl without libz feature
-    if [ "$#" -ne 1 ] || [ "$1" != "-V" ]; then
-        die "This fake curl only takes one parameter -V"
-    fi
-    echo "
+# curl without libz feature
+VERSION_MESSAGE="
 curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.32
 Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smb smbs smtp smtps telnet tftp
 Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL TLS-SRP UnixSockets"
-}
 
 ! nvm_curl_libz_support || die "nvm_curl_libz_support should return 1"
 
-unset -f curl
+cleanup

--- a/test/fast/Unit tests/nvm_curl_use_compression
+++ b/test/fast/Unit tests/nvm_curl_use_compression
@@ -1,18 +1,25 @@
 #!/bin/sh
 
+WORK="$PWD/nvm_curl_use_compression-work.$$"
+TEST_BIN="$WORK/bin"
+
 cleanup () {
   unset -f die
+  rm -rf "$WORK"
+  export PATH="$OLDPATH"
 }
 
 die () { echo -e "$@" ; cleanup ;  exit 1; }
 
 NVM_ENV=testing \. ../../../nvm.sh
 
-curl() {
-  if [ "$1" = "-V" ]; then
-    echo "${VERSION_MESSAGE}"
-  fi
-}
+\. ../../common.sh
+
+OLDPATH="$PATH"
+
+make_fake_curl "$TEST_BIN"
+
+export PATH="$TEST_BIN:$OLDPATH"
 
 CURL_VERSION_ON_ARCHLINUX_WITH_LIBZ="curl 7.54.0 (x86_64-pc-linux-gnu) libcurl/7.54.0 OpenSSL/1.1.0f zlib/1.2.11 libpsl/0.17.0 (+libicu/59.1) libssh2/1.8.0 nghttp2/1.22.0
 Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp

--- a/test/fast/Unit tests/nvm_curl_version
+++ b/test/fast/Unit tests/nvm_curl_version
@@ -1,19 +1,25 @@
 #!/bin/sh
 
+WORK="$PWD/nvm_curl_version-work.$$"
+TEST_BIN="$WORK/bin"
+
 cleanup () {
-  unset -f die
-  unset -f curl
+  unset -f die cleanup assert_version_is
+  rm -rf "$WORK"
+  export PATH="$OLDPATH"
 }
 
 die () { echo -e "$@" ; cleanup ;  exit 1; }
 
 NVM_ENV=testing \. ../../../nvm.sh
 
-curl() {
-  if [ "$1" = "-V" ]; then
-    echo "${VERSION_MESSAGE}"
-  fi
-}
+\. ../../common.sh
+
+OLDPATH="$PATH"
+
+make_fake_curl "$TEST_BIN"
+
+export PATH="$TEST_BIN:$OLDPATH"
 
 assert_version_is() {
   if [ "${1}" != "${2}" ]; then

--- a/test/fast/Unit tests/nvm_download and curl helpers bypass shadowed curl
+++ b/test/fast/Unit tests/nvm_download and curl helpers bypass shadowed curl
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+WORK="$PWD/shadowed-curl-work.$$"
+TEST_BIN="$WORK/bin"
+ARGV_LOG="$WORK/argv.log"
+
+cleanup () {
+  unset -f die cleanup curl wget
+  rm -rf "$WORK"
+  export PATH="$OLDPATH"
+}
+
+die () { echo "$@" ; cleanup ; exit 1; }
+
+NVM_ENV=testing \. ../../../nvm.sh
+
+\. ../../common.sh
+
+OLDPATH="$PATH"
+
+# real-looking curl on PATH; calling the shadowing shell function below instead is a failure
+make_fake_curl "$TEST_BIN" ': > "$ARGV_LOG"
+for a in "$@"; do printf "%s\n" "$a" >> "$ARGV_LOG"; done'
+
+VERSION_MESSAGE="curl 7.99.0 (fake)
+Features: libz"
+
+export ARGV_LOG
+export PATH="$TEST_BIN:$OLDPATH"
+
+# shadowing shell functions, like aliases baked into a user's shell, must be
+# bypassed in favor of the executables on PATH (https://github.com/nvm-sh/nvm/issues/2923)
+curl() {
+  echo 'curl 0.0.0-shadowed'
+  return 1
+}
+wget() {
+  return 1
+}
+
+[ "$(nvm_curl_version)" = '7.99.0' ] || die "nvm_curl_version used the shadowing curl function; got $(nvm_curl_version)"
+
+nvm_curl_libz_support || die 'nvm_curl_libz_support used the shadowing curl function'
+
+nvm_download -s 'http://example.com/' -o /dev/null || die 'nvm_download used the shadowing curl function and failed'
+grep -Fxq 'http://example.com/' "$ARGV_LOG" || die "nvm_download did not invoke the curl executable; got: $(cat "$ARGV_LOG")"
+
+cleanup

--- a/test/fast/Unit tests/nvm_download and curl helpers bypass shadowed curl
+++ b/test/fast/Unit tests/nvm_download and curl helpers bypass shadowed curl
@@ -45,4 +45,22 @@ nvm_curl_libz_support || die 'nvm_curl_libz_support used the shadowing curl func
 nvm_download -s 'http://example.com/' -o /dev/null || die 'nvm_download used the shadowing curl function and failed'
 grep -Fxq 'http://example.com/' "$ARGV_LOG" || die "nvm_download did not invoke the curl executable; got: $(cat "$ARGV_LOG")"
 
+# when no curl executable exists, a shadowing curl shell function must not fool
+# downloader selection: nvm_download must fall back to the wget executable
+WGET_ONLY_BIN="$WORK/wget-only-bin"
+mkdir -p "$WGET_ONLY_BIN"
+{
+  echo '#!/bin/sh'
+  echo ': > "$ARGV_LOG"'
+  echo 'for a in "$@"; do printf "%s\n" "$a" >> "$ARGV_LOG"; done'
+} > "$WGET_ONLY_BIN/wget"
+chmod +x "$WGET_ONLY_BIN/wget"
+
+(
+  PATH="$WGET_ONLY_BIN"
+  export PATH
+  nvm_download -s 'http://wget-fallback.example.com/' -o /dev/null
+) || die 'nvm_download did not fall back to wget when curl is only a shell function'
+grep -Fxq 'http://wget-fallback.example.com/' "$ARGV_LOG" || die "nvm_download did not invoke the wget executable; got: $(cat "$ARGV_LOG")"
+
 cleanup

--- a/test/fast/Unit tests/nvm_download wget Authorization header
+++ b/test/fast/Unit tests/nvm_download wget Authorization header
@@ -6,7 +6,7 @@ TEST_BIN="$WORK/bin"
 ARGV_LOG="$WORK/argv.log"
 
 cleanup() {
-  unset -f die cleanup nvm_has
+  unset -f die cleanup nvm_has_executable
   rm -rf "$WORK"
   export PATH="$OLDPATH"
 }
@@ -30,7 +30,7 @@ chmod +x "$TEST_BIN/wget"
 export ARGV_LOG
 export PATH="$TEST_BIN:$OLDPATH"
 # force the wget path while keeping system tools (sed) available for sanitization
-nvm_has() { [ "$1" != curl ] && command -v "$1" >/dev/null 2>&1; }
+nvm_has_executable() { [ "$1" != curl ] && command -v "$1" >/dev/null 2>&1; }
 
 # given an Authorization credential in NVM_AUTH_HEADER
 # when nvm_download uses the wget path

--- a/test/fast/Unit tests/nvm_get_latest missing curl or wget
+++ b/test/fast/Unit tests/nvm_get_latest missing curl or wget
@@ -3,7 +3,7 @@
 die () { echo "$@" ; cleanup ; exit 1; }
 
 cleanup() {
-  unset -f nvm_has
+  unset -f nvm_has nvm_has_executable
 }
 
 : nvm.sh
@@ -12,6 +12,7 @@ cleanup() {
 \. ../../common.sh
 
 nvm_has() { return 1 ; }
+nvm_has_executable() { return 1 ; }
 
 try_err nvm_get_latest
 [ "_$CAPTURED_STDERR" = "_nvm needs curl or wget to proceed." ] \

--- a/test/slow/nvm_get_latest/nvm_get_latest
+++ b/test/slow/nvm_get_latest/nvm_get_latest
@@ -2,37 +2,45 @@
 
 die () { echo "$@" ; cleanup ; exit 1; }
 
+WORK="$PWD/nvm_get_latest-work.$$"
+TEST_BIN="$WORK/bin"
+
 cleanup() {
-  unset -f curl wget nvm_has
+  rm -rf "$WORK"
+  export PATH="$OLDPATH"
 }
 
 \. ../../../nvm.sh
+
+\. ../../common.sh
+
+OLDPATH="$PATH"
 
 EXPECTED_VERSION="v12.3.456"
 URL="https://github.com/nvm-sh/nvm/releases/tag/$EXPECTED_VERSION"
 EXPECTED_CURL_ARGS="--compressed -q -w %{url_effective}\n -L -s -S https://latest.nvm.sh -o /dev/null"
 EXPECTED_WGET_ARGS="-q https://latest.nvm.sh --server-response -O /dev/null"
+export URL EXPECTED_CURL_ARGS EXPECTED_WGET_ARGS
 
-curl() {
-  if [ $# -eq 1 ] && [ "$1" = "-V" ]; then
-    echo "
+VERSION_MESSAGE="
 curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3
 Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smb smbs smtp smtps telnet tftp
 Features: AsynchDNS IDN IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz TLS-SRP UnixSockets"
-  elif [ "_$*" != "_$EXPECTED_CURL_ARGS" ]; then
-    echo >&2 "expected args ($EXPECTED_CURL_ARGS), got ($*)"
-    return 1
-  else
-    echo $URL
-  fi
-}
-wget() {
-  if [ "_$*" != "_$EXPECTED_WGET_ARGS" ]; then
-    echo >&2 "expected args ($EXPECTED_WGET_ARGS), got ($*)"
-    return 1
-  else
-    local WGET_CONTENTS
-    WGET_CONTENTS="
+
+# fake curl/wget: `command curl` bypasses shell functions, so the mocks must be executables on PATH
+make_fake_curl "$TEST_BIN" 'if [ "_$*" != "_$EXPECTED_CURL_ARGS" ]; then
+  echo >&2 "expected args ($EXPECTED_CURL_ARGS), got ($*)"
+  exit 1
+fi
+echo "$URL"'
+
+cat > "$TEST_BIN/wget" <<'OUTER'
+#!/bin/sh
+if [ "_$*" != "_$EXPECTED_WGET_ARGS" ]; then
+  echo >&2 "expected args ($EXPECTED_WGET_ARGS), got ($*)"
+  exit 1
+fi
+cat >&2 <<CONTENTS
   HTTP/1.1 301 Moved Permanently
   Location: https://github.com/nvm-sh/nvm/releases/latest
   Content-Type: text/html; charset=utf-8
@@ -82,15 +90,11 @@ wget() {
   X-Content-Type-Options: nosniff
   Vary: Accept-Encoding
   X-Served-By: 926b734ea1992f8ee1f88ab967a93dac
-"
-    "$WGET_CONTENTS" | while read line
-    do
-      >&2 echo "$line"
-    done
-  fi
-}
+CONTENTS
+OUTER
+chmod +x "$TEST_BIN/wget"
 
-\. ../../common.sh
+export PATH="$TEST_BIN:$OLDPATH"
 
 try nvm_get_latest
 [ "_$CAPTURED_STDOUT" = "_$EXPECTED_VERSION" ] \

--- a/test/slow/nvm_get_latest/nvm_get_latest
+++ b/test/slow/nvm_get_latest/nvm_get_latest
@@ -6,6 +6,7 @@ WORK="$PWD/nvm_get_latest-work.$$"
 TEST_BIN="$WORK/bin"
 
 cleanup() {
+  unset -f curl wget
   rm -rf "$WORK"
   export PATH="$OLDPATH"
 }
@@ -95,6 +96,17 @@ OUTER
 chmod +x "$TEST_BIN/wget"
 
 export PATH="$TEST_BIN:$OLDPATH"
+
+# shadowing shell functions, like aliases baked into a user's shell, must be
+# bypassed in favor of the executables on PATH (https://github.com/nvm-sh/nvm/issues/2923)
+curl() {
+  echo >&2 'the shadowing curl function was called'
+  return 1
+}
+wget() {
+  echo >&2 'the shadowing wget function was called'
+  return 1
+}
 
 try nvm_get_latest
 [ "_$CAPTURED_STDOUT" = "_$EXPECTED_VERSION" ] \

--- a/test/slow/nvm_get_latest/nvm_get_latest failed redirect
+++ b/test/slow/nvm_get_latest/nvm_get_latest failed redirect
@@ -2,20 +2,26 @@
 
 die () { echo "$@" ; cleanup ; exit 1; }
 
+WORK="$PWD/nvm_get_latest_failed_redirect-work.$$"
+TEST_BIN="$WORK/bin"
+
 cleanup() {
-  unset -f curl wget
+  rm -rf "$WORK"
+  export PATH="$OLDPATH"
 }
 
 \. ../../../nvm.sh
 
 \. ../../common.sh
 
-curl() {
-  return 1
-}
-wget() {
-  return 1
-}
+OLDPATH="$PATH"
+
+# fake curl/wget: `command curl` bypasses shell functions, so the mocks must be executables on PATH
+make_fake_curl "$TEST_BIN" 'exit 1'
+printf '#!/bin/sh\nexit 1\n' > "$TEST_BIN/wget"
+chmod +x "$TEST_BIN/wget"
+
+export PATH="$TEST_BIN:$OLDPATH"
 
 try_err nvm_get_latest
 [ "_$CAPTURED_STDERR" = "_https://latest.nvm.sh did not redirect to the latest release on GitHub" ] \


### PR DESCRIPTION
Use `command curl` ~add nvm_curl~ so that we can bypass aliased curl.

Context: https://github.com/nvm-sh/nvm/issues/2923#issuecomment-1299535388