### PR TITLE
[readme]: removing cdnvm command in readme for bashrc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ cdnvm() {
 }
 
 alias cd='cdnvm'
-cdnvm "$PWD" || exit
+
 ```
 
 This alias would search 'up' from your current directory in order to detect a `.nvmrc` file. If it finds it, it will switch to that version; if not, it will use the default version.


### PR DESCRIPTION
There is an uncessary `cdnvm "$PWD" || exit` taking place and not all the systems that have bash come with $PWD variable and it was uncessarly causing my terminal to shut down, so I thought I remove it as it is uncessary