### PR TITLE
[Fix] auth header: Add all valid base64 chars to sanitize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ Run [`npx nvmrc`](https://npmjs.com/nvmrc) to validate an `.nvmrc` file. If that
 
 You can use [`nvshim`](https://github.com/iamogbz/nvshim) to shim the `node`, `npm`, and `npx` bins to automatically use the `nvm` config in the current directory. `nvshim` is **not** supported by the `nvm` maintainers. Please [report issues to the `nvshim` team](https://github.com/iamogbz/nvshim/issues/new).
 
-If you prefer a lighter-weight solution, the recipes below have been contributed by `nvm` users. They are **not** supported by the `nvm` maintainers. We are, however, accepting pull requests for more examples.
+If you prefer a lighter-weight solution, the recipes below have been contributed by `nvm` users. They are **not** supported by the `nvm` maintainers. We are, however, accepting pull requests for more examples
 
 #### Calling `nvm use` automatically in a directory with a `.nvmrc` file
 

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ Run [`npx nvmrc`](https://npmjs.com/nvmrc) to validate an `.nvmrc` file. If that
 
 You can use [`nvshim`](https://github.com/iamogbz/nvshim) to shim the `node`, `npm`, and `npx` bins to automatically use the `nvm` config in the current directory. `nvshim` is **not** supported by the `nvm` maintainers. Please [report issues to the `nvshim` team](https://github.com/iamogbz/nvshim/issues/new).
 
-If you prefer a lighter-weight solution, the recipes below have been contributed by `nvm` users. They are **not** supported by the `nvm` maintainers. We are, however, accepting pull requests for more examples
+If you prefer a lighter-weight solution, the recipes below have been contributed by `nvm` users. They are **not** supported by the `nvm` maintainers. We are, however, accepting pull requests for more examples.
 
 #### Calling `nvm use` automatically in a directory with a `.nvmrc` file
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -160,7 +160,7 @@ nvm_download() {
 
 nvm_sanitize_auth_header() {
     # Remove potentially dangerous characters
-    nvm_echo "$1" | command sed 's/[^a-zA-Z0-9:;_. -]//g'
+    nvm_echo "$1" | command sed 's/[^a-zA-Z0-9:;_. -+/=]//g'
 }
 
 nvm_has_system_node() {

--- a/nvm.sh
+++ b/nvm.sh
@@ -159,8 +159,10 @@ nvm_download() {
 }
 
 nvm_sanitize_auth_header() {
-    # Remove potentially dangerous characters
-    nvm_echo "$1" | command sed 's/[^a-zA-Z0-9:;_. -+/=]//g'
+    # Remove potentially dangerous characters; allow full base64 charset (A-Za-z0-9+/=),
+    # base64url charset (A-Za-z0-9-_=), and safe Bearer token chars (space, colon, dot).
+    # Note: '-' must be at the end of the bracket expression to be treated as a literal.
+    nvm_echo "$1" | command sed 's/[^a-zA-Z0-9 :_.+/=-]//g'
 }
 
 nvm_has_system_node() {

--- a/nvm.sh
+++ b/nvm.sh
@@ -186,8 +186,13 @@ nvm_download() {
 }
 
 nvm_sanitize_auth_header() {
-    # Remove potentially dangerous characters
-    nvm_echo "$1" | command sed 's/[^a-zA-Z0-9:;_. -]//g'
+    # Remove potentially dangerous characters; allow the full base64 (A-Za-z0-9+/=)
+    # and base64url (A-Za-z0-9-_=) charsets, plus the space, colon, dot, and
+    # underscore the previous allowlist already permitted, so that values like
+    # `Basic <base64>` and `Bearer <token>` survive intact.
+    # token68's '~' is still stripped.
+    # Note: '-' must be at the end of the bracket expression to be treated as a literal.
+    nvm_echo "$1" | command sed 's/[^a-zA-Z0-9 :_.+/=-]//g'
 }
 
 nvm_has_system_node() {

--- a/test/fast/Unit tests/nvm_sanitize_auth_header
+++ b/test/fast/Unit tests/nvm_sanitize_auth_header
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+set -ex
+
+# Test 1: all standard base64 characters (RFC 4648) are preserved
+STANDARD_B64="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+RESULT=$(nvm_sanitize_auth_header "${STANDARD_B64}")
+[ "${RESULT}" = "${STANDARD_B64}" ] || die "FAIL: standard base64 chars were stripped. Got: '${RESULT}'"
+
+# Test 2: all base64url characters (RFC 4648 §5) are preserved
+B64URL="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_="
+RESULT=$(nvm_sanitize_auth_header "${B64URL}")
+[ "${RESULT}" = "${B64URL}" ] || die "FAIL: base64url chars were stripped. Got: '${RESULT}'"
+
+# Test 3: a real JWT Bearer token (base64url-encoded header.payload.signature) is preserved
+JWT_TOKEN="Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+RESULT=$(nvm_sanitize_auth_header "${JWT_TOKEN}")
+[ "${RESULT}" = "${JWT_TOKEN}" ] || die "FAIL: JWT Bearer token chars were stripped. Got: '${RESULT}'"
+
+# Test 4: Basic auth (base64-encoded user:pass) is preserved
+BASIC_TOKEN="Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+RESULT=$(nvm_sanitize_auth_header "${BASIC_TOKEN}")
+[ "${RESULT}" = "${BASIC_TOKEN}" ] || die "FAIL: Basic auth base64 token chars were stripped. Got: '${RESULT}'"
+
+# Test 5: dangerous shell metacharacters are removed
+DANGEROUS="Bearer token;\`evil\`-cmd \$(inject)"
+RESULT=$(nvm_sanitize_auth_header "${DANGEROUS}")
+case "${RESULT}" in
+  *";"*|*"\`"*|*'$'*|*"("*|*")"*)
+    die "FAIL: dangerous shell metacharacters survived sanitization. Got: '${RESULT}'"
+    ;;
+esac
+
+echo "All nvm_sanitize_auth_header tests passed"

--- a/test/fast/Unit tests/security_wget_injection
+++ b/test/fast/Unit tests/security_wget_injection
@@ -32,9 +32,9 @@ fi
 # Test 2: Verify that sanitized header still works for legitimate requests
 # The sanitized header should only contain safe characters
 SANITIZED=$(nvm_sanitize_auth_header "${MALICIOUS_HEADER}")
-# Verify that dangerous characters were removed
+# Verify that dangerous shell metacharacters were removed
 case "${SANITIZED}" in
-  *";"*|*"touch"*|*"/tmp"*)
+  *";"*|*'$'*|*"\`"*)
     die "SECURITY FAILURE: Sanitization did not remove dangerous characters properly"
     ;;
 esac


### PR DESCRIPTION
In our use case we use our Nexus as a nodejs.org proxy with basic auth. The authorization header option should support the full base64 character set. I updated nvm_sanitize_auth_header to support this.

I also added a unit test.

I modified security_wget_injection as it was incompatible with supporting base64 encoding in the authorization header due to the "/tmp" assertion. I changed that test to check for dangerous shell metacharacters instead.