### PR TITLE
remove unnecessary if block from nvm get artifact compression

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2239,8 +2239,6 @@ nvm_get_artifact_compression() {
   COMPRESSION='tar.gz'
   if [ "_${NVM_OS}" = '_win' ]; then
     COMPRESSION='zip'
-  elif nvm_supports_xz "${VERSION}"; then
-    COMPRESSION='tar.xz'
   fi
 
   nvm_echo "${COMPRESSION}"


### PR DESCRIPTION
## Changes
- Remove an unnecessary if block from the get_artifact_compression function. 

## Reasons
- Given that COMPRESSION is defaulted to tar.gz, we don't need to add another condition that assigns tar to the COMPRESSION variable.
- I have experienced issues with the condition of the removed if block on M2 max macbooks.