### PR TITLE
[Perf] Improve performance of listing aliases

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1068,7 +1068,7 @@ nvm_list_aliases() {
 
   (
     local ALIAS_NAME
-    for ALIAS_NAME in "$(nvm_node_prefix)" "stable" "unstable"; do
+    for ALIAS_NAME in "$(nvm_node_prefix)" "stable" "unstable" "$(nvm_iojs_prefix)"; do
       {
         # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
         if [ ! -f "${NVM_ALIAS_DIR}/${ALIAS_NAME}" ] && { [ -z "${ALIAS}" ] || [ "${ALIAS_NAME}" = "${ALIAS}" ]; }; then
@@ -1077,11 +1077,6 @@ nvm_list_aliases() {
       } &
     done
     wait
-    ALIAS_NAME="$(nvm_iojs_prefix)"
-    # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
-    if [ ! -f "${NVM_ALIAS_DIR}/${ALIAS_NAME}" ] && { [ -z "${ALIAS}" ] || [ "${ALIAS_NAME}" = "${ALIAS}" ]; }; then
-      NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_CURRENT="${NVM_CURRENT}" nvm_print_default_alias "${ALIAS_NAME}"
-    fi
   ) | sort
 
   (
@@ -1376,9 +1371,10 @@ nvm_ls() {
 
   if [ "${NVM_ADD_SYSTEM-}" = true ]; then
     if [ -z "${PATTERN}" ] || [ "${PATTERN}" = 'v' ]; then
-      VERSIONS="${VERSIONS}$(command printf '\n%s' 'system')"
+      VERSIONS="${VERSIONS}
+system"
     elif [ "${PATTERN}" = 'system' ]; then
-      VERSIONS="$(command printf '%s' 'system')"
+      VERSIONS="system"
     fi
   fi
 


### PR DESCRIPTION
Fixes #3054

Depending on the run, these changes improve the speed of `npm ls` by anywhere from 5% to 30% depending on the run, though it seems to average around 10%. It's not as much as I would like, but it's something.

I can get much better performance if I modify `nvm_list_aliases` to only have one `wait` call and no `sort`. It may be worth adding an option `--unsorted` which does exactly this, but I'm not familiar enough with argument parsing in sh to implement this myself.