### PR TITLE
Add instructions on how to install without editing shell config

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Eg: `curl ... | NVM_DIR="path/to/nvm"`. Ensure that the `NVM_DIR` does not conta
 
 - The installer can use `git`, `curl`, or `wget` to download `nvm`, whichever is available.
 
+- You can instruct the installer to not edit your shell config (for example if you already get completions via a [zsh nvm plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/nvm)) by setting `PROFILE=/dev/null` before running the `install.sh` script. Here's an example one-line command to do that: `PROFILE=/dev/null bash -c 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash'`
+
 #### Troubleshooting on Linux
 
 On Linux, after running the install script, if you get `nvm: command not found` or see no feedback from your terminal after you type `command -v nvm`, simply close your current terminal, open a new terminal, and try verifying again.


### PR DESCRIPTION
I had to dig into https://github.com/nvm-sh/nvm/issues/2410 to learn about the `PROFILE=/dev/null` technique to install without appending to my shell config. Figured this note would be good to add in the main installation docs.

Also added a note on how to do this as a one-liner which was not obvious for me.