### PR TITLE
[Fix] check invalid NVM_DIR in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,7 +68,7 @@ nvm_validate_install_dir() {
   local INSTALL_DIR_BASE
   INSTALL_DIR_BASE="$(nvm_install_dir_base "${INSTALL_DIR}")"
   if [ ! -d "${INSTALL_DIR_BASE}" ]; then
-    nvm_echo >&2 "Invalid \$NVM_DIR: failed to find directory \"${INSTALL_DIR_BASE}\""
+    nvm_echo >&2 "Invalid \$NVM_DIR \"${INSTALL_DIR}\": failed to find directory \"${INSTALL_DIR_BASE}\""
     return 1
   fi
 
@@ -80,9 +80,9 @@ nvm_validate_install_dir() {
   REMAINING_PATH="${INSTALL_DIR#"$INSTALL_DIR_BASE"}"
   REMAINING_PATH="${REMAINING_PATH#/}"
   if [ "${INSTALL_DIR_BASE}" = "/" ]; then
-    nvm_echo >&2 "Invalid \$NVM_DIR: failed to find directory \"/${REMAINING_PATH%%/*}\""
+    nvm_echo >&2 "Invalid \$NVM_DIR \"${INSTALL_DIR}\": failed to find directory \"/${REMAINING_PATH%%/*}\""
   else
-    nvm_echo >&2 "Invalid \$NVM_DIR: failed to find directory \"${INSTALL_DIR_BASE}/${REMAINING_PATH%%/*}\""
+    nvm_echo >&2 "Invalid \$NVM_DIR \"${INSTALL_DIR}\": failed to find directory \"${INSTALL_DIR_BASE}/${REMAINING_PATH%%/*}\""
   fi
   return 1
 }

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,61 @@ nvm_install_dir() {
   fi
 }
 
+nvm_install_dir_base() {
+  local INSTALL_DIR
+  INSTALL_DIR="${1}"
+  while [ "${INSTALL_DIR}" != "/" ] && [ ! -e "${INSTALL_DIR}" ]; do
+    INSTALL_DIR="${INSTALL_DIR%/*}"
+    if [ -z "${INSTALL_DIR}" ]; then
+      INSTALL_DIR="."
+    fi
+  done
+  printf %s "${INSTALL_DIR}"
+}
+
+nvm_validate_install_dir() {
+  local ALLOW_MISSING
+  ALLOW_MISSING="${1-}"
+  local INSTALL_DIR
+  INSTALL_DIR="$(nvm_install_dir)"
+
+  if [ -d "${INSTALL_DIR}" ]; then
+    return
+  fi
+
+  if [ -e "${INSTALL_DIR}" ]; then
+    nvm_echo >&2 "File \"${INSTALL_DIR}\" has the same name as installation directory."
+    return 1
+  fi
+
+  local DEFAULT_INSTALL_DIR
+  DEFAULT_INSTALL_DIR="$(nvm_default_install_dir)"
+  if [ "${INSTALL_DIR}" = "${DEFAULT_INSTALL_DIR}" ]; then
+    return
+  fi
+
+  local INSTALL_DIR_BASE
+  INSTALL_DIR_BASE="$(nvm_install_dir_base "${INSTALL_DIR}")"
+  if [ ! -d "${INSTALL_DIR_BASE}" ]; then
+    nvm_echo >&2 "Invalid \$NVM_DIR: failed to find directory \"${INSTALL_DIR_BASE}\""
+    return 1
+  fi
+
+  if [ -z "${NVM_DIR-}" ] || [ -n "${ALLOW_MISSING}" ]; then
+    return
+  fi
+
+  local REMAINING_PATH
+  REMAINING_PATH="${INSTALL_DIR#"$INSTALL_DIR_BASE"}"
+  REMAINING_PATH="${REMAINING_PATH#/}"
+  if [ "${INSTALL_DIR_BASE}" = "/" ]; then
+    nvm_echo >&2 "Invalid \$NVM_DIR: failed to find directory \"/${REMAINING_PATH%%/*}\""
+  else
+    nvm_echo >&2 "Invalid \$NVM_DIR: failed to find directory \"${INSTALL_DIR_BASE}/${REMAINING_PATH%%/*}\""
+  fi
+  return 1
+}
+
 nvm_latest_version() {
   nvm_echo "v0.40.5"
 }
@@ -126,6 +181,9 @@ nvm_download() {
 install_nvm_from_git() {
   local INSTALL_DIR
   INSTALL_DIR="$(nvm_install_dir)"
+  if [ ! -d "${INSTALL_DIR}" ]; then
+    nvm_validate_install_dir 'allow-missing' || exit 1
+  fi
   local NVM_VERSION
   NVM_VERSION="${NVM_INSTALL_VERSION:-$(nvm_latest_version)}"
   if [ -n "${NVM_INSTALL_VERSION:-}" ]; then
@@ -229,6 +287,9 @@ nvm_install_node() {
 install_nvm_as_script() {
   local INSTALL_DIR
   INSTALL_DIR="$(nvm_install_dir)"
+  if [ ! -d "${INSTALL_DIR}" ]; then
+    nvm_validate_install_dir 'allow-missing' || return 1
+  fi
   local NVM_SOURCE_LOCAL
   NVM_SOURCE_LOCAL="$(nvm_source script)"
   local NVM_EXEC_SOURCE
@@ -373,20 +434,15 @@ nvm_check_global_modules() {
 }
 
 nvm_do_install() {
-  if [ -n "${NVM_DIR-}" ] && ! [ -d "${NVM_DIR}" ]; then
-    if [ -e "${NVM_DIR}" ]; then
-      nvm_echo >&2 "File \"${NVM_DIR}\" has the same name as installation directory."
+  if [ -n "${NVM_DIR-}" ]; then
+    if ! nvm_validate_install_dir; then
       exit 1
     fi
-
-    if [ "${NVM_DIR}" = "$(nvm_default_install_dir)" ]; then
+    if [ ! -d "${NVM_DIR}" ]; then
       mkdir "${NVM_DIR}" || {
         nvm_echo >&2 "Failed to create directory '${NVM_DIR}'"
         exit 2
       }
-    else
-      nvm_echo >&2 "You have \$NVM_DIR set to \"${NVM_DIR}\", but that directory does not exist. Check your profile files and environment."
-      exit 1
     fi
   fi
   # Disable the optional which check, https://www.shellcheck.net/wiki/SC2230
@@ -499,7 +555,8 @@ nvm_reset() {
   unset -f nvm_has nvm_install_dir nvm_latest_version nvm_profile_is_bash_or_zsh \
     nvm_source nvm_node_version nvm_download install_nvm_from_git nvm_install_node \
     install_nvm_as_script nvm_try_profile nvm_detect_profile nvm_check_global_modules \
-    nvm_do_install nvm_reset nvm_default_install_dir nvm_grep
+    nvm_do_install nvm_reset nvm_default_install_dir nvm_grep nvm_install_dir_base \
+    nvm_validate_install_dir
 }
 
 [ "_$NVM_ENV" = "_testing" ] || nvm_do_install

--- a/test/install_script/nvm_mkdir_error_handling
+++ b/test/install_script/nvm_mkdir_error_handling
@@ -24,17 +24,24 @@ type nvm_do_install > /dev/null 2>&1 || die 'nvm_do_install is not available'
 
 IMPOSSIBLE_DIR="/dev/null/impossible_path"
 
-## install_nvm_from_git: mkdir failure should exit with code 2 and print error
+## install_nvm_from_git: invalid custom NVM_DIR should exit with code 1 and print error
 OUTPUT="$(NVM_DIR="${IMPOSSIBLE_DIR}" install_nvm_from_git 2>&1)"
 EXIT_CODE=$?
-[ "${EXIT_CODE}" = '2' ] || die "install_nvm_from_git should exit 2 on mkdir failure, got ${EXIT_CODE}"
-echo "${OUTPUT}" | grep -q "Failed to create directory" || die "install_nvm_from_git should print mkdir error message, got: ${OUTPUT}"
+[ "${EXIT_CODE}" = '1' ] || die "install_nvm_from_git should exit 1 on invalid custom NVM_DIR, got ${EXIT_CODE}"
+echo "${OUTPUT}" | grep -q "Invalid \$NVM_DIR: failed to find directory \"/dev/null\"" || die "install_nvm_from_git should print invalid NVM_DIR base path, got: ${OUTPUT}"
 
-## install_nvm_as_script: mkdir failure should return 1 and print error
+## install_nvm_as_script: invalid custom NVM_DIR should return 1 and print error
 OUTPUT="$(NVM_DIR="${IMPOSSIBLE_DIR}" install_nvm_as_script 2>&1)"
 EXIT_CODE=$?
-[ "${EXIT_CODE}" = '1' ] || die "install_nvm_as_script should return 1 on mkdir failure, got ${EXIT_CODE}"
-echo "${OUTPUT}" | grep -q "Failed to create directory" || die "install_nvm_as_script should print mkdir error message, got: ${OUTPUT}"
+[ "${EXIT_CODE}" = '1' ] || die "install_nvm_as_script should return 1 on invalid custom NVM_DIR, got ${EXIT_CODE}"
+echo "${OUTPUT}" | grep -q "Invalid \$NVM_DIR: failed to find directory \"/dev/null\"" || die "install_nvm_as_script should print invalid NVM_DIR base path, got: ${OUTPUT}"
+
+## nvm_do_install: invalid custom NVM_DIR should report the first missing directory
+MISSING_PARENT_DIR="$(pwd)/missing_parent/child"
+OUTPUT="$(NVM_DIR="${MISSING_PARENT_DIR}" nvm_do_install 2>&1)"
+EXIT_CODE=$?
+[ "${EXIT_CODE}" = '1' ] || die "nvm_do_install should exit 1 on invalid custom NVM_DIR, got ${EXIT_CODE}"
+echo "${OUTPUT}" | grep -q "Invalid \$NVM_DIR: failed to find directory \"$(pwd)/missing_parent\"" || die "nvm_do_install should print the first missing directory, got: ${OUTPUT}"
 
 ## nvm_do_install: mkdir failure for default dir should exit with code 2 and print error
 # Override nvm_default_install_dir to return the impossible path so the mkdir branch is taken

--- a/test/install_script/nvm_mkdir_error_handling
+++ b/test/install_script/nvm_mkdir_error_handling
@@ -28,20 +28,20 @@ IMPOSSIBLE_DIR="/dev/null/impossible_path"
 OUTPUT="$(NVM_DIR="${IMPOSSIBLE_DIR}" install_nvm_from_git 2>&1)"
 EXIT_CODE=$?
 [ "${EXIT_CODE}" = '1' ] || die "install_nvm_from_git should exit 1 on invalid custom NVM_DIR, got ${EXIT_CODE}"
-echo "${OUTPUT}" | grep -q "Invalid \$NVM_DIR: failed to find directory \"/dev/null\"" || die "install_nvm_from_git should print invalid NVM_DIR base path, got: ${OUTPUT}"
+echo "${OUTPUT}" | grep -q "Invalid \$NVM_DIR \"${IMPOSSIBLE_DIR}\": failed to find directory \"/dev/null\"" || die "install_nvm_from_git should print invalid NVM_DIR base path, got: ${OUTPUT}"
 
 ## install_nvm_as_script: invalid custom NVM_DIR should return 1 and print error
 OUTPUT="$(NVM_DIR="${IMPOSSIBLE_DIR}" install_nvm_as_script 2>&1)"
 EXIT_CODE=$?
 [ "${EXIT_CODE}" = '1' ] || die "install_nvm_as_script should return 1 on invalid custom NVM_DIR, got ${EXIT_CODE}"
-echo "${OUTPUT}" | grep -q "Invalid \$NVM_DIR: failed to find directory \"/dev/null\"" || die "install_nvm_as_script should print invalid NVM_DIR base path, got: ${OUTPUT}"
+echo "${OUTPUT}" | grep -q "Invalid \$NVM_DIR \"${IMPOSSIBLE_DIR}\": failed to find directory \"/dev/null\"" || die "install_nvm_as_script should print invalid NVM_DIR base path, got: ${OUTPUT}"
 
 ## nvm_do_install: invalid custom NVM_DIR should report the first missing directory
 MISSING_PARENT_DIR="$(pwd)/missing_parent/child"
 OUTPUT="$(NVM_DIR="${MISSING_PARENT_DIR}" nvm_do_install 2>&1)"
 EXIT_CODE=$?
 [ "${EXIT_CODE}" = '1' ] || die "nvm_do_install should exit 1 on invalid custom NVM_DIR, got ${EXIT_CODE}"
-echo "${OUTPUT}" | grep -q "Invalid \$NVM_DIR: failed to find directory \"$(pwd)/missing_parent\"" || die "nvm_do_install should print the first missing directory, got: ${OUTPUT}"
+echo "${OUTPUT}" | grep -q "Invalid \$NVM_DIR \"${MISSING_PARENT_DIR}\": failed to find directory \"$(pwd)/missing_parent\"" || die "nvm_do_install should print the first missing directory, got: ${OUTPUT}"
 
 ## nvm_do_install: mkdir failure for default dir should exit with code 2 and print error
 # Override nvm_default_install_dir to return the impossible path so the mkdir branch is taken

--- a/test/install_script/nvm_reset
+++ b/test/install_script/nvm_reset
@@ -17,6 +17,8 @@ safe_type() {
 ! safe_type install_nvm_from_git || die 'install_nvm_from_git is still available'
 ! safe_type nvm_reset || die 'nvm_reset is still available'
 ! safe_type nvm_detect_profile || die 'nvm_detect_profile is still available'
+! safe_type nvm_install_dir_base || die 'nvm_install_dir_base is still available'
+! safe_type nvm_validate_install_dir || die 'nvm_validate_install_dir is still available'
 
 NVM_ENV=testing \. ../../install.sh
 
@@ -34,5 +36,7 @@ nvm_reset || die 'nvm_reset failed'
 ! safe_type install_nvm_from_git || die 'install_nvm_from_git is still available'
 ! safe_type nvm_reset || die 'nvm_reset is still available'
 ! safe_type nvm_detect_profile || die 'nvm_detect_profile is still available'
+! safe_type nvm_install_dir_base || die 'nvm_install_dir_base is still available'
+! safe_type nvm_validate_install_dir || die 'nvm_validate_install_dir is still available'
 
 cleanup


### PR DESCRIPTION
Refs #1521

The install script now checks invalid `$NVM_DIR` paths and reports the first
invalid or missing directory.

Tests were added for this case.