### PR TITLE
[Fix] `nvm_strip_path`: Preserve leading/trailing colons

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -823,7 +823,8 @@ nvm_strip_path() {
     path = substr($0, length(NVM_DIR) + 1)
     if (path ~ "^(/versions/[^/]*)?/[^/]*'"${2-}"'.*$") { next }
   }
-  { print }' | command paste -s -d: -
+  # The final RT will contain a colon if the input has a trailing colon, or a null string otherwise
+  { printf "%s%s", sep, $0; sep=RS } END { printf "%s", RT }'
 }
 
 nvm_change_path() {

--- a/test/fast/Unit tests/nvm_strip_path
+++ b/test/fast/Unit tests/nvm_strip_path
@@ -16,3 +16,9 @@ TEST_PATH="$NVM_DIR/v0.10.5/bin:/usr/bin:$NVM_DIR/v0.11.5/bin:$NVM_DIR/v0.9.5/bi
 STRIPPED_PATH=`nvm_strip_path "$TEST_PATH" "/bin"`
 
 [ "$STRIPPED_PATH" = "/usr/bin:/usr/local/bin" ] || die "Not correctly stripped: $STRIPPED_PATH "
+
+TEST_PATH=":/a/b/bin::/c/d/bin:"
+
+STRIPPED_PATH=`nvm_strip_path "$TEST_PATH" "/bin"`
+
+[ "$STRIPPED_PATH" = "$TEST_PATH" ] || die "Stripping does not preserve colons: $STRIPPED_PATH "


### PR DESCRIPTION
Preserve leading & trailing colons in awk invocation.