### PR TITLE
Add nvm_get_arch overwrite

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1923,6 +1923,11 @@ nvm_get_arch() {
   local EXIT_CODE
   local LONG_BIT
 
+  if [ -n "$NVM_NODEJS_ORG_ARCH" ]; then
+    nvm_echo "${NVM_NODEJS_ORG_ARCH}"
+    return
+  fi
+
   NVM_OS="$(nvm_get_os)"
   # If the OS is SunOS, first try to use pkgsrc to guess
   # the most appropriate arch. If it's not available, use


### PR DESCRIPTION
Addresses https://github.com/nvm-sh/nvm/issues/3041

This bypasses the "guess" work for which "architecture" of node.js to use.

It was already possible to specify a custom mirror like mentioned here https://github.com/nvm-sh/nvm/issues/3175#issuecomment-1694759072, but without the ability to specify the suffix, its use cases are very limited.

One example for this addition is to use Node.js v18+ on centos7 which requires the glibc-217 compatible version. Now possible to install like this
`NVM_NODEJS_ORG_MIRROR=https://unofficial-builds.nodejs.org/download/release/ NVM_NODEJS_ORG_ARCH=x64-glibc-217 nvm install 18`

Before spending time on adding README, etc. what do you think of this approach?