### PR TITLE
[tests] remove double-substitution in assert_ok and assert_not_ok

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -28,14 +28,14 @@ assert_ok() {
   local FUNCTION=$1
   shift
 
-  $($FUNCTION $@) || die '"'"$FUNCTION $@"'" should have succeeded, but failed'
+  "$FUNCTION" "$@" || die '"'"$FUNCTION $@"'" should have succeeded, but failed'
 }
 
 assert_not_ok() {
   local FUNCTION=$1
   shift
 
-  ! $($FUNCTION $@) || die '"'"$FUNCTION $@"'" should have failed, but succeeded'
+  ! "$FUNCTION" "$@" || die '"'"$FUNCTION $@"'" should have failed, but succeeded'
 }
 
 strip_colors() {
@@ -46,7 +46,7 @@ strip_colors() {
 
 make_echo() {
   echo "#!/bin/sh" > "$1"
-  echo "echo \"${2}\"" > "$1"
+  echo "echo \"${2}\"" >> "$1"
   chmod a+x "$1"
 }
 

--- a/test/fast/Unit tests/assert_not_ok
+++ b/test/fast/Unit tests/assert_not_ok
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../common.sh
+
+_returns_zero() { return 0; }
+_returns_nonzero() { return 1; }
+
+# assert_not_ok should pass for a non-zero-exit function
+assert_not_ok _returns_nonzero \
+  || die 'assert_not_ok failed on a function that returns 1'
+
+# assert_not_ok should fail for a zero-exit function
+if (assert_not_ok _returns_zero 2>/dev/null); then
+  die 'assert_not_ok incorrectly passed for a function that returns 0'
+fi

--- a/test/fast/Unit tests/assert_ok
+++ b/test/fast/Unit tests/assert_ok
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../common.sh
+
+_returns_zero() { return 0; }
+_returns_nonzero() { return 1; }
+
+# assert_ok should pass for a zero-exit function
+assert_ok _returns_zero \
+  || die 'assert_ok failed on a function that returns 0'
+
+# assert_ok should fail for a non-zero-exit function
+if (assert_ok _returns_nonzero 2>/dev/null); then
+  die 'assert_ok incorrectly passed for a function that returns 1'
+fi

--- a/test/fast/Unit tests/make_echo
+++ b/test/fast/Unit tests/make_echo
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../common.sh
+
+TMPFILE="$(mktemp)"
+trap 'rm -f "${TMPFILE}"' EXIT
+
+make_echo "${TMPFILE}" "hello_nvm" || die 'make_echo returned non-zero'
+
+# shebang must still be on line 1
+[ "$(head -n 1 "${TMPFILE}")" = '#!/bin/sh' ] \
+  || die 'make_echo overwrote the shebang'
+
+# script body must be present
+grep -q 'hello_nvm' "${TMPFILE}" \
+  || die 'make_echo did not write the echo body'
+
+# file must be executable
+[ -x "${TMPFILE}" ] \
+  || die 'make_echo did not chmod the file'


### PR DESCRIPTION
Fixed make_echo appending the script body instead of overwriting the shebang, and replaced erroneous command-substitution wrappers in assert_ok/assert_not_ok with direct quoted function calls.