### PR TITLE
[Fix] nvm : Check if Node version is already active before switching

### DIFF
--- a/nvm-exec
+++ b/nvm-exec
@@ -8,6 +8,13 @@ unset NVM_CD_FLAGS
 \. "$DIR/nvm.sh" --no-use
 
 if [ -n "$NODE_VERSION" ]; then
+  CURRENT_VERSION=$(nvm current)
+
+  if [ "$CURRENT_VERSION" == "$NODE_VERSION" ]; then
+    echo "Node.js version $NODE_VERSION is already active."
+    exit 0
+  fi
+  
   nvm use "$NODE_VERSION" > /dev/null || exit 127
 elif ! nvm use >/dev/null 2>&1; then
   echo "No NODE_VERSION provided; no .nvmrc file found" >&2


### PR DESCRIPTION
### Description:
This PR adds a check to ensure that nvm doesn't attempt to switch to a Node.js version if it's already the active version. If the user tries to use a version that's already active, the script will print a message and skip the redundant operation, improving efficiency and user experience.

### Changes:
Added a check using nvm current to compare the currently active version with the requested version.
If the requested version is already active, it prints a message and exits without switching versions.

