### PR TITLE
[meta] add DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,3 +113,11 @@ Co-authored-by: Name Here <email@here>
 
 # Where can I ask for help?
 If you have any questions, please contact [@LJHarb](mailto:ljharb@gmail.com).
+
+# Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+  - The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+  - The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+  - The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+  - I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.


### PR DESCRIPTION
imo this shouldn‘t be necessary, as it should be implied by the act of making a PR.

Following the example in https://github.com/expressjs/express/pull/6048

See https://github.com/openjs-foundation/project-status/issues/2