### PR TITLE
[actions] update action versions to use node 20

### DIFF
--- a/.github/workflows/latest-npm.yml
+++ b/.github/workflows/latest-npm.yml
@@ -9,11 +9,12 @@ jobs:
       latest: ${{ steps.set-matrix.outputs.requireds }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v1
+        uses: step-security/harden-runner@v2
         with:
           allowed-endpoints:
             iojs.org:443
             nodejs.org:443
+            raw.githubusercontent.com:443
       - uses: ljharb/actions/node/matrix@main
         id: set-matrix
         with:
@@ -46,7 +47,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v1
+        uses: step-security/harden-runner@v2
         with:
           allowed-endpoints:
             github.com:443
@@ -54,7 +55,7 @@ jobs:
             iojs.org:443
             nodejs.org:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ljharb/actions/node/install@main
         name: 'install node'
         with:
@@ -75,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v1
+        uses: step-security/harden-runner@v2
         with:
           egress-policy: block
       - run: 'echo tests completed'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,14 +8,14 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v1
+      - uses: step-security/harden-runner@v2
         with:
           allowed-endpoints:
             github.com:443
             raw.githubusercontent.com:443
             nodejs.org:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
@@ -27,7 +27,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v1
+      - uses: step-security/harden-runner@v2
         with:
           allowed-endpoints:
             ghcr.io:443
@@ -36,7 +36,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             nodejs.org:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
@@ -48,14 +48,14 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v1
+      - uses: step-security/harden-runner@v2
         with:
           allowed-endpoints:
             github.com:443
             raw.githubusercontent.com:443
             nodejs.org:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
@@ -67,11 +67,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v1
+      - uses: step-security/harden-runner@v2
         with:
           allowed-endpoints:
             github.com:443
             raw.githubusercontent.com:443
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: check tests filenames
         run: ./rename_test.sh --check

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@v1
+      uses: step-security/harden-runner@v2
       with:
         allowed-endpoints:
           api.github.com:443
           github.com:443
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ljharb/rebase@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v1
+        uses: step-security/harden-runner@v2
         with:
           allowed-endpoints:
             github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "14"
       - run: npm install

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@v1
+      uses: step-security/harden-runner@v2
       with:
         allowed-endpoints:
           api.github.com:443

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -27,13 +27,14 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v1
+        uses: step-security/harden-runner@v2
         with:
           allowed-endpoints:
             ghcr.io:443
             github.com:443
             pkg-containers.githubusercontent.com:443
-      - uses: actions/checkout@v3
+            formulae.brew.sh:443
+      - uses: actions/checkout@v4
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install latest shellcheck
@@ -52,7 +53,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Harden Runner
-          uses: step-security/harden-runner@v1
+          uses: step-security/harden-runner@v2
           with:
             egress-policy: block
         - run: 'echo tests completed'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v1
+        uses: step-security/harden-runner@v2
         with:
           allowed-endpoints:
             github.com:443
@@ -34,7 +34,7 @@ jobs:
             raw.githubusercontent.com:443
             nodejs.org:443
             iojs.org:443
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo ${{ matrix.shell }} --version 2> /dev/null || dpkg -s ${{ matrix.shell }} 2> /dev/null || which ${{ matrix.shell }}
       - run: curl --version
       - run: wget --version

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@v1
+      uses: step-security/harden-runner@v2
       with:
         allowed-endpoints:
           github.com:443
           registry.npmjs.org:443
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # https://github.com/actions/checkout/issues/217#issue-599945005
         # pulls all commits (needed for lerna / semantic release to correctly version)
@@ -25,7 +25,7 @@ jobs:
 
     # pulls all tags (needed for lerna / semantic release to correctly version)
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '16'
     - run: npm install


### PR DESCRIPTION
Resolve deprecation warnings, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/