### PR TITLE
Fix Bash Completion Parse Error Zsh

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -32,14 +32,14 @@ __nvm_commands() {
 
     command="${COMP_WORDS[COMP_CWORD - 2]}"
     case "${command}" in
-      alias) __nvm_installed_nodes ;;
+      (alias) __nvm_installed_nodes ;;
     esac
 
   else
 
     case "${current_word}" in
-      -*) __nvm_options ;;
-      *) __nvm_generate_completion "${COMMANDS}" ;;
+      (-*) __nvm_options ;;
+      (*) __nvm_generate_completion "${COMMANDS}" ;;
     esac
 
   fi
@@ -72,9 +72,9 @@ __nvm() {
   previous_word="${COMP_WORDS[COMP_CWORD - 1]}"
 
   case "${previous_word}" in
-    use | run | exec | ls | list | uninstall) __nvm_installed_nodes ;;
-    alias | unalias) __nvm_alias ;;
-    *) __nvm_commands ;;
+    (use | run | exec | ls | list | uninstall) __nvm_installed_nodes ;;
+    (alias | unalias) __nvm_alias ;;
+    (*) __nvm_commands ;;
   esac
 
   return 0


### PR DESCRIPTION
ZSH's bashcompinit emulation requires the opening parenthesis form for  case patterns. Both forms are valid in Bash, but only the parenthesized form works in both Bash and ZSH.

Changed:
alias)  →  (alias)
-*)     →  (-*)
*)      →  (*)
use | …)         →  (use | …)
alias | unalias) →  (alias | unalias)
*)               →  (*)

Fixes source ~/.zshrc failing for users who load nvm via their zshrc.