### PR TITLE
Fix same owner for root when install from binary

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2614,7 +2614,7 @@ nvm_extract_tarball() {
       command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" -s '/[^\/]*\///' || return 1
     fi
   else
-    command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" --strip-components 1 || return 1
+    command "${tar}" -x${tar_compression_flag}f "${TARBALL}" -C "${TMPDIR}" --strip-components 1 --no-same-owner || return 1
   fi
 }
 

--- a/test/installation_node/install from binary
+++ b/test/installation_node/install from binary
@@ -17,6 +17,8 @@ nvm install $NVM_TEST_VERSION || die "install $NVM_TEST_VERSION failed"
 # Check
 [ -d ../../$NVM_TEST_VERSION ]
 nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION || die "'nvm run $NVM_TEST_VERSION --version | grep $NVM_TEST_VERSION' failed"
+[ -O "${NVM_DIR}/${NVM_TEST_VERSION}/bin/node" ] || die "Extracted file is not owned by effective user"
+[ -G "${NVM_DIR}/${NVM_TEST_VERSION}/bin/node" ] || die "Extracted file is not owned by effective group"
 
 # ensure default is set
 NVM_CURRENT_DEFAULT="$(nvm_alias default)"


### PR DESCRIPTION
GNU Tar has `--preserve-permissions` as a default enabled when executed as the superuser (root). This will cause the binaries to be installed using the permissions (owner and group) as defined in the tarball.

The argument `--no-same-owner` prevents this and will install the binaries as the effective owner/group just like when nvm is executed as a non superuser.

Updated the install from binary test from the installation_node test suite because this test is run in a docker container as root. Without `--no-same-owner` this test will fail beause the binaries of node v0.10.7 are owned by isaacs/admin in the tarball.

Fixed #3828