### PR TITLE
[readme] add examples of setting specific versions as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,9 @@ nvm deactivate
 To set a default Node version to be used in any new shell, use the alias 'default':
 
 ```sh
-nvm alias default node
+nvm alias default node # this refers to the latest installed version of node
+nvm alias default 18 # this refers to the latest installed v18.x version of node
+nvm alias default 18.12  # this refers to the latest installed v18.12.x version of node
 ```
 
 #### Use a mirror of node binaries


### PR DESCRIPTION

In numerous blog posts regarding the configuration of the default nodejs version using nvm, the following command is often cited:

```sh
nvm alias default node
```

While this command might work in some cases (as `node` will point to the latest version installed on your system), it might not behave as intended if you want to default to a specific version of Node.js. 

This command is actually referring to the [Set default node version](https://github.com/nvm-sh/nvm/blob/c6e35bae08ac4ea329c36aaaaf951b32a4612d80/README.md#set-default-node-version) section in the nvm's README. It's crucial to note that the instructions suggest setting a specific node version of your choosing, rather than using the generic `node`. 

So if you're aiming to set a particular version (for example, 14.15.1) as your default, the correct command would be:

```sh
nvm alias default 14.15.1
```

This ensures that the specified version of Node.js will be used by default. If you simply use `node` as in the first command, it could point to any installed version, which might not be what you intend.