### PR TITLE
fix: "Unable to obtain node version." in git bash windows

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1273,7 +1273,7 @@ nvm_ls_current() {
     nvm_add_iojs_prefix "$(iojs --version 2>/dev/null)"
   elif nvm_tree_contains_path "${NVM_DIR}" "${NVM_LS_CURRENT_NODE_PATH}"; then
     local VERSION
-    VERSION="$(node --version 2>/dev/null)"
+    VERSION="$(command node --version 2>/dev/null)"
     if [ "${VERSION}" = "v0.6.21-pre" ]; then
       nvm_echo 'v0.6.21'
     else


### PR DESCRIPTION
```
$ nvm install-latest-npm
Attempting to upgrade to the latest working version of npm... Unable to obtain node version.
```

Fixes "Unable to obtain node version." error in git bash (for windows). running `npm --version` without `command` does not print anything to stdout.
running `nvm_echo "$(command where node)"` gives the windows path, like so: `C:\Users\user\portable_apps\.nvm\versions\node\v18.20.2\bin\node.exe`. It might be the cause.

Its a stretch, but this could also be related to #2780 