### PR TITLE
Changed setting the architecture for Alpine to also work for arm64

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2116,7 +2116,7 @@ nvm_get_arch() {
   fi
 
   if [ -f "/etc/alpine-release" ]; then
-    NVM_ARCH=x64-musl
+    NVM_ARCH="${NVM_ARCH}-musl"
   fi
 
   nvm_echo "${NVM_ARCH}"


### PR DESCRIPTION
This fixes #3616 by not having the architecture hardcoded to `x64-musl`, but instead appending the `-musl` part to the architecture that was already found.
I am unable to supply tests, since the tarball I want to have loaded only exists on a private server. But the existing alpine-test should still work -- couldn't test this because the test would generally not run on my machine, probably because I am generally using nvm.