### PR TITLE
Allow global installation of NVM with individual user .nvm directories for Node installs

### DIFF
--- a/nvm-exec
+++ b/nvm-exec
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DIR="$(command cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$(dirname $(realpath "${BASH_SOURCE[0]}"))"
 
 unset NVM_CD_FLAGS
 

--- a/nvm-exec
+++ b/nvm-exec
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DIR="$(dirname $(realpath "${BASH_SOURCE[0]}"))"
+DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 unset NVM_CD_FLAGS
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -4075,8 +4075,14 @@ nvm() {
           nvm_echo "Running node ${VERSION}$(nvm use --silent "${VERSION}" && nvm_print_npm_version)"
         fi
       fi
-      NODE_VERSION="${VERSION}" "${NVM_DIR}/nvm-exec" "$@"
+
+      NVM_EXEC="${NVM_DIR}/nvm-exec"
+      if [ ! -f "${NVM_EXEC}" ]; then
+        NVM_EXEC=`dirname ${BASH_SOURCE[0]-}`/nvm-exec
+      fi
+      NODE_VERSION="${VERSION}" "${NVM_EXEC}" "$@"
     ;;
+
     "ls" | "list")
       local PATTERN
       local NVM_NO_COLORS

--- a/nvm.sh
+++ b/nvm.sh
@@ -4078,7 +4078,7 @@ nvm() {
 
       NVM_EXEC="${NVM_DIR}/nvm-exec"
       if [ ! -f "${NVM_EXEC}" ]; then
-        NVM_EXEC=`dirname ${BASH_SOURCE[0]-}`/nvm-exec
+        NVM_EXEC="$(dirname "${BASH_SOURCE[0]-}")/nvm-exec"
       fi
       NODE_VERSION="${VERSION}" "${NVM_EXEC}" "$@"
     ;;

--- a/test/slow/nvm exec/Running 'nvm exec --lts' when NVM_DIR differs from nvm
+++ b/test/slow/nvm exec/Running 'nvm exec --lts' when NVM_DIR differs from nvm
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -ex
+
+die () { echo "$@" ; exit 1; }
+
+INSTPATH="$(mktemp -p "$(pwd)" -d)"
+trap 'test ! -z "${INSTPATH-}" && test -d "$INSTPATH" && rm -rf "$INSTPATH"' EXIT
+declare -x NVM_DIR=$INSTPATH
+\. ../../../nvm.sh
+
+nvm install --lts || die 'nvm install --lts failed'
+nvm exec --lts npm --version || die "`nvm exec` failed to run"
+declare -x NODE_VERSION="$(nvm exec --lts --silent node --version)"
+
+ln -s ../../../../nvm-exec "$INSTPATH/nvm-exec" || die "failed to create a symlink to $INSTPATH/"
+"$INSTPATH/nvm-exec" npm ls > /dev/null || die "`nvm exec` failed to run using nvm-exec helper"
+


### PR DESCRIPTION
This PR is a clone of #1845; updated and rebased onto the current master and into a repo not tied to an unrelated project.

The goal is to provide a central install of NVM that permits users to have their own `$NVM_DIR` where Node installs live but have NVM's core files live elsewhere.  It is still required that a user's `$NVM_DIR` be a directory where the current user has full access.

I'm actively using a setup like this throughout the infrastructure I manage and am testing this specific change on a CI server I control.  NVM, while not intending to be multi-user, actually works quite well outside of `nvm exec`, which this PR resolves.

I've made a few modifications from the original PR.  Namely:

* Simpler `DIR` determination in `nvm-exec`
* Applied a change recommended by @ljharb on the original PR
* Removed the `tar` flag changes since specific flag applied appears to be the default for all `tar`s I'm aware of and doesn't exist on OpenBSD's `tar`, as far as I could tell.

With the changes to the main `nvm` script, I've noticed that it's not even required to have `nvm-exec` symlinked into `$NVM_DIR` when executed as `nvm exec`.  This change could also allow for `nvm-exec` exec to be symlinked into a standard location for binaries (e.g. /usr/local/bin) to provide nvm-exec easily to system processes, though I haven't tested this personally.