### PR TITLE
Fix directory traversal when workdir path is not readable

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -418,7 +418,7 @@ nvm_tree_contains_path() {
 nvm_find_project_dir() {
   local path_
   path_="${PWD}"
-  while [ "${path_}" != "" ] && [ ! -f "${path_}/package.json" ] && [ ! -d "${path_}/node_modules" ]; do
+  while [ "${path_}" != "" ] && [ "${path_}" != '.' ] && [ ! -f "${path_}/package.json" ] && [ ! -d "${path_}/node_modules" ]; do
     path_=${path_%/*}
   done
   nvm_echo "${path_}"
@@ -428,7 +428,7 @@ nvm_find_project_dir() {
 nvm_find_up() {
   local path_
   path_="${PWD}"
-  while [ "${path_}" != "" ] && [ ! -f "${path_}/${1-}" ]; do
+  while [ "${path_}" != "" ] && [ "${path_}" != '.' ] && [ ! -f "${path_}/${1-}" ]; do
     path_=${path_%/*}
   done
   nvm_echo "${path_}"

--- a/test/fast/Unit tests/nvm_find_project_dir
+++ b/test/fast/Unit tests/nvm_find_project_dir
@@ -31,3 +31,6 @@ ACTUAL="$(PWD=$TEST_DIR/no-nesting-n_m nvm_find_project_dir)"
 
 ACTUAL="$(PWD=$TEST_DIR/no-nesting-pkg nvm_find_project_dir)"
 [ "${ACTUAL}" = "$TEST_DIR/no-nesting-pkg" ] || die "no-nesting-pkg: got ${ACTUAL}"
+
+ACTUAL="$(PWD="." nvm_find_project_dir)"
+[ "${ACTUAL}" = "." ] || die "insufficient permissions for pwd: got ${ACTUAL}"

--- a/test/fast/Unit tests/nvm_find_up
+++ b/test/fast/Unit tests/nvm_find_up
@@ -21,5 +21,6 @@ TEST_DIR="$PWD"
 [ "~$(PWD=$TEST_DIR/tmp_nvm_find_up/a/b nvm_find_up 'test')" = "~$TEST_DIR/tmp_nvm_find_up" ] || die "failed to find 2 dirs up"
 [ "~$(PWD=$TEST_DIR/tmp_nvm_find_up/a/b/c nvm_find_up 'test')" = "~$TEST_DIR/tmp_nvm_find_up/a/b/c" ] || die "failed to find in current dir"
 [ "~$(PWD=$TEST_DIR/tmp_nvm_find_up/a/b/c/d nvm_find_up 'test')" = "~$TEST_DIR/tmp_nvm_find_up/a/b/c" ] || die "failed to find 1 level up from current dir"
+[ "~$(PWD="." nvm_find_up 'test')" = "~." ] || die "failed to handle '.' output from pwd"
 
 cleanup


### PR DESCRIPTION
This PR fixes an issue where `pwd` can return `"."` due to insufficient permissions, e.g. when switching users using the `su` command, which causes an infinite loop in the `nvm_find_project_dir` and `nvm_find_up` functions.