### PR TITLE
Patch .bashrc extension snippet in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ cdnvm() {
 
     elif [[ -s $nvm_path/.nvmrc && -r $nvm_path/.nvmrc ]]; then
         declare nvm_version
-        nvm_version=$(<"$nvm_path"/.nvmrc)
+        nvm_version=$(<"$nvm_path"/.nvmrc | sed 's/^v//g')
 
         declare locally_resolved_nvm_version
         # `nvm ls` will check all locally-available versions


### PR DESCRIPTION
In the case of nvm 0.39.3, this patch fixes the message error:

«' not found - try `nvm ls-remote` to browse available versions.»

that occurs when cd'ing to a directory whose .nvmrc file contains a version starting with "v" - which is, in particular, the output of `node --version`.