### PR TITLE
[readme] do not use tilde expansion in ENV of Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ When invoking bash as a non-interactive shell, like in a Docker container, none 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Create a script file sourced by both interactive and non-interactive bash shells
-ENV BASH_ENV ~/.bash_env
+ENV BASH_ENV "${HOME}/.bash_env"
 RUN touch "${BASH_ENV}"
 RUN echo '. "${BASH_ENV}"' >> ~/.bashrc
 


### PR DESCRIPTION
Fix #3799.

> any reason not to use `~`?
> 
> *from: https://github.com/nvm-sh/nvm/pull/3799#discussion_r2891782095*

Yes. Tilde expansion does not work within the "ENV" statement in Dockerfile. Tilde expansion is a feature of shell, but "$HOME" is an environment variable which is a simpler thing.

Sorry, this is my bad that I didn't run the Dockerfile after modifying it.