### PR TITLE
[readme] fix typo in resolv.conf filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ This could simply be solved by running this in your root directory:
   sudo chattr +i /etc/resolv.conf
   ```
 
-This deletes your `resolve.conf` file thats automatically generated when u run WSL, creates a new file and puts `nameserver 8.8.8.8`, then creates a `wsl.conf` file and adds `[network]` and `generateResolveConf = false` to prevent auto generation of that file.
+This deletes your `resolv.conf` file thats automatically generated when u run WSL, creates a new file and puts `nameserver 8.8.8.8`, then creates a `wsl.conf` file and adds `[network]` and `generateResolveConf = false` to prevent auto generation of that file.
 
 You can check the contents of the file by running:
 


### PR DESCRIPTION
**PR Summary**:
The PR contains a fix to typo found it the `README.md` file. The `resolve.conf` file should be `resolv.conf`.