### PR TITLE
[Fix] gracefully handle GNU tar on MacOS during `nvm install`

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -4325,7 +4325,11 @@ nvm_supports_xz() {
   if [ "_${NVM_OS}" = '_darwin' ]; then
     local MACOS_VERSION
     MACOS_VERSION="$(sw_vers -productVersion)"
-    if nvm_version_greater "10.9.0" "${MACOS_VERSION}"; then
+    if tar --version | command grep -q GNU && ! command which xz >/dev/null 2>&1; then
+      # On macOS with GNU tar in use, and no xv on the path, xv-compressed
+      # tarballs aren't supported
+      return 1
+    elif nvm_version_greater "10.9.0" "${MACOS_VERSION}"; then
       # macOS 10.8 and earlier doesn't support extracting xz-compressed tarballs with tar
       return 1
     fi


### PR DESCRIPTION
GNU tar doesn't support using the -J flag required to unpack xz-compressed tarballs when xv isn't installed. Check for this scenario and fallback to using gzip-compressed tarballs.

Fixes #3034