### PR TITLE
Fall back to .node-version if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
   - [Set default node version](#set-default-node-version)
   - [Use a mirror of node binaries](#use-a-mirror-of-node-binaries)
   - [.nvmrc](#nvmrc)
+  - [.node-version](#node-version)
   - [Deeper Shell Integration](#deeper-shell-integration)
     - [Calling `nvm use` automatically in a directory with a `.nvmrc` file](#calling-nvm-use-automatically-in-a-directory-with-a-nvmrc-file)
       - [bash](#bash)
@@ -564,6 +565,14 @@ Now using node v5.9.1 (npm v3.7.3)
 `nvm use` et. al. will traverse directory structure upwards from the current directory looking for the `.nvmrc` file. In other words, running `nvm use` et. al. in any subdirectory of a directory with an `.nvmrc` will result in that `.nvmrc` being utilized.
 
 The contents of a `.nvmrc` file **must** be the `<version>` (as described by `nvm --help`) followed by a newline. No trailing spaces are allowed, and the trailing newline is required.
+
+### .node-version
+
+For a little compatability with other node version managers, nvm will also sniff for `.node-version` files. They're the same as `.nmvrc`, they just share a common name.
+
+$ echo "5.9" > .node-version
+
+They'll be loaded after `.nvmrc`, and can contain the same values as `.nvmrc`.
 
 ### Deeper Shell Integration
 

--- a/README.md
+++ b/README.md
@@ -568,11 +568,13 @@ The contents of a `.nvmrc` file **must** be the `<version>` (as described by `nv
 
 ### .node-version
 
-For a little compatability with other node version managers, nvm will also sniff for `.node-version` files. They're the same as `.nmvrc`, they just share a common name.
+For a little compatability with other node version managers, nvm will also sniff for `.node-version` files, defaulting to `.nvmrc` if both are found in the same folder.
 
+```
 $ echo "5.9" > .node-version
+```
 
-They'll be loaded after `.nvmrc`, and can contain the same values as `.nvmrc`.
+Unlike `.nvmrc`, `.node-version` cannot contain a "versionish" (an alias, like `node`, `iojs`, or a custom alias you’ve defined). `.node-version` can only have versions in the format of v1, v1.2, or v1.2.3 (the `v` is optional).
 
 ### Deeper Shell Integration
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -464,6 +464,11 @@ nvm_find_nvmrc() {
   dir="$(nvm_find_up '.nvmrc')"
   if [ -e "${dir}/.nvmrc" ]; then
     nvm_echo "${dir}/.nvmrc"
+  else
+    dir="$(nvm_find_up '.node-version')"
+    if [ -e "${dir}/.node-version" ]; then
+      nvm_echo "${dir}/.node-version"
+    fi
   fi
 }
 
@@ -474,14 +479,14 @@ nvm_rc_version() {
   NVMRC_PATH="$(nvm_find_nvmrc)"
   if [ ! -e "${NVMRC_PATH}" ]; then
     if [ "${NVM_SILENT:-0}" -ne 1 ]; then
-      nvm_err "No .nvmrc file found"
+      nvm_err "No .nvmrc or .node-version file found"
     fi
     return 1
   fi
   NVM_RC_VERSION="$(command head -n 1 "${NVMRC_PATH}" | command tr -d '\r')" || command printf ''
   if [ -z "${NVM_RC_VERSION}" ]; then
     if [ "${NVM_SILENT:-0}" -ne 1 ]; then
-      nvm_err "Warning: empty .nvmrc file found at \"${NVMRC_PATH}\""
+      nvm_err "Warning: empty nvm file found at \"${NVMRC_PATH}\""
     fi
     return 2
   fi

--- a/test/slow/nvm exec/setup_dir
+++ b/test/slow/nvm exec/setup_dir
@@ -8,3 +8,7 @@ nvm install --lts
 if [ -f ".nvmrc" ]; then
   mv .nvmrc .nvmrc.bak
 fi
+
+if [ -f ".node-version" ]; then
+  mv .node-version .node-version.bak
+fi

--- a/test/slow/nvm exec/teardown_dir
+++ b/test/slow/nvm exec/teardown_dir
@@ -7,7 +7,12 @@ nvm uninstall v1.0.0
 nvm uninstall --lts
 
 rm .nvmrc
+rm .node-version
 
 if [ -f ".nvmrc.bak" ]; then
   mv .nvmrc.bak .nvmrc
+fi
+
+if [ -f ".node-version.bak" ]; then
+  mv .node-version.bak .node-version
 fi

--- a/test/slow/nvm run/Running 'nvm run' should pick up .nvmrc version
+++ b/test/slow/nvm run/Running 'nvm run' should pick up .nvmrc version
@@ -12,6 +12,21 @@ echo "0.10.7" > .nvmrc
 [ "$(nvm run --version | head -1)" = "Found '$PWD/.nvmrc' with version <0.10.7>" ] || die "\`nvm run\` failed to print out the \"found in .nvmrc\" message"
 
 
+echo "0.12.0" > .node-version
+
+[ "$(nvm run --version | tail -1)" = "v0.10.7" ] || die "\`nvm run\` failed to run with the .nvmrc version"
+
+[ "$(nvm run --version | head -1)" = "Found '$PWD/.nvmrc' with version <0.10.7>" ] || die "\`nvm run\` failed to print out the \"found in .nvmrc\" message"
+
+rm .nvmrc
+
+[ "$(nvm run --version | tail -1)" = "v0.12.0" ] || die "\`nvm run\` failed to run with the .node-version version"
+
+[ "$(nvm run --version | head -1)" = "Found '$PWD/.node-version' with version <0.12.0>" ] || die "\`nvm run\` failed to print out the \"found in .node-version\" message"
+
+rm .node-version
+
+
 echo "foo" > .nvmrc
 
 # running nvm run with .nvmrc should not print the version information when not installed


### PR DESCRIPTION
Replaces #1625 which was abandoned.

Resolves #794.

I rebased the latest changes of the `master` branch and fixed an issue with the changes made to `nvm_find_up()`.