### PR TITLE
[Fix] Parse commented nvmrc content in nvm_ls

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -560,12 +560,12 @@ ${1}"
 $(nvm_wrap_with_color_code 'y' "${warn_text}")"
 }
 
-nvm_process_nvmrc() {
-  local NVMRC_PATH
-  NVMRC_PATH="$1"
+nvm_process_nvmrc_content() {
+  local NVMRC_CONTENT
+  NVMRC_CONTENT="${1-}"
   local lines
 
-  lines=$(command sed 's/#.*//' "$NVMRC_PATH" | command sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | nvm_grep -v '^$')
+  lines=$(nvm_echo "${NVMRC_CONTENT}" | command sed 's/#.*//' | command sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | nvm_grep -v '^$')
 
   if [ -z "$lines" ]; then
     nvm_nvmrc_invalid_msg "${lines}"
@@ -627,6 +627,13 @@ EOF
   fi
 
   nvm_echo "${unpaired_line}"
+}
+
+nvm_process_nvmrc() {
+  local NVMRC_PATH
+  NVMRC_PATH="$1"
+
+  nvm_process_nvmrc_content "$(command cat "${NVMRC_PATH}")"
 }
 
 nvm_rc_version() {
@@ -1486,6 +1493,17 @@ nvm_strip_iojs_prefix() {
 nvm_ls() {
   local PATTERN
   PATTERN="${1-}"
+  case "${PATTERN}" in
+    *'#'* | *'
+'*)
+      local NVMRC_PATTERN
+      if ! NVMRC_PATTERN="$(nvm_process_nvmrc_content "${PATTERN}" 2>/dev/null)"; then
+        nvm_echo 'N/A'
+        return 3
+      fi
+      PATTERN="${NVMRC_PATTERN}"
+    ;;
+  esac
   local VERSIONS
   VERSIONS=''
   if [ "${PATTERN}" = 'current' ]; then
@@ -4717,7 +4735,7 @@ nvm() {
         nvm_get_colors nvm_set_colors nvm_print_color_code nvm_wrap_with_color_code nvm_format_help_message_colors \
         nvm_echo_with_colors nvm_err_with_colors \
         nvm_get_artifact_compression nvm_install_binary_extract nvm_extract_tarball \
-        nvm_process_nvmrc nvm_nvmrc_invalid_msg \
+        nvm_process_nvmrc nvm_process_nvmrc_content nvm_nvmrc_invalid_msg \
         nvm_write_nvmrc \
         >/dev/null 2>&1
       unset NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR NVM_DIR \

--- a/test/fast/Unit tests/nvm_ls handles hash in pattern
+++ b/test/fast/Unit tests/nvm_ls handles hash in pattern
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-die () { echo "$@" ; exit 1; }
+die () { echo "$@" ; cleanup ; exit 1; }
+
+cleanup() {
+  unset NVMRC_CONTENT OUTPUT EXIT_CODE TEST_DIR
+  rm -rf "${TEST_DIR-}"
+}
 
 : nvm.sh
 \. ../../../nvm.sh
@@ -22,3 +27,26 @@ echo "$OUTPUT" | grep -q "invalid command code" && \
 # Should return N/A with exit code 3 (not found)
 [ "$EXIT_CODE" = "3" ] || die "nvm_ls 'foo#bar' should exit with code 3, got $EXIT_CODE"
 echo "$OUTPUT" | grep -q "N/A" || die "nvm_ls 'foo#bar' should output N/A, got: $OUTPUT"
+
+TEST_DIR="${PWD}/nvm_ls_hash_pattern_tmp"
+mkdir -p "${TEST_DIR}/versions/node/v24.13.0/bin" || die 'failed to create test version dir'
+printf '#!/bin/sh\nprintf v24.13.0\\\\n\n' > "${TEST_DIR}/versions/node/v24.13.0/bin/node" || die 'failed to create test node binary'
+chmod +x "${TEST_DIR}/versions/node/v24.13.0/bin/node" || die 'failed to chmod test node binary'
+
+NVM_DIR="${TEST_DIR}"
+NVMRC_CONTENT='v24.13.0
+# krypton is the codename for Node.js v24.x'
+
+OUTPUT="$(nvm_ls "${NVMRC_CONTENT}" 2>&1)"
+EXIT_CODE=$?
+
+echo "$OUTPUT" | grep -q "unterminated regular expression" && \
+  die "nvm_ls with .nvmrc comments caused sed 'unterminated regular expression' error: $OUTPUT"
+
+[ "$EXIT_CODE" = "0" ] || die "nvm_ls with .nvmrc comments should exit with code 0, got $EXIT_CODE"
+[ "$OUTPUT" = "v24.13.0" ] || die "nvm_ls with .nvmrc comments should output v24.13.0, got: $OUTPUT"
+
+OUTPUT="$(nvm_version "${NVMRC_CONTENT}" 2>&1)"
+[ "$OUTPUT" = "v24.13.0" ] || die "nvm_version with .nvmrc comments should output v24.13.0, got: $OUTPUT"
+
+cleanup

--- a/test/fast/Unit tests/nvm_ls handles hash in pattern
+++ b/test/fast/Unit tests/nvm_ls handles hash in pattern
@@ -3,12 +3,21 @@
 die () { echo "$@" ; cleanup ; exit 1; }
 
 cleanup() {
-  unset NVMRC_CONTENT OUTPUT EXIT_CODE TEST_DIR
   rm -rf "${TEST_DIR-}"
+  unset NVMRC_CONTENT OUTPUT EXIT_CODE TEST_DIR NVM_DIR
 }
 
 : nvm.sh
 \. ../../../nvm.sh
+
+\. ../../common.sh
+
+# an isolated NVM_DIR with a single known version, so that ambient versions
+# and aliases can not affect any assertions
+TEST_DIR="${PWD}/nvm_ls_hash_pattern_tmp"
+mkdir -p "${TEST_DIR}/versions/node/v24.13.0/bin" || die 'failed to create test version dir'
+make_echo "${TEST_DIR}/versions/node/v24.13.0/bin/node" 'v24.13.0' || die 'failed to create test node binary'
+NVM_DIR="${TEST_DIR}"
 
 # Test: nvm_ls with pattern containing # should not cause sed error
 # This is a regression test for https://github.com/nvm-sh/nvm/issues/3761
@@ -28,25 +37,32 @@ echo "$OUTPUT" | grep -q "invalid command code" && \
 [ "$EXIT_CODE" = "3" ] || die "nvm_ls 'foo#bar' should exit with code 3, got $EXIT_CODE"
 echo "$OUTPUT" | grep -q "N/A" || die "nvm_ls 'foo#bar' should output N/A, got: $OUTPUT"
 
-TEST_DIR="${PWD}/nvm_ls_hash_pattern_tmp"
-mkdir -p "${TEST_DIR}/versions/node/v24.13.0/bin" || die 'failed to create test version dir'
-printf '#!/bin/sh\nprintf v24.13.0\\\\n\n' > "${TEST_DIR}/versions/node/v24.13.0/bin/node" || die 'failed to create test node binary'
-chmod +x "${TEST_DIR}/versions/node/v24.13.0/bin/node" || die 'failed to chmod test node binary'
-
-NVM_DIR="${TEST_DIR}"
 NVMRC_CONTENT='v24.13.0
 # krypton is the codename for Node.js v24.x'
 
 OUTPUT="$(nvm_ls "${NVMRC_CONTENT}" 2>&1)"
 EXIT_CODE=$?
 
-echo "$OUTPUT" | grep -q "unterminated regular expression" && \
-  die "nvm_ls with .nvmrc comments caused sed 'unterminated regular expression' error: $OUTPUT"
-
 [ "$EXIT_CODE" = "0" ] || die "nvm_ls with .nvmrc comments should exit with code 0, got $EXIT_CODE"
 [ "$OUTPUT" = "v24.13.0" ] || die "nvm_ls with .nvmrc comments should output v24.13.0, got: $OUTPUT"
 
 OUTPUT="$(nvm_version "${NVMRC_CONTENT}" 2>&1)"
 [ "$OUTPUT" = "v24.13.0" ] || die "nvm_version with .nvmrc comments should output v24.13.0, got: $OUTPUT"
+
+# a partial version reaches nvm_ls's find/sed pipeline, which is where multiline
+# patterns used to break sed ("unterminated regular expression" on BSD sed,
+# "unterminated address regex" on GNU sed); a full x.y.z version takes the
+# explicit-version fast path and never reaches it
+NVMRC_CONTENT='24
+# krypton is the codename for Node.js v24.x'
+
+OUTPUT="$(nvm_ls "${NVMRC_CONTENT}" 2>&1)"
+EXIT_CODE=$?
+
+echo "$OUTPUT" | grep -q "unterminated" && \
+  die "nvm_ls with partial version + comments caused a sed error: $OUTPUT"
+
+[ "$EXIT_CODE" = "0" ] || die "nvm_ls with partial version + comments should exit with code 0, got $EXIT_CODE"
+[ "$OUTPUT" = "v24.13.0" ] || die "nvm_ls with partial version + comments should output v24.13.0, got: $OUTPUT"
 
 cleanup


### PR DESCRIPTION
## Summary

Fixes #3761.

The documented shell integrations pass raw `.nvmrc` contents to `nvm version`. When those contents include comments, `nvm_ls` used the raw value in its sed search expression, which could trigger an `unterminated regular expression` error. This reuses the `.nvmrc` parser for commented or multiline patterns before local version matching.

## Changes

- Split `.nvmrc` content parsing into `nvm_process_nvmrc_content`.
- Normalize raw commented or multiline `.nvmrc` patterns in `nvm_ls`.
- Extend the existing hash-pattern regression test to cover raw `.nvmrc` content through `nvm_ls` and `nvm_version`.

## Testing

- `for shell in sh bash dash zsh; do printf '== %s ==\n' "$shell"; "$shell" './nvm_ls handles hash in pattern' || exit $?; done`
- `for shell in sh bash dash zsh; do printf '== %s ==\n' "$shell"; "$shell" './nvm_process_nvmrc' || exit $?; done`
- `for shell in sh bash dash zsh; do printf '== %s ==\n' "$shell"; "$shell" './nvm_version' || exit $?; done`
- `for shell in bash dash zsh; do printf '== %s -n ==\n' "$shell"; "$shell" -n nvm.sh || exit $?; done`
- `npm run test:check-nonexec`
- `git diff --check`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.
