### PR TITLE
[Fix] `install`: use darwin-x64 for all binary on mac for node < v16

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2438,15 +2438,10 @@ nvm_get_download_slug() {
     fi
   fi
 
-  # If running MAC M1 :: Node v14.17.0 was the first version to offer official experimental support:
-  # https://github.com/nodejs/node/issues/40126 (although binary distributions aren't available until v16)
-  if \
-    nvm_version_greater '14.17.0' "${VERSION}" \
-    || (nvm_version_greater_than_or_equal_to "${VERSION}" '15.0.0' && nvm_version_greater '16.0.0' "${VERSION}") \
-  ; then
-    if [ "_${NVM_OS}" = '_darwin' ] && [ "${NVM_ARCH}" = 'arm64' ]; then
-      NVM_ARCH=x64
-    fi
+  # If running MAC M1 :: ARM64 binaries are not available for Node < 16.0.0
+  # https://github.com/nodejs/node/issues/40126 (binary distributions aren't available until v16)
+  if nvm_version_greater '16.0.0' "${VERSION}" && [ "_${NVM_OS}" = '_darwin' ] && [ "${NVM_ARCH}" = 'arm64' ]; then
+    NVM_ARCH=x64
   fi
 
   if [ "${KIND}" = 'binary' ]; then

--- a/test/fast/Unit tests/nvm_get_download_slug
+++ b/test/fast/Unit tests/nvm_get_download_slug
@@ -110,3 +110,26 @@ ACTUAL="$(nvm_get_download_slug iojs source 15.99.99)"
 EXPECTED="iojs-15.99.99"
 [ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
 
+
+REAL_OS="$(command uname -s 2>/dev/null || echo '')"
+REAL_ARCH="$(command uname -m 2>/dev/null || echo '')"
+if [ "${REAL_OS}" = "Darwin" ] && [ "${REAL_ARCH}" = "arm64" ]; then
+  # Node < 16 uses x64 on darwin-arm64
+  ACTUAL="$(nvm_get_download_slug node binary 14.21.3)"
+  EXPECTED='node-14.21.3-darwin-x64'
+  [ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+  ACTUAL="$(nvm_get_download_slug node binary 15.99.99)"
+  EXPECTED='node-15.99.99-darwin-x64'
+  [ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+  ACTUAL="$(nvm_get_download_slug iojs binary 15.99.99)"
+  EXPECTED='iojs-15.99.99-darwin-x64'
+  [ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+
+  # Test Node >= 16 uses arm64 on darwin-arm64
+  ACTUAL="$(nvm_get_download_slug node binary 16.0.0)"
+  EXPECTED='node-16.0.0-darwin-arm64'
+  [ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+  ACTUAL="$(nvm_get_download_slug node binary 18.0.0)"
+  EXPECTED='node-18.0.0-darwin-arm64'
+  [ "${ACTUAL}" = "${EXPECTED}" ] || die "expected >${EXPECTED}<, got >${ACTUAL}<"
+fi


### PR DESCRIPTION
This PR addresses the issue raised by https://github.com/nvm-sh/nvm/issues/3588

- For Node Version < 16.0.0 there are no amd64 binaries
- Due to Resotta 2, x64 binaries can be run on new Macs
- Existing logic was having an issue for node versions like 14.18.0, it looked for darwin-amd64 binaries
- This PR updates the existing logic to make a stricter check for all versions less than 16.0.0
- Added a few unit test cases to ensure that changes are behaving as expected.

```
> bash -c "source ./nvm.sh && nvm install 14.18.0"
Downloading and installing node v14.18.0...
Downloading https://nodejs.org/dist/v14.18.0/node-v14.18.0-darwin-x64.tar.xz...
######################################################################### 100.0%
Computing checksum with sha256sum
Checksums matched!
Now using node v14.18.0 (npm v6.14.15)
> uname -a 
Darwin Mac.lan 24.6.0 Darwin Kernel Version 24.6.0
```