### PR TITLE
fix: fix symlink creation under cygwin

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -3910,7 +3910,14 @@ nvm() {
       export NVM_BIN="${NVM_VERSION_DIR}/bin"
       export NVM_INC="${NVM_VERSION_DIR}/include/node"
       if [ "${NVM_SYMLINK_CURRENT-}" = true ]; then
-        command rm -f "${NVM_DIR}/current" && ln -s "${NVM_VERSION_DIR}" "${NVM_DIR}/current"
+        case "$(uname -s)" in
+          CYGWIN*|MINGW*|MINGW32*|MSYS*)
+            command rm -f "${NVM_DIR}/current" && cmd //C mklink //J "$(cygpath -w "${NVM_DIR}/current")" "$(cygpath -w "${NVM_VERSION_DIR}")"
+            ;;
+          *)
+            command rm -f "${NVM_DIR}/current" && ln -s "${NVM_VERSION_DIR}" "${NVM_DIR}/current"
+            ;;
+        esac
       fi
       local NVM_USE_OUTPUT
       NVM_USE_OUTPUT=''

--- a/nvm.sh
+++ b/nvm.sh
@@ -3912,7 +3912,7 @@ nvm() {
       if [ "${NVM_SYMLINK_CURRENT-}" = true ]; then
         case "$(uname -s)" in
           CYGWIN*|MINGW*|MINGW32*|MSYS*)
-            command rm -f "${NVM_DIR}/current" && cmd //C mklink //J "$(cygpath -w "${NVM_DIR}/current")" "$(cygpath -w "${NVM_VERSION_DIR}")"
+            command rm -rf "${NVM_DIR}/current" && cmd //C mklink //J "$(cygpath -w "${NVM_DIR}/current")" "$(cygpath -w "${NVM_VERSION_DIR}")" >/dev/null
             ;;
           *)
             command rm -f "${NVM_DIR}/current" && ln -s "${NVM_VERSION_DIR}" "${NVM_DIR}/current"


### PR DESCRIPTION
In `cygwin` environment `ln -s` works incorrectly and creates full copy instead of a symbolic link.
This patch fix this problem by using Windows `mklink` command to create directory junction.