### PR TITLE
[actions] update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/latest-npm.yml
+++ b/.github/workflows/latest-npm.yml
@@ -63,7 +63,7 @@ jobs:
             iojs.org:443
             nodejs.org:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ljharb/actions/node/install@main
         name: 'install node'
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
             raw.githubusercontent.com:443
             nodejs.org:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
@@ -35,7 +35,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             nodejs.org:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
@@ -52,7 +52,7 @@ jobs:
             raw.githubusercontent.com:443
             nodejs.org:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
@@ -67,6 +67,6 @@ jobs:
           allowed-endpoints:
             github.com:443
             raw.githubusercontent.com:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: check tests filenames
         run: ./rename_test.sh --check

--- a/.github/workflows/nvm-install-test.yml
+++ b/.github/workflows/nvm-install-test.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - id: matrix
@@ -55,7 +55,7 @@ jobs:
           - 2 shlvls
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: resolve HEAD to sha
         run: |
           if [ '${{ matrix.ref }}' = 'HEAD' ]; then

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ljharb/rebase@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
             raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             registry.npmjs.org:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-tags: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "14"
       - run: npm install

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -35,7 +35,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             formulae.brew.sh:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install latest shellcheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
             iojs.org:443
             azure.archive.ubuntu.com:80
             packages.microsoft.com:443
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: sudo apt-get update; sudo apt-get install ${{ matrix.shell }}
         if: matrix.shell == 'zsh' || matrix.shell == 'ksh'
         # zsh (https://github.com/actions/runner-images/issues/264) and ksh are not in the ubuntu image

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -21,7 +21,7 @@ jobs:
           github.com:443
           registry.npmjs.org:443
           api.github.com:443
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # https://github.com/actions/checkout/issues/217#issue-599945005
         # pulls all commits (needed for lerna / semantic release to correctly version)
@@ -29,7 +29,7 @@ jobs:
 
     # pulls all tags (needed for lerna / semantic release to correctly version)
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 'lts/*'
     - run: npm install


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/latest-npm.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/toc.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/nvm-install-test.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/tests.yml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/rebase.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/toc.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/lint.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/shellcheck.yml`
