### PR TITLE
fix: Do a version check on `nvm-exec`

### DIFF
--- a/nvm-exec
+++ b/nvm-exec
@@ -7,6 +7,7 @@ unset NVM_CD_FLAGS
 # shellcheck disable=SC1090,SC1091
 \. "$DIR/nvm.sh" --no-use
 
+nvm_rc_version > /dev/null && nvm_ensure_version_installed "$NVM_RC_VERSION";
 if [ -n "$NODE_VERSION" ]; then
   nvm use "$NODE_VERSION" > /dev/null || exit 127
 elif ! nvm use >/dev/null 2>&1; then


### PR DESCRIPTION
This check would display a message in case the `.nvmrc` version is not installed, and would not alter the output otherwise.

`nvm_ensure_version_installed` returns the message that we care for.
It requires an argument (version) against which to do the check, which we get after calling `nvm_rc_version`

Fixes: #1769 