### PR TITLE
Submodule nvmrc update protocol from git to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/fixtures/nvmrc"]
   path = test/fixtures/nvmrc
-  url = git@github.com:nvm-sh/nvmrc.git
+	url = https://github.com/nvm-sh/nvmrc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/fixtures/nvmrc"]
   path = test/fixtures/nvmrc
-	url = https://github.com/nvm-sh/nvmrc.git
+  url = https://github.com/nvm-sh/nvmrc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/fixtures/nvmrc"]
   path = test/fixtures/nvmrc
-  url = https://github.com/nvm-sh/nvmrc.git
+  url = ../nvmrc.git


### PR DESCRIPTION
Using Ansible to clone NVM to one of my server I am getting authentication error due to `fatal: Could not read from remote repository.`

The error is due to the fact that the submodule is currently set to use GIT protocol and require autentication. I just updated Submodule URL from GIT to HTTPS.

Error:
```
TASK [application_deps : Clone nvm v0.40.3] ************************************************
[ERROR]: Task failed: Module failed: Failed to init/update submodules: Submodule 'test/fixtures/nvmrc' (git@github.com:nvm-sh/nvmrc.git) registered for path 'test/fixtures/nvmrc'
Cloning into '/home/my-user/.nvm/test/fixtures/nvmrc'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:nvm-sh/nvmrc.git' into submodule path '/home/my-user/.nvm/test/fixtures/nvmrc' failed
Failed to clone 'test/fixtures/nvmrc'. Retry scheduled
Cloning into '/home/my-user/.nvm/test/fixtures/nvmrc'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
