### PR TITLE
[Dockerfile] [Fix] add missing leading slash in path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN useradd -ms /bin/bash nvm
 
 # Copy and set permission for nvm directory
 COPY . /home/nvm/.nvm/
-RUN chown nvm:nvm -R "home/nvm/.nvm"
+RUN chown nvm:nvm -R "/home/nvm/.nvm"
 
 # Set sudoer for "nvm"
 RUN echo 'nvm ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers


### PR DESCRIPTION
Bug: missing `/home`
```
> [18/24] RUN chown nvm:nvm -R "home/nvm/.nvm":
0.467 chown: cannot access 'home/nvm/.nvm': No such file or directory
------
dockerfile:90