### PR TITLE
[New] nvm.sh: add basic support for loongarch64 architecture

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2183,6 +2183,7 @@ nvm_get_arch() {
     x86_64 | amd64) NVM_ARCH="x64" ;;
     i*86) NVM_ARCH="x86" ;;
     aarch64 | armv8l) NVM_ARCH="arm64" ;;
+    loongarch64) NVM_ARCH="loong64" ;;
     *) NVM_ARCH="${HOST_ARCH}" ;;
   esac
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -2156,6 +2156,7 @@ nvm_get_arch() {
     x86_64 | amd64) NVM_ARCH="x64" ;;
     i*86) NVM_ARCH="x86" ;;
     aarch64 | armv8l) NVM_ARCH="arm64" ;;
+    loongarch64) NVM_ARCH="loong64" ;;
     *) NVM_ARCH="${HOST_ARCH}" ;;
   esac
 

--- a/test/fast/Unit tests/nvm_get_arch
+++ b/test/fast/Unit tests/nvm_get_arch
@@ -93,4 +93,6 @@ run_test amd64 osx x64
 run_test arm64 smartos x64
 run_test armv8l smartos x64
 
+run_test loongarch64 linux loong64
+
 cleanup

--- a/test/mocks/uname_linux_loongarch64
+++ b/test/mocks/uname_linux_loongarch64
@@ -1,0 +1,5 @@
+if [ "_$1" = "_-m" ]; then
+  echo "loongarch64"
+else
+  echo "Linux foo 6.12.54-16k #0 SMP PREEMPT_DYNAMIC Fri Dec  5 12:35:43 UTC loongarch64 GNU/Linux"
+fi


### PR DESCRIPTION
Like riscv64, LoongArch64 is also an experimental architecture on the Node platform list. Users can install Node.js from the unofficial builds website. However, the `uname -m` output for the LoongArch64 platform (i.e. `loongarch64`) differs from the identifier chosen by Node (i.e. `loong64`). Given that `loong64` is an abbreviation of `loongarch64`. This PR adds the necessary mapping for this. 

The following information may be useful:

- The output of `uname -m` on a LoongArch64 machine running Debian:

  ```shell
  elysia@elysia-loongson:~ (master =)$ uname -m
  loongarch64
  ```

- Platform list of Node.js: <https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list>

- An example link on the unofficial build website: <https://unofficial-builds.nodejs.org/download/release/v20.5.0/>

- Relationship between `loongarch64` and `loong64`: <https://areweloongyet.com/en/docs/loong-or-loongarch/>


