### PR TITLE
Migrate GitHub Copilot instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# nvm Copilot Instructions
+# nvm Coding Agent Instructions
 
-This document provides guidance for GitHub Copilot when working with the Node Version Manager (nvm) codebase.
+This document provides guidance for AI coding agents when working with the Node Version Manager (nvm) codebase.
 
 ## Overview
 
@@ -424,4 +424,4 @@ nvm works on Windows via several compatibility layers:
 2. Include bash, curl, git, tar, and wget packages during installation
 3. Run nvm installation in Cygwin terminal
 
-This guide should help GitHub Copilot understand the nvm codebase structure, testing procedures, and development environment setup requirements.
+This guide should help AI coding agents understand the nvm codebase structure, testing procedures, and development environment setup requirements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Copilot coding agent now supports AGENTS.md custom instructions, as more coding agents support it. Migrating from GitHub Copilot's custom instructions file to AGENTS.md will help developers leverage more and different coding agents than just GitHub Copilot.

Reference:
- https://agents.md/
- https://github.blog/changelog/2025-08-28-copilot-coding-agent-now-supports-agents-md-custom-instructions/