### PR TITLE
[readme] Docker: build time is "several" minutes, not 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,7 +1021,7 @@ $ docker run -h nvm-dev -it nvm-dev
 nvm@nvm-dev:~/.nvm$
 ```
 
-It takes about about 8 minutes to build the image and the image size is about 650MB, so it's not suitable for production usage.
+It takes several minutes to build the image and the image size is about 650MB, so it's not suitable for production usage.
 
 For more information and documentation about Docker, please refer to its [official website][docker-www] and [documentation][docker-docs]:
 


### PR DESCRIPTION
On my system, even without using local mirrors, the build is only two minutes, even though I have only a 1 Gbps Internet connection and I'm half-way across the world in Tokyo.

There probably are still users with much slower Internet connections where the build could take eight minutes or more, but "several" still covers that.