### PR TITLE
Remove unneeded call to ls in `nvm_arch`

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1917,10 +1917,10 @@ nvm_get_arch() {
 
   # If running a 64bit ARM kernel but a 32bit ARM userland,
   # change ARCH to 32bit ARM (armv7l) if /sbin/init is 32bit executable
-  local L
-  if [ "$(uname)" = "Linux" ] && [ "${NVM_ARCH}" = arm64 ] &&
-    L="$(command ls -dl /sbin/init 2>/dev/null)" &&
-    [ "$(od -An -t x1 -j 4 -N 1 "${L#*-> }")" = ' 01' ]; then
+  if [ "$(uname)" = "Linux" ] \
+    && [ "${NVM_ARCH}" = arm64 ] \
+    && [ "$(command od -An -t x1 -j 4 -N 1 "/sbin/init" 2>/dev/null)" = ' 01' ]\
+  ; then
     NVM_ARCH=armv7l
     HOST_ARCH=armv7l
   fi


### PR DESCRIPTION
Remove the call to `ls` that was used to determine the symlink
destination

Reasoning :

* `od` resolves symlink itself due to the use of `fopen`
* Prevent the behaviour of `od` which will hang if the filename is
  empty (i.e. `/sbin/init` missing) as it will be waiting for `stdin`
  compared to quitting with error if the file just doesn't exist

Closes #3006
