### PR TITLE
Set NVM_IOJS to false by default to fix unbound variable error

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -4000,7 +4000,7 @@ nvm() {
         fi
       fi
 
-      local NVM_IOJS
+      local NVM_IOJS=false
       if nvm_is_iojs_version "${VERSION}"; then
         NVM_IOJS=true
       fi


### PR DESCRIPTION
When calling `nvm run` from a bash script that has "Treat unset variables as an error when substituting." set using `set -u`, it triggers an unbound variable error:

```
Found '/home/user/path/.nvmrc' with version <23.11.1>
/home/user/.nvm/nvm.sh: line 4017: NVM_IOJS: unbound variable
```

Setting the variable to false by default fixes this issue.

Test:
```bash
minimal_test_for_nvm_bug() {
    export NVM_DIR="$HOME/.nvm"
    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
    echo "23.11.1" > .nvmrc
    set -u
    nvm run node -e 'console.log("NVM Test Successful")'
}

minimal_test_for_nvm_bug
```

Notes: Tests not run. No AI used in this PR (except for AI line-completion while editing, which surely everyone uses by now).