### PR TITLE
[Fix] Use default alias in nvm-exec fallback

### DIFF
--- a/nvm-exec
+++ b/nvm-exec
@@ -10,8 +10,13 @@ unset NVM_CD_FLAGS
 if [ -n "$NODE_VERSION" ]; then
   nvm use "$NODE_VERSION" > /dev/null || exit 127
 else
-  { NVM_RC_VERSION="$(nvm_rc_version 3>&1 1>&4)"; } 4>&1 && nvm_ensure_version_installed "$NVM_RC_VERSION";
-  if ! nvm use >/dev/null 2>&1; then
+  if [ -e "$(nvm_find_nvmrc)" ]; then
+    { NVM_RC_VERSION="$(nvm_rc_version 3>&1 1>&4)"; } 4>&1 && nvm_ensure_version_installed "$NVM_RC_VERSION";
+  else
+    NVM_RC_VERSION="default"
+  fi
+
+  if ! nvm use "$NVM_RC_VERSION" >/dev/null 2>&1; then
     echo "No NODE_VERSION provided; no .nvmrc file found" >&2
     exit 127
   fi

--- a/test/fast/Running 'nvm-exec' should display required node version
+++ b/test/fast/Running 'nvm-exec' should display required node version
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 set -x
+export NVM_DIR="$(cd ../.. && pwd)"
 : nvm.sh
 \. ../../nvm.sh
+\. ../common.sh
 
-cleanup() { rm -f .nvmrc; }
+cleanup() { rm -f .nvmrc ../../alias/default; rm -rf ../../v0.0.1; }
 die () { echo "$@" ; cleanup ; exit 1; }
 
 NVM_TEST_VERSION=v0.42
@@ -20,6 +22,16 @@ You need to run \`nvm install ${NVM_TEST_VERSION}\` to install and use it.
 No NODE_VERSION provided; no .nvmrc file found";
 
 # Skip install, we want to test the error message
+[ "${EXPECTED}" = "${OUTPUT}" ] || die "expected >${EXPECTED}<, got >${OUTPUT}<"
+
+cleanup
+
+make_fake_node v0.0.1 || die "unable to create fake node"
+echo "0.0.1" > ../../alias/default || die "unable to create default alias"
+
+OUTPUT="$(../../nvm-exec node 2>&1)";
+EXPECTED="v0.0.1";
+
 [ "${EXPECTED}" = "${OUTPUT}" ] || die "expected >${EXPECTED}<, got >${OUTPUT}<"
 
 cleanup


### PR DESCRIPTION
Closes #3810

## Summary
- make direct `nvm-exec` fall back to the `default` alias when `NODE_VERSION` and `.nvmrc` are absent
- preserve existing `.nvmrc` handling when a project file is present
- add fast test coverage with a fake installed default node version

## Tests
- `bash -n nvm-exec`
- `bash -n "test/fast/Running 'nvm-exec' should display required node version"`\n- `./setup && "./Running 'nvm-exec' should display required node version"; code=$?; ./teardown; exit $code` from `test/fast`\n- `git diff --check`\n- `make TEST_SUITE=fast test-bash URCHIN=./node_modules/.bin/urchin` was also attempted; the updated `nvm-exec` test passed, while the broader run failed on existing local-environment-sensitive cases involving color expectations, sudo, missing Linux loader/ldd, `/dev/tty`, and platform fixture output.