### PR TITLE
Improve uninstall error message for missing versions

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -3750,7 +3750,13 @@ nvm() {
       fi
 
       if ! nvm_is_version_installed "${VERSION}"; then
-        nvm_err "${VERSION} version is not installed..."
+        local REQUESTED_VERSION
+        REQUESTED_VERSION="${PATTERN}"
+        if [ "_${VERSION}" != "_N/A" ] && [ "_${VERSION}" != "_${PATTERN}" ]; then
+          nvm_err "Version '${VERSION}' (inferred from ${PATTERN}) is not installed."
+        else
+          nvm_err "Version '${REQUESTED_VERSION}' is not installed."
+        fi
         return
       fi
 

--- a/test/fast/Running 'nvm uninstall' with an inferred version shows the inferred message
+++ b/test/fast/Running 'nvm uninstall' with an inferred version shows the inferred message
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -ex
+
+\. ../../nvm.sh
+\. ../common.sh
+
+VERSION='v0.0.1'
+PATTERN='0.0'
+
+mkdir -p "${NVM_DIR}/${VERSION}"
+
+set +ex # needed for stderr
+RETURN_MESSAGE="$(nvm uninstall "${PATTERN}" 2>&1 || echo)"
+set -ex
+EXPECTED_MESSAGE="Version '${VERSION}' (inferred from ${PATTERN}) is not installed."
+
+[ "${RETURN_MESSAGE}" = "${EXPECTED_MESSAGE}" ]

--- a/test/fast/Running 'nvm uninstall' with an uninstalled version shows the requested version
+++ b/test/fast/Running 'nvm uninstall' with an uninstalled version shows the requested version
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+\. ../../nvm.sh
+\. ../common.sh
+
+set +ex # needed for stderr
+RETURN_MESSAGE="$(nvm uninstall 22 2>&1 || echo)"
+set -ex
+EXPECTED_MESSAGE="Version '22' is not installed."
+
+[ "${RETURN_MESSAGE}" = "${EXPECTED_MESSAGE}" ]

--- a/test/fast/Running 'nvm-exec' should display required node version
+++ b/test/fast/Running 'nvm-exec' should display required node version
@@ -5,7 +5,6 @@ set -x
 \. ../../nvm.sh
 
 cleanup() { rm -f .nvmrc; }
-
 die () { echo "$@" ; cleanup ; exit 1; }
 
 NVM_TEST_VERSION=v0.42


### PR DESCRIPTION
Include the requested version in the uninstall error output when the target is not installed.

Add a fast test to lock the behavior.

Close #3767

GitHub Copilot summary:

> This pull request improves the error messaging in `nvm.sh` when attempting to uninstall a Node version that is not installed. It also adds a new test to verify the updated error message behavior.
> 
> **Error handling improvements:**
> 
> * Improved the error message in the `nvm()` function in `nvm.sh` to specify the requested version more clearly when an uninstall is attempted for a version that is not installed. Now, if the inferred version differs from the requested pattern, the message indicates which version was inferred; otherwise, it states the requested version is not installed.
> 
> **Testing:**
> 
> * Added a new test script `test/fast/Running 'nvm uninstall' with an uninstalled version shows the requested version` to ensure that uninstalling a non-installed version returns the correct error message.