### PR TITLE
fix: pin 32 unpinned action(s),extract 1 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/latest-npm.yml
+++ b/.github/workflows/latest-npm.yml
@@ -12,13 +12,13 @@ jobs:
       latest: ${{ steps.set-matrix.outputs.requireds }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             iojs.org:443
             nodejs.org:443
             raw.githubusercontent.com:443
-      - uses: ljharb/actions/node/matrix@main
+      - uses: ljharb/actions/node/matrix@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         id: set-matrix
         with:
           versionsAsRoot: true
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443
@@ -64,7 +64,7 @@ jobs:
             nodejs.org:443
             registry.npmjs.org:443
       - uses: actions/checkout@v6
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'install node'
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   eclint:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443
@@ -17,7 +17,7 @@ jobs:
             nodejs.org:443
             registry.npmjs.org:443
       - uses: actions/checkout@v6
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
           node-version: 'lts/*'
@@ -26,7 +26,7 @@ jobs:
   dockerfile_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             ghcr.io:443
@@ -36,7 +36,7 @@ jobs:
             nodejs.org:443
             registry.npmjs.org:443
       - uses: actions/checkout@v6
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
           node-version: 'lts/*'
@@ -45,7 +45,7 @@ jobs:
   doctoc:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443
@@ -53,7 +53,7 @@ jobs:
             nodejs.org:443
             registry.npmjs.org:443
       - uses: actions/checkout@v6
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
           node-version: 'lts/*'
@@ -62,7 +62,7 @@ jobs:
   test_naming:
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v2
+      - uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443

--- a/.github/workflows/nodejs-org.yml
+++ b/.github/workflows/nodejs-org.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443

--- a/.github/workflows/nvm-install-test.yml
+++ b/.github/workflows/nvm-install-test.yml
@@ -24,8 +24,8 @@ jobs:
           fetch-depth: 0
       - id: matrix
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.ref }}" ]; then
-            echo "matrix=\"[\"${{ github.event.inputs.ref }}\"]\"" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${INPUT_REF}" ]; then
+            echo "matrix=\"[\"${INPUT_REF}\"]\"" >> $GITHUB_OUTPUT
           else
             TAGS="$((echo "HEAD" && git tag --sort=-v:refname --merged HEAD --format='%(refname:strip=2) %(creatordate:short)' | grep '^v' | while read tag date; do
               if [ "$(uname)" == "Darwin" ]; then
@@ -42,6 +42,8 @@ jobs:
             echo "matrix=${TAGS_JSON}" >> $GITHUB_OUTPUT
           fi
 
+        env:
+          INPUT_REF: ${{ github.event.inputs.ref }}
   test:
     needs: [matrix]
     runs-on: ubuntu-latest

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -12,6 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: ljharb/rebase@master
+      - uses: ljharb/rebase@c6bd0a72b14dfaf76ad6a070029c8b4592d03eea # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ljharb/require-allow-edits@main
+      - uses: ljharb/require-allow-edits@13f90bc8cc5de000f2b44a0e2c3a11d108e8cd9f # main

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             ghcr.io:443
@@ -37,7 +37,7 @@ jobs:
             formulae.brew.sh:443
       - uses: actions/checkout@v6
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@4ebd32341e5b59ae7e1581111aa99d5d34cef962 # master
       - name: Install latest shellcheck
         run: brew install shellcheck
         env:

--- a/.github/workflows/tests-fast.yml
+++ b/.github/workflows/tests-fast.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443
@@ -62,7 +62,7 @@ jobs:
       - run: awk --version 2>&1 | head -1 || awk -W version 2>&1 | head -1
       - run: curl --version
       - run: wget --version
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'npm install && version checks'
         with:
           node-version: 'lts/*'

