### PR TITLE
[Fix]: Escape `#` in nvm_alias to support zsh EXTENDED_GLOB

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -1430,7 +1430,7 @@ nvm_alias() {
 
   local NVM_ALIAS_LINE
   while IFS= read -r NVM_ALIAS_LINE || [ -n "${NVM_ALIAS_LINE}" ]; do
-    NVM_ALIAS_LINE="${NVM_ALIAS_LINE%%#*}"
+    NVM_ALIAS_LINE="${NVM_ALIAS_LINE%%\#*}"
     case "${NVM_ALIAS_LINE}" in
       *[![:space:]]*) ;;
       *) continue ;;

--- a/test/fast/Unit tests/nvm_alias handles comments
+++ b/test/fast/Unit tests/nvm_alias handles comments
@@ -6,6 +6,7 @@ cleanup () {
   rm -rf ../../../alias/test-comment
   rm -rf ../../../alias/test-inline-comment
   rm -rf ../../../alias/test-comment-first
+  rm -rf ../../../alias/test-extended-glob
 }
 
 : nvm.sh
@@ -30,5 +31,19 @@ v0.12" > ../../../alias/test-comment-first
 OUTPUT="$(nvm_alias test-comment-first)"
 EXPECTED_OUTPUT="v0.12"
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_alias test-comment-first' should skip comment-only first line; expected '$EXPECTED_OUTPUT', got '$OUTPUT'"
+
+# Test: alias file with inline comment under zsh EXTENDED_GLOB (regression for #3895)
+# Under zsh's EXTENDED_GLOB, `#` is a glob operator, so the comment-strip
+# expansion `${var%%#*}` raises "bad pattern: #*" and yields no output. The fix
+# escapes the `#` so it is matched literally. Only zsh supports EXTENDED_GLOB,
+# so this assertion is skipped on other shells.
+if nvm_is_zsh; then
+  echo "v0.13 # inline comment under EXTENDED_GLOB" > ../../../alias/test-extended-glob
+  setopt EXTENDED_GLOB
+  OUTPUT="$(nvm_alias test-extended-glob)"
+  setopt NO_EXTENDED_GLOB
+  EXPECTED_OUTPUT="v0.13"
+  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_alias test-extended-glob' should strip inline comment under EXTENDED_GLOB; expected '$EXPECTED_OUTPUT', got '$OUTPUT'"
+fi
 
 cleanup


### PR DESCRIPTION
## Problem
`nvm use default` (and any command that reads aliases) fails under zsh when `EXTENDED_GLOB` is enabled (e.g. via prezto):

    nvm_alias:32: bad pattern: #*

## Cause
In `nvm_alias`, the comment-stripping expansion

    NVM_ALIAS_LINE="${NVM_ALIAS_LINE%%#*}"

treats `#` as a glob operator under zsh's `EXTENDED_GLOB`, so `#*` is an invalid pattern. `nvm_alias` then returns nothing, which cascades: `nvm_resolve_alias` → empty → `nvm_version default` → `N/A` → `nvm use default` reports the version as not installed.

## Fix
Escape the `#` so it is matched literally:

    NVM_ALIAS_LINE="${NVM_ALIAS_LINE%%\#*}"

`\#` is a literal `#` in both bash and zsh (with or without `EXTENDED_GLOB`), so behaviour is unchanged elsewhere.

## Verification
- `nvm use default` / `nvm alias default` / `nvm which default` work with `EXTENDED_GLOB` on in zsh.
- The `${var%%\#*}` expansion yields identical results in zsh (EXTENDED_GLOB on/off) and bash.