### PR TITLE
[Dockerfile] Update base image from Ubuntu 20.04 to 22.04, cc #2877

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Please note that it'll use about 1.2 GB disk space and about 15 minutes to
 # build this image, it depends on your hardware.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL maintainer="Peter Dave Hello <hsu@peterdavehello.org>"
 LABEL name="nvm-dev-env"
 LABEL version="latest"


### PR DESCRIPTION
Did some basic tests, besides old versions like node.js v12 will need python 2 to build from source, the other part looks good.