### PR TITLE
[readme] fix level of headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@
   - [Setting Custom Colors](#setting-custom-colors)
     - [Persisting custom colors](#persisting-custom-colors)
     - [Suppressing colorized output](#suppressing-colorized-output)
-    - [Restoring PATH](#restoring-path)
-    - [Set default node version](#set-default-node-version)
-    - [Use a mirror of node binaries](#use-a-mirror-of-node-binaries)
+  - [Restoring PATH](#restoring-path)
+  - [Set default node version](#set-default-node-version)
+  - [Use a mirror of node binaries](#use-a-mirror-of-node-binaries)
   - [.nvmrc](#nvmrc)
   - [Deeper Shell Integration](#deeper-shell-integration)
     - [bash](#bash)
@@ -488,14 +488,14 @@ nvm help --no-colors
 TERM=dumb nvm ls
 ```
 
-#### Restoring PATH
+### Restoring PATH
 To restore your PATH, you can deactivate it:
 
 ```sh
 nvm deactivate
 ```
 
-#### Set default node version
+### Set default node version
 To set a default Node version to be used in any new shell, use the alias 'default':
 
 ```sh
@@ -504,7 +504,7 @@ nvm alias default 18 # this refers to the latest installed v18.x version of node
 nvm alias default 18.12  # this refers to the latest installed v18.12.x version of node
 ```
 
-#### Use a mirror of node binaries
+### Use a mirror of node binaries
 To use a mirror of the node binaries, set `$NVM_NODEJS_ORG_MIRROR`:
 
 ```sh


### PR DESCRIPTION
This PR fixes the level of a few headings in the README file.

"Restoring PATH", "Set default node version", and "Use a mirror of node binaries" should not be subsections under the "Setting Custom Colors" section. The change will make the TOC easier to scan for readers.