### PR TITLE
[Fix] `install.sh`: fix failing install tests from #3458

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: urchin tests
 
-on: [push]
+on: [push, pull_request]
 
 permissions:
   contents: read

--- a/install.sh
+++ b/install.sh
@@ -306,7 +306,7 @@ nvm_detect_profile() {
   if [ -z "$DETECTED_PROFILE" ]; then
     for EACH_PROFILE in ".profile" ".bashrc" ".bash_profile" ".zprofile" ".zshrc"
     do
-      if DETECTED_PROFILE="$(nvm_try_profile "${HOME}/${EACH_PROFILE}")"; then
+      if DETECTED_PROFILE="$(nvm_try_profile "${ZDOTDIR:-${HOME}}/${EACH_PROFILE}")"; then
         break
       fi
     done

--- a/test/install_script/nvm_detect_profile
+++ b/test/install_script/nvm_detect_profile
@@ -35,31 +35,31 @@ setup
 #
 
 # setting $PROFILE to /dev/null should return no detected profile
-NVM_DETECT_PROFILE="$(PROFILE='/dev/null'; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(PROFILE='/dev/null' nvm_detect_profile)"
 if [ -n "$NVM_DETECT_PROFILE" ]; then
   die "nvm_detect_profile still detected a profile even though PROFILE=/dev/null"
 fi
 
 # .bashrc should be detected for bash
-NVM_DETECT_PROFILE="$(SHELL="/bin/bash"; unset PROFILE; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL="/bin/bash" PROFILE= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.bashrc" ]; then
   die "nvm_detect_profile didn't pick \$HOME/.bashrc for bash"
 fi
 
 # $PROFILE should override .bashrc profile detection
-NVM_DETECT_PROFILE="$(SHELL="/bin/bash"; PROFILE="test_profile"; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL="/bin/bash" PROFILE="test_profile" nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "test_profile" ]; then
   die "nvm_detect_profile ignored \$PROFILE"
 fi
 
 # zdotdir/.zshrc should be detected for zsh
-NVM_DETECT_PROFILE="$(SHELL="/bin/zsh"; unset PROFILE; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL="/bin/zsh" PROFILE= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$ZDOTDIR/.zshrc" ]; then
   die "nvm_detect_profile didn't pick \$ZDOTDIR/.zshrc for zsh"
 fi
 
 # .zshrc should be detected for zsh
-NVM_DETECT_PROFILE="$(SHELL="/bin/zsh"; unset PROFILE; unset ZDOTDIR; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL="/bin/zsh" PROFILE= ZDOTDIR= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.zshrc" ]; then
   die "nvm_detect_profile didn't pick \$HOME/.zshrc for zsh"
 fi
@@ -75,7 +75,7 @@ fi
 #
 
 # $PROFILE is a valid file
-NVM_DETECT_PROFILE="$(PROFILE="test_profile"; unset SHELL; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(PROFILE="test_profile" SHELL= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "test_profile" ]; then
   die "nvm_detect_profile didn't pick \$PROFILE when it was a valid file"
 fi
@@ -94,56 +94,56 @@ fi
 #
 
 # It should favor .profile if file exists
-NVM_DETECT_PROFILE="$(unset SHELL; unset ZDOTDIR; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL= ZDOTDIR= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.profile" ]; then
   die "nvm_detect_profile should have selected .profile"
 fi
 
 # Otherwise, it should favor .bashrc if file exists
 rm ".profile"
-NVM_DETECT_PROFILE="$(unset SHELL; unset ZDOTDIR; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL= ZDOTDIR= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.bashrc" ]; then
   die "nvm_detect_profile should have selected .bashrc"
 fi
 
 # Otherwise, it should favor .bash_profile if file exists
 rm ".bashrc"
-NVM_DETECT_PROFILE="$(unset SHELL; unset ZDOTDIR; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL= ZDOTDIR= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.bash_profile" ]; then
   die "nvm_detect_profile should have selected .bash_profile"
 fi
 
 # Otherwise, it should favor zdotdir/.zprofile if file exists
 rm ".bash_profile"
-NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$ZDOTDIR/.zprofile" ]; then
   die "nvm_detect_profile should have selected zdotdir/.zprofile"
 fi
 
 # Otherwise, it should favor .zprofile if file exists
 rm "zdotdir/.zprofile"
-NVM_DETECT_PROFILE="$(unset SHELL; unset ZDOTDIR; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL= ZDOTDIR= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.zprofile" ]; then
   die "nvm_detect_profile should have selected .zprofile"
 fi
 
 # Otherwise, it should favor zdotdir/.zshrc if file exists
 rm ".zprofile"
-NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$ZDOTDIR/.zshrc" ]; then
   die "nvm_detect_profile should have selected zdotdir/.zshrc"
 fi
 
 # Otherwise, it should favor .zshrc if file exists
 rm "zdotdir/.zshrc"
-NVM_DETECT_PROFILE="$(unset SHELL; unset ZDOTDIR; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL= ZDOTDIR= nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.zshrc" ]; then
   die "nvm_detect_profile should have selected .zshrc"
 fi
 
 # It should be empty if none is found
 rm ".zshrc"
-NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(SHELL= nvm_detect_profile)"
 if [ ! -z "$NVM_DETECT_PROFILE" ]; then
   die "nvm_detect_profile should have returned an empty value"
 fi

--- a/test/install_script/nvm_detect_profile
+++ b/test/install_script/nvm_detect_profile
@@ -23,7 +23,7 @@ cleanup () {
   unset -f setup cleanup die
   unset ZDOTDIR
   rm -f ".bashrc" ".bash_profile" ".zprofile" ".zshrc" ".profile" "test_profile" > "/dev/null" 2>&1
-  rm -rf zdot>&1
+  rm -rf zdotdir 2>&1
 }
 
 die () { echo "$@" '$NVM_DETECT_PROFILE:' "$NVM_DETECT_PROFILE"; cleanup; exit 1; }
@@ -94,21 +94,21 @@ fi
 #
 
 # It should favor .profile if file exists
-NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(unset SHELL; unset ZDOTDIR; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.profile" ]; then
   die "nvm_detect_profile should have selected .profile"
 fi
 
 # Otherwise, it should favor .bashrc if file exists
 rm ".profile"
-NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(unset SHELL; unset ZDOTDIR; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.bashrc" ]; then
   die "nvm_detect_profile should have selected .bashrc"
 fi
 
 # Otherwise, it should favor .bash_profile if file exists
 rm ".bashrc"
-NVM_DETECT_PROFILE="$(unset SHELL; nvm_detect_profile)"
+NVM_DETECT_PROFILE="$(unset SHELL; unset ZDOTDIR; nvm_detect_profile)"
 if [ "$NVM_DETECT_PROFILE" != "$HOME/.bash_profile" ]; then
   die "nvm_detect_profile should have selected .bash_profile"
 fi


### PR DESCRIPTION
I just saw that you merged it and your message, it seems that the urchin tests aren't run until a commit is pushed - which is why we didn't catch the test failing. (So I added that as a separate PR #3466 - under the assumption that if you merge that first, we can run the test on this PR to ensure it fixes the issue)

This should address the failing tests. I missed the line for an unset $SHELL variable in `install.sh` - the rest of the PR is unsetting `$ZDOTDIR` for the other shells test (they will fail if it remains set). Local testing verifies this passes the urchin tests, though.