--- a/.github/workflows/tests-installation-iojs.yml
+++ b/.github/workflows/tests-installation-iojs.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443
@@ -51,7 +51,7 @@ jobs:
         shell: bash
       - run: sudo ${{ matrix.shell }} --version 2> /dev/null || dpkg -s ${{ matrix.shell }} 2> /dev/null || which ${{ matrix.shell }}
       - run: wget --version
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'npm install && version checks'
         with:
           node-version: 'lts/*'

--- a/.github/workflows/tests-installation-node.yml
+++ b/.github/workflows/tests-installation-node.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'npm install && version checks'
         with:
           node-version: 'lts/*'

--- a/.github/workflows/tests-xenial.yml
+++ b/.github/workflows/tests-xenial.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'npm install && version checks'
         with:
           node-version: 'lts/*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
         with:
           allowed-endpoints:
             github.com:443
@@ -61,7 +61,7 @@ jobs:
       - run: sudo ${{ matrix.shell }} --version 2> /dev/null || dpkg -s ${{ matrix.shell }} 2> /dev/null || which ${{ matrix.shell }}
       - run: curl --version
       - run: wget --version
-      - uses: ljharb/actions/node/install@main
+      - uses: ljharb/actions/node/install@46bd9bc79196ec7b5c336b66bc3f5d99c6d2e828 # main
         name: 'npm install && version checks'
         with:
           node-version: 'lts/*'

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@v2
+      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2
       with:
         allowed-endpoints:
           github.com:443
@@ -35,7 +35,7 @@ jobs:
     - run: npm install
     - run: npm run doctoc
     - name: commit changes
-      uses: ljharb/actions-js-build/commit@v3+amendpush
+      uses: ljharb/actions-js-build/commit@2b0d6d3e176fd0c188f0182fdc024527bf960692 # v3+amendpush
       with:
         amend: true
         force: true

--- a/.github/workflows/windows-npm.yml
+++ b/.github/workflows/windows-npm.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
       # For Ubuntu: install with packages directly
       - if: matrix.wsl-distrib != 'Debian'
-        uses: Vampire/setup-wsl@v6
+        uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6
         with:
           distribution: ${{ matrix.wsl-distrib }}
           additional-packages: bash git curl ca-certificates wget
@@ -144,7 +144,7 @@ jobs:
       # For Debian: install without packages first (apt-get update fails due to stale sources.list)
       # see https://github.com/Vampire/setup-wsl/issues/76
       - if: matrix.wsl-distrib == 'Debian'
-        uses: Vampire/setup-wsl@v6
+        uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6
         with:
           distribution: ${{ matrix.wsl-distrib }}
       - if: matrix.wsl-distrib == 'Debian'
@@ -214,7 +214,7 @@ jobs:
           - ''
           - 'script'
     steps:
-      - uses: Vampire/setup-wsl@v6
+      - uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6
         with:
           distribution: ${{ matrix.wsl-distrib }}
           additional-packages: bash git curl ca-certificates wget


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/latest-npm.yml` | Pinned 4 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/lint.yml` | Pinned 7 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/nodejs-org.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/nvm-install-test.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/rebase.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/release.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/require-allow-edits.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/shellcheck.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/tests-fast.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/tests-installation-iojs.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/tests-installation-node.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/tests-xenial.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/tests.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/toc.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/windows-npm.yml` | Pinned 3 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-018 | high | `.github/workflows/nvm-install-test.yml` | Suspicious Payload Execution Pattern |
| RGS-018 | high | `.github/workflows/windows-npm.yml` | Suspicious Payload Execution Pattern |
| RGS-006 | high | `.github/workflows/windows-npm.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-018 | high | `.github/workflows/windows-npm.yml` | Suspicious Payload Execution Pattern |
| RGS-018 | high | `.github/workflows/windows-npm.yml` | Suspicious Payload Execution Pattern |
| RGS-006 | high | `.github/workflows/windows-npm.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-018 | high | `.github/workflows/windows-npm.yml` | Suspicious Payload Execution Pattern |
| RGS-006 | high | `.github/workflows/windows-npm.yml` | Curl-Pipe-Bash Remote Code Execution |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.