### PR TITLE
[Fix] install.sh: Force remote name of cloned repo to be 'origin'

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -163,7 +163,7 @@ install_nvm_from_git() {
       }
     else
       # Cloning repo
-      command git clone "$(nvm_source)" --depth=1 "${INSTALL_DIR}" || {
+      command git clone -o origin "$(nvm_source)" --depth=1 "${INSTALL_DIR}" || {
         nvm_echo >&2 'Failed to clone nvm repo. Please report this!'
         exit 2
       }


### PR DESCRIPTION
See the commit message(s) for details. (I avoid duplicating them here because the commit messages are being updated as we review.)

Feel free to change the commit message (or anything else) as necessary. The `[Fix]` prefix is not mentioned in the ["rest of the conventions"](https://gist.github.com/ljharb/772b0334387a4bee89af24183114b3c7) for commit messages, but seems to be what is used for similar things in previous commits.

This has been tested manually on my personal machine, where I use `clone.defaultRemoteName`. The automated tests against the current head of `master` (`make TEST_SUITE=fast test-bash`) had some issues for me, including what looked like spurious failures; I assume that this is just my configuration.

The CI tests below also appear to have unrelated issues, giving e.g. `sed: /etc/apt/sources.list: No such file or directory` on WSL.