### PR TITLE
fix: fix cygwin symlink

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,26 +10,26 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.txt]
-indent_size = false
+indent_size = unset
 
 [test/fast/Listing versions/Running 'nvm ls' calls into nvm_alias]
-indent_size = false
+indent_size = unset
 
 [test/fast/Listing versions/Running 'nvm ls --no-alias' does not call into nvm_alias]
-indent_size = false
+indent_size = unset
 
 [test/fast/Unit tests/mocks/**]
-insert_final_newline = off
+insert_final_newline = unset
 
 [test/**/.urchin*]
-insert_final_newline = off
+insert_final_newline = unset
 
 [Makefile]
 indent_style = tab
 
 [test/fixtures/nvmrc/**]
-indent_style = off
-insert_final_newline = off
+indent_style = unset
+insert_final_newline = unset
 
 [test/fixtures/actual/alias/empty]
-insert_final_newline = off
+insert_final_newline = unset

--- a/nvm.sh
+++ b/nvm.sh
@@ -3910,7 +3910,18 @@ nvm() {
       export NVM_BIN="${NVM_VERSION_DIR}/bin"
       export NVM_INC="${NVM_VERSION_DIR}/include/node"
       if [ "${NVM_SYMLINK_CURRENT-}" = true ]; then
-        command rm -f "${NVM_DIR}/current" && ln -s "${NVM_VERSION_DIR}" "${NVM_DIR}/current"
+        case "$(uname -s)" in
+          CYGWIN*|MINGW*|MSYS*)
+
+            # Windows cygwin
+            command rm -rf "${NVM_DIR}/current" && cmd //C mklink //J "$(cygpath -w "${NVM_DIR}/current")" "$(cygpath -w "${NVM_VERSION_DIR}")" >/dev/null
+            ;;
+          *)
+
+            # Linux or other environment
+            command rm -f "${NVM_DIR}/current" && ln -s "${NVM_VERSION_DIR}" "${NVM_DIR}/current"
+            ;;
+        esac
       fi
       local NVM_USE_OUTPUT
       NVM_USE_OUTPUT=''


### PR DESCRIPTION
Under `cygwin` environment `ln -s` works incorrectly and creates full copy instead of a symbolic link.
This patch fix this problem by using Windows `mklink` command to create directory junction.