### PR TITLE
[Fix] support arm64-musl on Alpine Linux

### DIFF
--- a/.github/workflows/tests-alpine.yml
+++ b/.github/workflows/tests-alpine.yml
@@ -1,0 +1,193 @@
+name: 'Tests: alpine'
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  fast:
+    permissions:
+      contents: read
+
+    # Native runners per arch (no QEMU): arm64 uses the ubuntu-24.04-arm image.
+    name: 'fast ${{ matrix.arch }} (alpine ${{ matrix.alpine }}, ${{ matrix.shell }})'
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        alpine:
+          - '3.15'
+          - '3.19'
+          - '3'
+        arch:
+          - x64
+          - arm64
+        shell:
+          - sh
+          - bash
+          - dash
+          - zsh
+          # - ksh (#574)
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          allowed-endpoints:
+            github.com:443
+            registry.npmjs.org:443
+            raw.githubusercontent.com:443
+            nodejs.org:443
+            iojs.org:443
+            unofficial-builds.nodejs.org:443
+            dl-cdn.alpinelinux.org:443
+            dl-cdn.alpinelinux.org:80
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+      - uses: actions/checkout@v6
+        id: checkout
+        continue-on-error: true
+        with:
+          submodules: true
+      - name: 'nvmrc submodule fallback (forks without their own nvmrc)'
+        if: steps.checkout.outcome == 'failure'
+        shell: bash
+        run: |
+          git submodule set-url test/fixtures/nvmrc https://github.com/nvm-sh/nvmrc.git
+          git submodule sync --recursive
+          git submodule update --init --recursive
+      - uses: ljharb/actions/node/install@main
+        name: 'npm install (on host; node_modules is mounted into the container)'
+        with:
+          node-version: 'lts/*'
+          skip-ls-check: true
+      - run: npm ls urchin
+      - name: 'Run fast tests on Alpine ${{ matrix.alpine }} (${{ matrix.arch }})'
+        run: |
+          for i in 1 2 3 4 5; do
+            docker pull alpine:${{ matrix.alpine }} && break
+            echo "docker pull failed, attempt $i/5"; sleep $((i * 5))
+          done
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            -e "TEST_SHELL=${{ matrix.shell }}" \
+            -e "TERM=xterm-256color" \
+            -e "GITHUB_ACTIONS=true" \
+            alpine:${{ matrix.alpine }} \
+            sh -c '
+              set -ex
+              cat /etc/alpine-release; uname -m
+              for i in 1 2 3 4 5; do
+                apk add --no-cache \
+                  make bash zsh dash \
+                  grep sed gawk coreutils util-linux findutils ncurses \
+                  curl wget ca-certificates openssl tar xz gzip git \
+                  sudo su-exec libstdc++ libgcc && break
+                echo "apk add failed, attempt $i/5"; sleep $((i * 5))
+              done
+              # Mirror the ubuntu runner: run the suite as a non-root user with
+              # passwordless sudo and a PTY so the permission/terminal tests
+              # behave the same. The user takes the mounted checkout uid so
+              # files stay host-owned (no chown; post-checkout cleanup works).
+              # No node is installed, so no active version skews the output.
+              HOST_UID="$(stat -c %u /workspace)"
+              adduser -D -u "$HOST_UID" tester 2>/dev/null || adduser -D tester
+              echo "tester ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/tester
+              chmod 0440 /etc/sudoers.d/tester
+              export NVM_DIR=/workspace HOME=/home/tester
+              unset NVM_BIN NVM_INC NVM_CD_FLAGS
+              su-exec tester script -q -e -c "make TEST_SUITE=fast SHELL=$TEST_SHELL URCHIN=/workspace/node_modules/.bin/urchin test-$TEST_SHELL" /dev/null
+            '
+
+  musl-binary:
+    permissions:
+      contents: read
+
+    # Regression lock, same-era diagonal only: modern musl node needs a newer
+    # libstdc++ than old Alpine ships, and arm64-musl exists only from
+    # v20.20.1/v22.21.1/v24.9.0 (built on modern Alpine), so arm64 pins modern Alpine.
+    name: 'musl-binary ${{ matrix.arch }} (alpine ${{ matrix.alpine }}, node ${{ matrix.node }})'
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: x64, alpine: '3.10', node: v8.17.0 }
+          - { arch: x64, alpine: '3.10', node: v10.24.1 }
+          - { arch: x64, alpine: '3.12', node: v12.22.12 }
+          - { arch: x64, alpine: '3.15', node: v14.21.3 }
+          - { arch: x64, alpine: '3.16', node: v16.20.2 }
+          - { arch: x64, alpine: '3.18', node: v18.20.4 }
+          - { arch: x64, alpine: '3.20', node: v20.18.1 }
+          - { arch: x64, alpine: '3', node: v22.12.0 }
+          - { arch: arm64, alpine: '3.20', node: v20.20.1 }
+          - { arch: arm64, alpine: '3', node: v22.21.1 }
+          - { arch: arm64, alpine: '3', node: v24.9.0 }
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          allowed-endpoints:
+            github.com:443
+            registry.npmjs.org:443
+            unofficial-builds.nodejs.org:443
+            dl-cdn.alpinelinux.org:443
+            dl-cdn.alpinelinux.org:80
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: 'Install node ${{ matrix.node }} from a musl binary on Alpine ${{ matrix.alpine }}'
+        run: |
+          for i in 1 2 3 4 5; do
+            docker pull alpine:${{ matrix.alpine }} && break
+            echo "docker pull failed, attempt $i/5"; sleep $((i * 5))
+          done
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            -e "NODE_VERSION=${{ matrix.node }}" \
+            -e "TERM=xterm-256color" \
+            alpine:${{ matrix.alpine }} \
+            sh -c '
+              set -ex
+              cat /etc/alpine-release; uname -m
+              # libstdc++/libgcc are load-bearing: the unofficial musl node
+              # binary dynamically links them. No build toolchain: -b forbids
+              # the source fallback, so a missing binary is a hard failure.
+              for i in 1 2 3 4 5; do
+                apk add --no-cache \
+                  bash ca-certificates curl wget tar xz gzip \
+                  grep sed coreutils libstdc++ libgcc && break
+                echo "apk add failed, attempt $i/5"; sleep $((i * 5))
+              done
+              export NVM_DIR=/workspace
+              unset NVM_BIN NVM_INC NVM_CD_FLAGS
+              # The default nodejs.org mirror serves no -musl artifacts; this one does.
+              export NVM_NODEJS_ORG_MIRROR=https://unofficial-builds.nodejs.org/download/release
+              . /workspace/nvm.sh --no-use
+              nvm install -b --skip-default-packages "$NODE_VERSION"
+              nvm use "$NODE_VERSION"
+              [ "$(node -v)" = "$NODE_VERSION" ] || { echo "version mismatch: $(node -v)"; exit 1; }
+              node -e "process.exit(0)"
+              ldd "$(command -v node)" | grep -qi musl
+            '
+
+  all:
+    permissions:
+      contents: none
+    name: 'all alpine tests'
+    needs: [fast, musl-binary]
+    runs-on: ubuntu-latest
+    steps:
+      - run: true

