### PR TITLE
[Fix] Reject bare LTS codenames in nvm install

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -781,6 +781,15 @@ nvm_remote_version() {
   else
     VERSION="$(NVM_LTS="${NVM_LTS-}" nvm_remote_versions "${PATTERN}" | command tail -1)"
   fi
+
+  if [ -n "${PATTERN}" ] && [ "_${VERSION}" != "_N/A" ] && ! nvm_validate_implicit_alias "${PATTERN}" 2>/dev/null; then
+    local VERSION_NUM
+    VERSION_NUM="$(nvm_echo "${VERSION}" | command awk '{print $1}')"
+    if ! nvm_echo "${VERSION_NUM}" | nvm_grep -q "${PATTERN}"; then
+      VERSION='N/A'
+    fi
+  fi
+
   if [ -n "${NVM_VERSION_ONLY-}" ]; then
     command awk 'BEGIN {
       n = split(ARGV[1], a);

--- a/test/fast/Unit tests/nvm_remote_version
+++ b/test/fast/Unit tests/nvm_remote_version
@@ -75,4 +75,24 @@ EXIT_CODE="$(nvm_remote_version node >/dev/null 2>&1 ; echo $?)"
   || die "nvm_remote_version node did not return contents of nvm_ls_remote node; got $OUTPUT"
 [ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version node did not exit with 0, got $EXIT_CODE"
 
+# Test LTS name rejection (Issue #3474)
+# When nvm_remote_versions returns a line with LTS name in description,
+# nvm_remote_version should reject it if the pattern doesn't match the version number
+
+nvm_remote_versions() {
+    echo "v4.9.1 Argon *"
+}
+OUTPUT="$(nvm_remote_version Argon)"
+EXIT_CODE="$(nvm_remote_version Argon >/dev/null 2>&1 ; echo $?)"
+[ "_$OUTPUT" = "_N/A" ] || die "nvm_remote_version Argon should return N/A (LTS name not in version), got $OUTPUT"
+[ "_$EXIT_CODE" = "_3" ] || die "nvm_remote_version Argon should exit with code 3, got $EXIT_CODE"
+
+nvm_remote_versions() {
+  echo "v4.9.1"
+}
+OUTPUT="$(nvm_remote_version 4)"
+EXIT_CODE="$(nvm_remote_version 4 >/dev/null 2>&1 ; echo $?)"
+[ "_$OUTPUT" = "_v4.9.1" ] || die "nvm_remote_version 4 should return v4.9.1, got $OUTPUT"
+[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version 4 should exit with code 0, got $EXIT_CODE"
+
 cleanup


### PR DESCRIPTION
## Problem
Users could run `nvm install Argon` (or any LTS codename) and it would install successfully, but `nvm uninstall Argon` would fail with "N/A version is not installed". This inconsistency was confusing.
**Root Cause:** [nvm_ls_remote](cci:1://file:///home/rahul/opensource/nvm/test/fast/Unit%20tests/nvm_remote_version:27:0-33:1) uses [grep](cci:1://file:///home/rahul/opensource/nvm/nvm.sh:43:0-45:1) which matches "Argon" in the description `v4.9.1 (Latest LTS: Argon)`, not just the version number.
## Solution
Added verification in [nvm_remote_version](cci:7://file:///home/rahul/opensource/nvm/test/fast/Unit%20tests/nvm_remote_version:0:0-0:0) to check if the search pattern actually exists in the version number (not just the description).
## Changes
- **nvm.sh (lines 785-791)**: Added pattern verification logic
- **test/fast/Unit tests/nvm_remote_version**: Added tests for LTS name rejection
## Behavior Changes
| Command | Before | After |
|---------|--------|-------|
| `nvm install Argon` | ✅ Installs v4.9.1 | ❌ Fails: "Version 'Argon' not found" |
| `nvm uninstall Argon` | ❌ Fails | ❌ Fails (consistent now) |
| `nvm install lts/argon` | ✅ Works | ✅ Works |
| `nvm install 4` | ✅ Works | ✅ Works |
| `nvm install node` | ✅ Works | ✅ Works |
## Testing
- ✅ Added unit tests for LTS name rejection
- ✅ Added regression tests for version numbers
- ✅ Manually verified with `nvm install Argon`, `nvm install 4`, `nvm install node`
Fixes #3474