### PR TITLE
[Fix]: Fix NodeJS download link for armv8l

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1913,7 +1913,7 @@ nvm_get_arch() {
   case "${HOST_ARCH}" in
     x86_64 | amd64) NVM_ARCH="x64" ;;
     i*86) NVM_ARCH="x86" ;;
-    aarch64) NVM_ARCH="arm64" ;;
+    aarch64 | armv8l) NVM_ARCH="arm64" ;;
     *) NVM_ARCH="${HOST_ARCH}" ;;
   esac
 

--- a/test/fast/Unit tests/nvm_get_arch
+++ b/test/fast/Unit tests/nvm_get_arch
@@ -80,5 +80,6 @@ run_test x86 osx x86
 run_test amd64 osx x64
 
 run_test arm64 smartos x64
+run_test armv8l smartos x64
 
 cleanup

--- a/test/mocks/uname_linux_armv8l
+++ b/test/mocks/uname_linux_armv8l
@@ -1,0 +1,5 @@
+if [ "_$1" = "_-m" ]; then
+  echo "armv8l"
+else
+  echo "Linux 3.18.14-14721103 #1 SMP PREEMPT Thu Mar 5 20:35:37 KST 2020 armv8l armv8l armv8l GNU/Linux"
+fi


### PR DESCRIPTION
Fixes https://github.com/nvm-sh/nvm/issues/3035

I wasn't sure what would be the best solution. Right now, if `NVM_ARCH` is `armv8l`, it falls back to `armv7l` since `ARMv8` is backward compatible with `ARMv7`.

I think other approaches are

- Changing `aarch64) NVM_ARCH="arm64" ;;` pattern to  `aarch64 | armv8l) NVM_ARCH="arm64" ;;`. That way it would step into the following code block and also fall back to `armv7l`.
```
  # If running a 64bit ARM kernel but a 32bit ARM userland,
  # change ARCH to 32bit ARM (armv7l) if /sbin/init is 32bit executable
  if [ "$(uname)" = "Linux" ] \
    && ( [ "${NVM_ARCH}" = arm64 ] || [ "${NVM_ARCH}" = armv8l ] ) \
    && [ "$(command od -An -t x1 -j 4 -N 1 "/sbin/init" 2>/dev/null)" = ' 01' ]\
  ; then
    NVM_ARCH=armv7l
    HOST_ARCH=armv7l
  fi
```

- Instead of falling back to `armv7l`, create another if block to use `arm64`, something like
```
  if [ "$(uname)" = "Linux" ] \
    && [ "${NVM_ARCH}" = armv8l ] \
  ; then
    NVM_ARCH=arm64
    HOST_ARCH=arm64
  fi
```

Please let me know if you have any suggestions, feedback, or concerns!