### PR TITLE
Add `nvm prune` command to clean up old versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
   - [io.js](#iojs)
   - [System Version of Node](#system-version-of-node)
   - [Listing Versions](#listing-versions)
+  - [Pruning old versions](#pruning-old-versions)
   - [Setting Custom Colors](#setting-custom-colors)
     - [Persisting custom colors](#persisting-custom-colors)
     - [Suppressing colorized output](#suppressing-colorized-output)
@@ -552,6 +553,21 @@ If you want to see what versions are available to install:
 ```sh
 nvm ls-remote
 ```
+
+### Pruning old versions
+
+To clean up old, unused Node.js versions, use `nvm prune`:
+
+```sh
+nvm prune
+```
+
+This will uninstall all installed versions except for the latest one within each major version group (e.g., if you have `v16.1.0` and `v16.2.0`, it will keep `v16.2.0`).
+
+- **Safety**: The currently active version is **never** removed, even if it is not the latest in its group.
+- **Global Modules**: `nvm prune` will warn you if it's about to uninstall a version that contains global npm modules (other than `npm` itself).
+- **Preview**: Use `nvm prune --dry-run` to see which versions would be removed without actually uninstalling them.
+- **Minor Version Retention**: Use `nvm prune --minor` to keep the latest version of each **minor** release group instead of major.
 
 ### Setting Custom Colors
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -1721,13 +1721,13 @@ END"
 
       for V in ${GROUP_VERSIONS}; do
         if [ "${V}" = "${LATEST_IN_GROUP}" ]; then
-           # It's the latest, keep it
-           # nvm_echo "Keeping latest: ${V}"
-           continue
+          # It's the latest, keep it
+          # nvm_echo "Keeping latest: ${V}"
+          continue
         fi
         if [ "${V}" = "${CURRENT_VERSION}" ]; then
-           nvm_echo "Keeping current version: ${V}"
-           continue
+          nvm_echo "Keeping current version: ${V}"
+          continue
         fi
 
         # Prune V
@@ -1738,10 +1738,10 @@ END"
           nvm uninstall "${V}" >/dev/null
         fi
       done
-      
+
       GROUP_VERSIONS=""
     fi
-    
+
     if [ "${VERSION}" = "END" ]; then
       break
     fi

--- a/nvm.sh
+++ b/nvm.sh
@@ -1689,11 +1689,11 @@ nvm_prune() {
 
   local VERSIONS
   if [ "${HAS_SORT_V}" -eq 1 ]; then
-    VERSIONS="$(nvm_ls --no-colors --no-alias | command awk "${AWK_CMD}" | command sort -V)"
+    VERSIONS="$(nvm_ls | command awk "${AWK_CMD}" | command sort -V)"
   else
     # Fallback to numeric sort on fields roughly for POSIX compliance
     # v1.2.3 -> field 1 (1.2n ignores 'v'), field 2, field 3
-    VERSIONS="$(nvm_ls --no-colors --no-alias | command awk "${AWK_CMD}" | command sort -t. -k 1.2,1n -k 2,2n -k 3,3n)"
+    VERSIONS="$(nvm_ls | command awk "${AWK_CMD}" | command sort -t. -k 1.2,1n -k 2,2n -k 3,3n)"
   fi
 
   if [ -z "${VERSIONS}" ]; then

--- a/nvm.sh
+++ b/nvm.sh
@@ -4812,6 +4812,7 @@ nvm() {
         nvm_get_artifact_compression nvm_install_binary_extract nvm_extract_tarball \
         nvm_process_nvmrc nvm_nvmrc_invalid_msg \
         nvm_write_nvmrc \
+        nvm_prune \
         >/dev/null 2>&1
       unset NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR NVM_DIR \
         NVM_CD_FLAGS NVM_BIN NVM_INC NVM_MAKE_JOBS \

--- a/nvm.sh
+++ b/nvm.sh
@@ -1698,7 +1698,12 @@ nvm_prune() {
   VERSIONS="${VERSIONS}
 END"
 
-  nvm_echo "${VERSIONS}" | while read -r VERSION; do
+  local IFS
+  IFS='
+'
+  # shellcheck disable=SC2013
+  for VERSION in ${VERSIONS}; do
+    unset IFS
     local MAJOR
     MAJOR=""
     if [ "${VERSION}" != "END" ] && [ -n "${VERSION}" ]; then

--- a/nvm.sh
+++ b/nvm.sh
@@ -1648,11 +1648,16 @@ nvm_ls_remote() {
 nvm_prune() {
   local NVM_DRY_RUN
   NVM_DRY_RUN=0
+  local KEEP_MINOR
+  KEEP_MINOR=0
   local ARG
   for ARG in "$@"; do
     case "${ARG}" in
       --dry-run)
         NVM_DRY_RUN=1
+        ;;
+      --minor)
+        KEEP_MINOR=1
         ;;
       *)
         nvm_err "Unknown argument: ${ARG}"
@@ -1666,25 +1671,39 @@ nvm_prune() {
     nvm_echo "Dry run mode: no versions will be removed."
   fi
 
-  local SORT_COMMAND
+  local HAS_SORT_V
+  HAS_SORT_V=0
   if command sort -V </dev/null >/dev/null 2>&1; then
-    SORT_COMMAND='command sort -V'
+    HAS_SORT_V=1
+  fi
+
+  local AWK_CMD
+  AWK_CMD='{
+    for(i=1;i<=NF;i++) {
+      if ($i ~ /^(iojs-)?v[0-9]+\.[0-9]+\.[0-9]+$/) {
+        sub(/^iojs-/, "", $i)
+        print $i
+      }
+    }
+  }'
+
+  local VERSIONS
+  if [ "${HAS_SORT_V}" -eq 1 ]; then
+    VERSIONS="$(nvm_ls --no-colors --no-alias | command awk "${AWK_CMD}" | command sort -V)"
   else
     # Fallback to numeric sort on fields roughly for POSIX compliance
     # v1.2.3 -> field 1 (1.2n ignores 'v'), field 2, field 3
-    SORT_COMMAND='command sort -t. -k 1.2,1n -k 2,2n -k 3,3n'
+    VERSIONS="$(nvm_ls --no-colors --no-alias | command awk "${AWK_CMD}" | command sort -t. -k 1.2,1n -k 2,2n -k 3,3n)"
   fi
-
-  local VERSIONS
-  VERSIONS="$(nvm_ls --no-colors --no-alias | nvm_grep -v "iojs" | command awk '{ for(i=1;i<=NF;i++) if($i ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/) print $i }' | $SORT_COMMAND)"
 
   if [ -z "${VERSIONS}" ]; then
     nvm_echo "No versions installed to prune."
     return 0
   fi
 
+  # Ensure the current version is stripped of iojs prefix to match our clean list
   local CURRENT_VERSION
-  CURRENT_VERSION="$(nvm_ls_current)"
+  CURRENT_VERSION="$(nvm_strip_iojs_prefix "$(nvm_ls_current)")"
   if [ "${CURRENT_VERSION}" = "system" ] || [ "${CURRENT_VERSION}" = "none" ]; then
     CURRENT_VERSION=""
   fi
@@ -1707,7 +1726,11 @@ END"
     local MAJOR
     MAJOR=""
     if [ "${VERSION}" != "END" ] && [ -n "${VERSION}" ]; then
-      MAJOR="$(nvm_echo "${VERSION}" | command cut -d. -f1)"
+      if [ "${KEEP_MINOR}" -eq 1 ]; then
+        MAJOR="$(nvm_echo "${VERSION}" | command cut -d. -f1,2)"
+      else
+        MAJOR="$(nvm_echo "${VERSION}" | command cut -d. -f1)"
+      fi
     fi
 
     if [ "${MAJOR}" != "${PREV_MAJOR}" ] && [ -n "${PREV_MAJOR}" ]; then
@@ -1730,12 +1753,38 @@ END"
           continue
         fi
 
+        # Re-resolve if the version is actually iojs
+        local UNINSTALL_V
+        UNINSTALL_V="${V}"
+        if ! nvm_is_version_installed "${UNINSTALL_V}" >/dev/null 2>&1; then
+          UNINSTALL_V="$(nvm_add_iojs_prefix "${V}")"
+        fi
+
+        # Check for global npm modules explicitly
+        local NODE_MODULES_DIR
+        NODE_MODULES_DIR="$(nvm_version_path "${UNINSTALL_V}")/lib/node_modules"
+        local HAS_GLOBALS
+        HAS_GLOBALS=0
+        if [ -d "${NODE_MODULES_DIR}" ]; then
+          local NUM_GLOBALS
+          NUM_GLOBALS="$(command ls -1 "${NODE_MODULES_DIR}" 2>/dev/null | nvm_grep -v '^npm$' | command wc -l | command awk '{print $1}')"
+          if [ "${NUM_GLOBALS}" -gt 0 ]; then
+            HAS_GLOBALS="${NUM_GLOBALS}"
+          fi
+        fi
+
+        local MSG_SUFFIX
+        MSG_SUFFIX=""
+        if [ "${HAS_GLOBALS}" -gt 0 ]; then
+          MSG_SUFFIX=" (Warning: replacing ${HAS_GLOBALS} global module(s))"
+        fi
+
         # Prune V
         if [ "${NVM_DRY_RUN}" -eq 1 ]; then
-          nvm_echo "[Dry Run] Uninstalling ${V}..."
+          nvm_echo "[Dry Run] Uninstalling ${UNINSTALL_V}...${MSG_SUFFIX}"
         else
-          nvm_echo "Uninstalling ${V}..."
-          nvm uninstall "${V}" >/dev/null
+          nvm_echo "Uninstalling ${UNINSTALL_V}...${MSG_SUFFIX}"
+          nvm uninstall "${UNINSTALL_V}" >/dev/null
         fi
       done
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -3376,6 +3376,7 @@ nvm() {
         nvm_echo '  nvm uninstall --lts=<LTS name>              Uninstall using automatic alias for provided LTS line, if available.'
         nvm_echo '  nvm prune                                   Uninstall all versions except the latest one for each major version.'
         nvm_echo '    --dry-run                                 Preview deletions without executing them.'
+        nvm_echo '    --minor                                   Uninstall all versions except the latest one for each minor version.'
         nvm_echo '  nvm use [<version>]                         Modify PATH to use <version>. Uses .nvmrc if available and version is omitted.'
         nvm_echo '   The following optional arguments, if provided, must appear directly after `nvm use`:'
         nvm_echo '    --silent                                  Silences stdout/stderr output'

--- a/nvm.sh
+++ b/nvm.sh
@@ -1717,6 +1717,7 @@ nvm_prune() {
   VERSIONS="${VERSIONS}
 END"
 
+  nvm_is_zsh && setopt local_options shwordsplit
   local IFS
   IFS='
 '

--- a/nvm.sh
+++ b/nvm.sh
@@ -1666,9 +1666,11 @@ nvm_prune() {
     esac
   done
 
-  nvm_echo "Pruning old installed versions..."
-  if [ "${NVM_DRY_RUN}" -eq 1 ]; then
-    nvm_echo "Dry run mode: no versions will be removed."
+  if [ "${NVM_DEBUG-}" = 1 ]; then
+    nvm_echo "Pruning old installed versions..."
+    if [ "${NVM_DRY_RUN}" -eq 1 ]; then
+      nvm_echo "Dry run mode: no versions will be removed."
+    fi
   fi
 
   local HAS_SORT_V
@@ -1750,7 +1752,9 @@ END"
           continue
         fi
         if [ "${V}" = "${CURRENT_VERSION}" ]; then
-          nvm_echo "Keeping current version: ${V}"
+          if [ "${NVM_DEBUG-}" = 1 ]; then
+            nvm_echo "Keeping current version: ${V}"
+          fi
           continue
         fi
 
@@ -1758,7 +1762,15 @@ END"
         local UNINSTALL_V
         UNINSTALL_V="${V}"
         if ! nvm_is_version_installed "${UNINSTALL_V}" >/dev/null 2>&1; then
-          UNINSTALL_V="$(nvm_add_iojs_prefix "${V}")"
+          local IOJS_V
+          IOJS_V="$(nvm_add_iojs_prefix "${V}")"
+          if nvm_is_version_installed "${IOJS_V}" >/dev/null 2>&1; then
+            UNINSTALL_V="${IOJS_V}"
+          fi
+        fi
+
+        if ! nvm_is_version_installed "${UNINSTALL_V}" >/dev/null 2>&1; then
+          continue
         fi
 
         # Check for global npm modules explicitly

--- a/nvm.sh
+++ b/nvm.sh
@@ -1645,6 +1645,109 @@ nvm_ls_remote() {
   NVM_LTS="${NVM_LTS-}" nvm_ls_remote_index_tab node std "${PATTERN}"
 }
 
+nvm_prune() {
+  local NVM_DRY_RUN
+  NVM_DRY_RUN=0
+  local ARG
+  for ARG in "$@"; do
+    case "${ARG}" in
+      --dry-run)
+        NVM_DRY_RUN=1
+        ;;
+      *)
+        nvm_err "Unknown argument: ${ARG}"
+        return 127
+        ;;
+    esac
+  done
+
+  nvm_echo "Pruning old installed versions..."
+  if [ "${NVM_DRY_RUN}" -eq 1 ]; then
+    nvm_echo "Dry run mode: no versions will be removed."
+  fi
+
+  local SORT_COMMAND
+  if command sort -V </dev/null >/dev/null 2>&1; then
+    SORT_COMMAND='command sort -V'
+  else
+    # Fallback to numeric sort on fields roughly for POSIX compliance
+    # v1.2.3 -> field 1 (1.2n ignores 'v'), field 2, field 3
+    SORT_COMMAND='command sort -t. -k 1.2,1n -k 2,2n -k 3,3n'
+  fi
+
+  local VERSIONS
+  VERSIONS="$(nvm_ls --no-colors --no-alias | nvm_grep -v "iojs" | command awk '{ for(i=1;i<=NF;i++) if($i ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/) print $i }' | $SORT_COMMAND)"
+
+  if [ -z "${VERSIONS}" ]; then
+    nvm_echo "No versions installed to prune."
+    return 0
+  fi
+
+  local CURRENT_VERSION
+  CURRENT_VERSION="$(nvm_ls_current)"
+  if [ "${CURRENT_VERSION}" = "system" ] || [ "${CURRENT_VERSION}" = "none" ]; then
+    CURRENT_VERSION=""
+  fi
+
+  local PREV_MAJOR
+  PREV_MAJOR=""
+  local GROUP_VERSIONS
+  GROUP_VERSIONS=""
+
+  # Append a dummy line to flush the last group
+  VERSIONS="${VERSIONS}
+END"
+
+  nvm_echo "${VERSIONS}" | while read -r VERSION; do
+    local MAJOR
+    MAJOR=""
+    if [ "${VERSION}" != "END" ] && [ -n "${VERSION}" ]; then
+      MAJOR="$(nvm_echo "${VERSION}" | command cut -d. -f1)"
+    fi
+
+    if [ "${MAJOR}" != "${PREV_MAJOR}" ] && [ -n "${PREV_MAJOR}" ]; then
+      # Process previous group
+      local LATEST_IN_GROUP
+      # Get the last word in GROUP_VERSIONS
+      LATEST_IN_GROUP=""
+      for V in ${GROUP_VERSIONS}; do
+        LATEST_IN_GROUP="${V}"
+      done
+
+      for V in ${GROUP_VERSIONS}; do
+        if [ "${V}" = "${LATEST_IN_GROUP}" ]; then
+           # It's the latest, keep it
+           # nvm_echo "Keeping latest: ${V}"
+           continue
+        fi
+        if [ "${V}" = "${CURRENT_VERSION}" ]; then
+           nvm_echo "Keeping current version: ${V}"
+           continue
+        fi
+
+        # Prune V
+        if [ "${NVM_DRY_RUN}" -eq 1 ]; then
+          nvm_echo "[Dry Run] Uninstalling ${V}..."
+        else
+          nvm_echo "Uninstalling ${V}..."
+          nvm uninstall "${V}" >/dev/null
+        fi
+      done
+      
+      GROUP_VERSIONS=""
+    fi
+    
+    if [ "${VERSION}" = "END" ]; then
+      break
+    fi
+
+    if [ -n "${VERSION}" ]; then
+      PREV_MAJOR="${MAJOR}"
+      GROUP_VERSIONS="${GROUP_VERSIONS} ${VERSION}"
+    fi
+  done
+}
+
 nvm_ls_remote_iojs() {
   NVM_LTS="${NVM_LTS-}" nvm_ls_remote_index_tab iojs std "${1-}"
 }
@@ -3217,6 +3320,8 @@ nvm() {
         nvm_echo '  nvm uninstall <version>                     Uninstall a version'
         nvm_echo '  nvm uninstall --lts                         Uninstall using automatic LTS (long-term support) alias `lts/*`, if available.'
         nvm_echo '  nvm uninstall --lts=<LTS name>              Uninstall using automatic alias for provided LTS line, if available.'
+        nvm_echo '  nvm prune                                   Uninstall all versions except the latest one for each major version.'
+        nvm_echo '    --dry-run                                 Preview deletions without executing them.'
         nvm_echo '  nvm use [<version>]                         Modify PATH to use <version>. Uses .nvmrc if available and version is omitted.'
         nvm_echo '   The following optional arguments, if provided, must appear directly after `nvm use`:'
         nvm_echo '    --silent                                  Silences stdout/stderr output'
@@ -3913,6 +4018,9 @@ nvm() {
       for ALIAS in $(nvm_grep -l "${VERSION}" "$(nvm_alias_path)"/* 2>/dev/null); do
         nvm unalias "$(command basename "${ALIAS}")"
       done
+    ;;
+    "prune")
+      nvm_prune "$@"
     ;;
     "deactivate")
       local NVM_SILENT

--- a/test/fast/Running 'nvm prune' should remove old versions
+++ b/test/fast/Running 'nvm prune' should remove old versions
@@ -1,0 +1,92 @@
+#!/bin/sh
+
+# Test: Running 'nvm prune' should remove old versions
+
+die () { echo "$@" ; exit 1; }
+
+# Mocking nvm_ls output logic relies on nvm_ls calling directory listing.
+# Instead of mocking filesystem which is complex, we will override nvm_ls and nvm_ls_current.
+
+. ../../nvm.sh
+
+# Mock nvm_ls to return specific versions as if they were installed
+# The implementation of nvm_prune calls: nvm_ls --no-colors --no-alias
+# We must mock nvm_ls to respond to that or just return the list.
+# Note: nvm_prune strips output except vX.Y.Z.
+nvm_ls() {
+  echo "       v16.20.2"
+  echo "       v18.20.5"
+  echo "       v18.20.7"
+  echo "       v20.17.0"
+  echo "->     v22.22.0"
+  echo "       v24.13.0"
+}
+
+# Mock nvm_ls_current
+nvm_ls_current() {
+  echo "v22.22.0"
+}
+
+# Mock nvm function to intercept uninstall calls
+# nvm_prune calls `nvm uninstall`.
+UNINSTALLED_VERSIONS=""
+nvm() {
+  if [ "$1" = "uninstall" ]; then
+    UNINSTALLED_VERSIONS="${UNINSTALLED_VERSIONS} $2"
+    return 0
+  fi
+  echo "nvm called with unexpected args: $*"
+}
+
+# Run prune
+nvm_prune
+
+# Expected:
+# v16.20.2 (Keep: Only one v16)
+# v18.20.5 (Delete: v18.20.7 is newer) -> WAIT. v18.20.7 is newer. So keep 18.20.7. Delete 18.20.5.
+# v18.20.7 (Keep: Latest v18)
+# v20.17.0 (Keep: Only one v20)
+# v22.22.0 (Keep: Current)
+# v24.13.0 (Keep: Only one v24)
+
+# Wait, my logic for nvm_prune was to keep latest per major.
+# v18.20.5 and v18.20.7 are Major 18. 
+# Latest is v18.20.7.
+# So v18.20.5 should be pruned.
+
+# Check UNINSTALLED_VERSIONS
+EXPECTED=" v18.20.5"
+if [ "${UNINSTALLED_VERSIONS}" != "${EXPECTED}" ]; then
+  die "Expected uninstalled: '${EXPECTED}', got: '${UNINSTALLED_VERSIONS}'"
+fi
+
+# New Test Case: Current version is NOT the latest.
+# v18.1.0 (Current)
+# v18.2.0 (Latest)
+# v18.0.0 (Old)
+
+nvm_ls() {
+  echo "       v18.0.0"
+  echo "->     v18.1.0"
+  echo "       v18.2.0"
+}
+
+nvm_ls_current() {
+  echo "v18.1.0"
+}
+
+UNINSTALLED_VERSIONS=""
+nvm_prune
+
+# Expected:
+# v18.0.0 (Prune)
+# v18.1.0 (Keep: Current)
+# v18.2.0 (Keep: Latest)
+
+EXPECTED=" v18.0.0"
+
+if [ "${UNINSTALLED_VERSIONS}" != "${EXPECTED}" ]; then
+  die "TestCase 2 Failed. Expected uninstalled: '${EXPECTED}', got: '${UNINSTALLED_VERSIONS}'"
+fi
+
+echo "All tests passed"

--- a/test/fast/Running 'nvm prune' should remove old versions
+++ b/test/fast/Running 'nvm prune' should remove old versions
@@ -27,6 +27,11 @@ nvm_ls_current() {
   echo "v22.22.0"
 }
 
+# Mock nvm_is_version_installed
+nvm_is_version_installed() {
+  return 0
+}
+
 # Mock nvm function to intercept uninstall calls
 # nvm_prune calls `nvm uninstall`.
 UNINSTALLED_VERSIONS=""
@@ -50,7 +55,7 @@ nvm_prune
 # v24.13.0 (Keep: Only one v24)
 
 # Wait, my logic for nvm_prune was to keep latest per major.
-# v18.20.5 and v18.20.7 are Major 18. 
+# v18.20.5 and v18.20.7 are Major 18.
 # Latest is v18.20.7.
 # So v18.20.5 should be pruned.
 


### PR DESCRIPTION
## Description
This PR introduces a new command, `nvm prune`, which allows users to easily clean up old, unused Node.js versions from their local installation while ensuring important versions are kept safe.


## Motivation
Over time, users accumulate many patch versions of Node.js (e.g., `v14.17.0`, `v14.17.1`, `v14.17.2`). Manually finding and uninstalling these old versions is tedious. `nvm prune` automates this maintenance task by keeping only the latest version of each major release installed. This also was requested back in [2016](https://github.com/nvm-sh/nvm/issues/1195#issuecomment-239005717)


## Behavior & Rules
When running `nvm prune`, it iterates through all installed versions and applies the following retention policy for **each version group**:
1.  **Keep the Latest:** The most recent version of a major release is always preserved (e.g., if you have `v16.1.0` and `v16.2.0`, `v16.2.0` is kept).
2.  **Keep the Current:** The currently active version (in use by the shell) is **never** deleted, even if it is not the latest in its group.
3.  **Keep Minor (Optional):** If the `--minor` flag is used, the command preserves the latest version of each *minor* group (e.g., keeps both the latest `v18.19.x` and `v18.20.x`).
4.  **Prune the Rest:** All other versions in that group are uninstalled.
5.  **Best Effort:** If uninstalling a specific version fails (e.g., permission error), the command logs the error and proceeds with the rest of the list.


## Features
*   **`--dry-run` support:** Preview which versions would be removed without actually deleting anything.
*   **Safety Warning:** Detects and warns if a version to be pruned contains global npm modules (other than [npm](cci:1://file:///Users/esguerrag/Labs/nvm/nvm.sh:187:0-195:1) itself).
*   **Resiliency:** A failure to uninstall one version does not stop the process for others.
*   **Comprehensive:** Includes [iojs](cci:1://file:///Users/esguerrag/Labs/nvm/nvm.sh:1418:0-1420:1) versions in the pruning logic.


## Implementation Details
*   **POSIX Compliance:**
    *   Replaced `grep -o` (GNU extension) with standard `awk`.
    *   Added a fallback for `sort -V` (GNU extension) to use standard `sort` with field keys (`-k 1.2,1n ...`) to ensure correct version ordering on all systems.
*   Added [nvm_prune](cci:1://file:///Users/esguerrag/Labs/nvm/nvm.sh:1634:0-1789:1) internal function and exposed it via the main `nvm` command switch.


## Usage Examples
```bash
# Preview what would be removed
nvm prune --dry-run
# Run the cleanup (latest per major)
nvm prune
# Keep the latest of each minor version
nvm prune --minor
```

## Test Plan

- [x] Verified `nvm prune --dry-run` lists candidates without uninstalling.
- [x] Verified `nvm prune` correctly identifies the "latest" version per major version group.
- [x] Verified `nvm prune` does *not* remove the currently active version.
- [x] Verified compatibility with `bash` and `zsh`.