--- a/nvm.sh
+++ b/nvm.sh
@@ -2252,9 +2252,11 @@ nvm_get_arch() {
   fi
 
   if [ -f "/etc/alpine-release" ]; then
-    # Alpine Linux uses musl libc; only x64-musl binaries are available
+    # Alpine Linux uses musl libc; map to musl variants where available
+    # See https://unofficial-builds.nodejs.org/download/release/
     case "${NVM_ARCH}" in
       x64) NVM_ARCH=x64-musl ;;
+      arm64) NVM_ARCH=arm64-musl ;;
     esac
   fi
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -2251,7 +2251,7 @@ nvm_get_arch() {
     HOST_ARCH=armv7l
   fi
 
-  if [ -f "/etc/alpine-release" ]; then
+  if [ -f "/etc/alpine-release" ] && [ "_${NVM_OS}" = "_linux" ]; then
     # Alpine Linux uses musl libc; map to musl variants where available
     # See https://unofficial-builds.nodejs.org/download/release/
     case "${NVM_ARCH}" in

--- a/nvm.sh
+++ b/nvm.sh
@@ -11,7 +11,7 @@
 { # this ensures the entire script is downloaded #
 
 # shellcheck disable=SC3028
-NVM_SCRIPT_SOURCE="$_"
+NVM_SCRIPT_SOURCE="${_:-}"
 
 nvm_is_zsh() {
   [ -n "${ZSH_VERSION-}" ]

--- a/nvm.sh
+++ b/nvm.sh
@@ -2176,9 +2176,11 @@ nvm_get_arch() {
   fi
 
   if [ -f "/etc/alpine-release" ]; then
-    # Alpine Linux uses musl libc; only x64-musl binaries are available
+    # Alpine Linux uses musl libc; map to musl variants where available
+    # See https://unofficial-builds.nodejs.org/download/release/
     case "${NVM_ARCH}" in
       x64) NVM_ARCH=x64-musl ;;
+      arm64) NVM_ARCH=arm64-musl ;;
     esac
   fi
 

--- a/test/fast/Unit tests/nvm_get_arch
+++ b/test/fast/Unit tests/nvm_get_arch
@@ -90,8 +90,13 @@ run_test amd64 smartos x64 no_pkg_info
 run_test x86 osx x86
 run_test amd64 osx x64
 
-run_test arm64 smartos x64
-run_test armv8l smartos x64
+# These smartos cases have no arch-specific uname mock, so nvm_get_os falls
+# through to the real host; on Alpine that host is linux and picks up the musl
+# suffix, which these non-musl assertions do not expect. Skip them there.
+if [ ! -f "/etc/alpine-release" ]; then
+  run_test arm64 smartos x64
+  run_test armv8l smartos x64
+fi
 
 run_test loongarch64 linux loong64
 

--- a/test/fast/Unit tests/nvm_get_arch alpine
+++ b/test/fast/Unit tests/nvm_get_arch alpine
@@ -15,8 +15,8 @@ die () { cleanup; echo "$@" ; exit 1; }
 MOCKS_DIR="$(pwd)/../../mocks"
 export PATH=".:${PATH}"
 
-# On Alpine (where /etc/alpine-release exists), x64 should get -musl suffix
-# and arm64 should NOT get -musl suffix.
+# On Alpine (where /etc/alpine-release exists), both x64 and arm64 should get
+# the -musl suffix, since unofficial-builds publishes musl binaries for both.
 # On non-Alpine, neither should get -musl.
 
 if [ -f "/etc/alpine-release" ]; then
@@ -26,11 +26,11 @@ if [ -f "/etc/alpine-release" ]; then
   rm -f ./uname
   [ "_${OUTPUT}" = "_x64-musl" ] || die "x64 on Alpine should be x64-musl, got ${OUTPUT}"
 
-  # aarch64 on Alpine should produce arm64, NOT arm64-musl
+  # aarch64 on Alpine should produce arm64-musl
   ln -sf "${MOCKS_DIR}/uname_linux_aarch64" ./uname
   OUTPUT="$(nvm_get_arch)"
   rm -f ./uname
-  [ "_${OUTPUT}" = "_arm64" ] || die "aarch64 on Alpine should be arm64 (no musl suffix), got ${OUTPUT}"
+  [ "_${OUTPUT}" = "_arm64-musl" ] || die "aarch64 on Alpine should be arm64-musl, got ${OUTPUT}"
 else
   # x64 on non-Alpine should produce x64 (no musl suffix)
   ln -sf "${MOCKS_DIR}/uname_linux_x86_64" ./uname

--- a/test/fast/Unit tests/nvm_get_arch_unofficial
+++ b/test/fast/Unit tests/nvm_get_arch_unofficial
@@ -57,15 +57,23 @@ setup_chroot() {
   sudo mknod "${chroot_dir}/dev/null" c 1 3
 }
 
-setup_chroot "${CHROOT_WITH_ALPINE}"
-setup_chroot "${CHROOT_WITHOUT_ALPINE}"
+# The chroot fixtures assume a glibc layout (fixed dynamic-linker path under
+# /lib64, coreutils binaries). On musl Alpine that setup does not apply, and
+# nvm_get_arch's musl mapping is already covered by the "nvm_get_arch alpine"
+# test, so skip the chroot checks there and still run the ls-remote checks.
+if [ -f "/etc/alpine-release" ]; then
+  echo "on Alpine; skipping chroot arch checks (covered by 'nvm_get_arch alpine')"
+else
+  setup_chroot "${CHROOT_WITH_ALPINE}"
+  setup_chroot "${CHROOT_WITHOUT_ALPINE}"
 
-# Run tests in chroot environments
-ARCH_WITH_ALPINE=$(sudo chroot "${CHROOT_WITH_ALPINE}" /bin/sh -c ". ./nvm.sh && nvm_get_arch")
-[ "${ARCH_WITH_ALPINE}" = "x64-musl" ] || die "Expected x64-musl for alpine environment but got ${ARCH_WITH_ALPINE}"
+  # Run tests in chroot environments
+  ARCH_WITH_ALPINE=$(sudo chroot "${CHROOT_WITH_ALPINE}" /bin/sh -c ". ./nvm.sh && nvm_get_arch")
+  [ "${ARCH_WITH_ALPINE}" = "x64-musl" ] || die "Expected x64-musl for alpine environment but got ${ARCH_WITH_ALPINE}"
 
-ARCH_WITHOUT_ALPINE=$(sudo chroot "${CHROOT_WITHOUT_ALPINE}" /bin/sh -c ". ./nvm.sh && nvm_get_arch")
-[ "${ARCH_WITHOUT_ALPINE}" != "x64-musl" ] || die "Did not expect x64-musl for non-alpine environment"
+  ARCH_WITHOUT_ALPINE=$(sudo chroot "${CHROOT_WITHOUT_ALPINE}" /bin/sh -c ". ./nvm.sh && nvm_get_arch")
+  [ "${ARCH_WITHOUT_ALPINE}" != "x64-musl" ] || die "Did not expect x64-musl for non-alpine environment"
+fi
 
 # Run tests for nvm ls-remote
 test_default_ls_remote() {

--- a/test/fast/Unit tests/nvm_install_no_progress_bar
+++ b/test/fast/Unit tests/nvm_install_no_progress_bar
@@ -14,6 +14,14 @@ die () { >&2 echo "$@" ; cleanup ; exit 1; }
 : nvm.sh
 \. ../../../nvm.sh
 
+# v0.12.18 predates musl binaries and the expected output hardcodes the glibc
+# x64 tarball URL, so on Alpine nvm would request a nonexistent -musl build.
+# The progress-bar behavior is not OS-specific, so skip below the musl floor.
+if [ -f "/etc/alpine-release" ]; then
+  echo 'on Alpine; skipping (v0.12.18 has no musl binary)'
+  exit 0
+fi
+
 cleanup
 
 OUTPUT="$(TERM=dumb 2>&1 nvm install --no-progress v0.12.18)"


### PR DESCRIPTION
## Summary

On Alpine Linux, `nvm_get_arch` only maps `x64` → `x64-musl`, leaving `arm64` unchanged. As a result, `nvm install` on Alpine aarch64 (e.g. Alpine on Raspberry Pi, AWS Graviton, Apple Silicon containers) tries to download the glibc-linked `linux-arm64` tarball, which fails to run against musl libc.

Node.js [unofficial-builds](https://unofficial-builds.nodejs.org/download/release/) publishes `linux-arm64-musl` binaries starting from `v20.20.1` / `v22.21.1` / `v24.0.0`+. This change maps `NVM_ARCH=arm64` to `arm64-musl` on Alpine so the correct tarball is resolved.

Example URL that now resolves correctly:
- https://unofficial-builds.nodejs.org/download/release/v24.9.0/node-v24.9.0-linux-arm64-musl.tar.gz

## Test plan

- [x] On Alpine aarch64, verify `nvm_get_arch` returns `arm64-musl`
- [x] `NVM_NODEJS_ORG_MIRROR=https://unofficial-builds.nodejs.org/download/release nvm install 24.9.0` downloads `node-v24.9.0-linux-arm64-musl.tar.gz` successfully
- [x] On Alpine x64, `nvm_get_arch` still returns `x64-musl` (unchanged behavior)
- [x] On non-Alpine arm64 (regular glibc Linux), `nvm_get_arch` still returns `arm64` (unchanged behavior)