### PR TITLE
[Docs] `install.sh`: Fix missing words in bash/zsh completion message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -496,7 +496,7 @@ nvm_do_install() {
     fi
   fi
   if ${BASH_OR_ZSH} && [ -z "${NVM_PROFILE-}" ] ; then
-    nvm_echo "=> Please also append the following lines to the if you are using bash/zsh shell:"
+    nvm_echo "=> Please also append the following lines to the correct file if you are using bash/zsh shell:"
     command printf "${COMPLETION_STR}"
   fi
 


### PR DESCRIPTION
## Summary
- Fixes the incomplete sentence in `install.sh` when nvm cannot detect a profile and needs to tell bash/zsh users to add the completion lines themselves.
- Adds the missing "correct file" wording so it matches the nearby "Append the following lines to the correct file yourself" message.

Fixes #3528

## Test plan
- [x] Confirmed the updated string in `install.sh`
- [ ] Run install with no detectable profile on bash/zsh and confirm the hint reads correctly