### PR TITLE
Dockerfile: Remove mirror site setting; it broke the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,6 @@ ENV DEBIAN_FRONTEND noninteractive
 # ShellCheck version
 ENV SHELLCHECK_VERSION=0.7.0
 
-# Pick a Ubuntu apt mirror site for better speed
-# ref: https://launchpad.net/ubuntu/+archivemirrors
-ENV UBUNTU_APT_SITE ubuntu.cs.utah.edu
-
-# Replace origin apt package site with the mirror site
-RUN sed -E -i "s/([a-z]+.)?archive.ubuntu.com/$UBUNTU_APT_SITE/g" /etc/apt/sources.list
-RUN sed -i "s/security.ubuntu.com/$UBUNTU_APT_SITE/g" /etc/apt/sources.list
-
 # Install apt packages
 RUN apt update         && \
     apt upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"  && \


### PR DESCRIPTION
The ubuntu.cs.utah.edu mirror appears to be obsolete; trying to use it produces error messages along the lines of:

    Ign:2 https://ubuntu.cs.utah.edu/ubuntu jammy-updates InRelease
    Err:2 https://ubuntu.cs.utah.edu/ubuntu jammy-updates InRelease
      Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 155.98.64.89 443]
    W: http://ubuntu.cs.utah.edu/ubuntu/dists/jammy-updates/InRelease: No system certificates available. Try installing ca-certificates.

These messages don't make it completely obvious what the problem is, and it's also a rather obscure setting; you have to carefully read the Dockerfile to find it.

Due to issues like this, and changing mirrors over time, it's best just to drop attempts to use a specific mirror and use whatever the default you get for archive.ubuntu.com etc. With modern CNDs, this is likely to be *faster* than a mirror, anyway.

The package downloads generally happen only once per host, anyway, since Docker will keep not only the final image, but also the layers used to generate it: if the final image is deleted or anything in the Dockerfile after the OS package updates is changed, these cached layers will be used.