### PR TITLE
[readme] use tilde instead of hardcoded home directory "/home/user"

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ When invoking bash as a non-interactive shell, like in a Docker container, none 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Create a script file sourced by both interactive and non-interactive bash shells
-ENV BASH_ENV /home/user/.bash_env
+ENV BASH_ENV $HOME/.bash_env
 RUN touch "${BASH_ENV}"
 RUN echo '. "${BASH_ENV}"' >> ~/.bashrc
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ When invoking bash as a non-interactive shell, like in a Docker container, none 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Create a script file sourced by both interactive and non-interactive bash shells
-ENV BASH_ENV $HOME/.bash_env
+ENV BASH_ENV ~/.bash_env
 RUN touch "${BASH_ENV}"
 RUN echo '. "${BASH_ENV}"' >> ~/.bashrc
 


### PR DESCRIPTION
Hello!

A simple copy-paste produced some errors, and the hardcoded path was the cause. Just let README use `$HOME` when possible.
