### PR TITLE
[Fix] `nvm --help`: render the `set-colors` legend in color

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -594,6 +594,8 @@ nvm_find_nvmrc() {
 }
 
 nvm_nvmrc_invalid_msg() {
+  local NVM_HAS_COLORS
+  NVM_HAS_COLORS=0
   local error_text
   error_text="invalid .nvmrc!
 all non-commented content (anything after # is a comment) must be either:

--- a/nvm.sh
+++ b/nvm.sh
@@ -1128,6 +1128,8 @@ nvm_set_colors() {
     local CURRENT_COLOR
     local NOT_INSTALLED_COLOR
     local DEFAULT_COLOR
+    local NVM_HAS_COLORS
+    NVM_HAS_COLORS=0
 
     INSTALLED_COLOR="$(echo "$1" | awk '{ print substr($0, 1, 1); }')"
     LTS_AND_SYSTEM_COLOR="$(echo "$1" | awk '{ print substr($0, 2, 1); }')"
@@ -1138,6 +1140,7 @@ nvm_set_colors() {
       nvm_echo "Setting colors to: ${INSTALLED_COLOR} ${LTS_AND_SYSTEM_COLOR} ${CURRENT_COLOR} ${NOT_INSTALLED_COLOR} ${DEFAULT_COLOR}"
       nvm_echo "WARNING: Colors may not display because they are not supported in this shell."
     else
+      NVM_HAS_COLORS=1
       nvm_echo_with_colors "Setting colors to: $(nvm_wrap_with_color_code "${INSTALLED_COLOR}" "${INSTALLED_COLOR}")$(nvm_wrap_with_color_code "${LTS_AND_SYSTEM_COLOR}" "${LTS_AND_SYSTEM_COLOR}")$(nvm_wrap_with_color_code "${CURRENT_COLOR}" "${CURRENT_COLOR}")$(nvm_wrap_with_color_code "${NOT_INSTALLED_COLOR}" "${NOT_INSTALLED_COLOR}")$(nvm_wrap_with_color_code "${DEFAULT_COLOR}" "${DEFAULT_COLOR}")"
     fi
     export NVM_COLORS="$1"
@@ -1175,7 +1178,7 @@ nvm_wrap_with_color_code() {
   CODE="$(nvm_print_color_code "${1}" 2>/dev/null ||:)"
   local TEXT
   TEXT="${2-}"
-  if nvm_has_colors && [ -n "${CODE}" ]; then
+  if { [ "${NVM_HAS_COLORS-}" = 1 ] || nvm_has_colors; } && [ -n "${CODE}" ]; then
     nvm_echo_with_colors "\033[${CODE}${TEXT}\033[0m"
   else
     nvm_echo "${TEXT}"
@@ -3412,6 +3415,12 @@ nvm() {
             break
           fi
         done
+
+        local NVM_HAS_COLORS
+        NVM_HAS_COLORS=0
+        if nvm_has_colors; then
+          NVM_HAS_COLORS=1
+        fi
 
         local NVM_IOJS_PREFIX
         NVM_IOJS_PREFIX="$(nvm_iojs_prefix)"

--- a/test/fast/Set Colors/nvm --help colors the set-colors legend
+++ b/test/fast/Set Colors/nvm --help colors the set-colors legend
@@ -2,14 +2,30 @@
 
 set -e
 
-die () { echo "$@" ; exit 1; }
+cleanup() {
+  rm -f "${NVM_HAS_COLORS_MARKER}"
+  unset NVM_HAS_COLORS_MARKER NVM_NO_COLORS
+  unset -f nvm_has_colors
+}
+
+die () { echo "$@" ; cleanup ; exit 1; }
 
 export NVM_DIR="$(cd ../../.. && pwd)"
 
 : nvm.sh
 \. ../../../nvm.sh
 
-nvm_has_colors() { return 0; }
+unset NVM_HAS_COLORS
+unset NVM_NO_COLORS
+
+NVM_HAS_COLORS_MARKER="$(mktemp)"
+# one-shot: the fix asks once up front, while the unfixed code re-asks inside every command substitution
+nvm_has_colors() {
+  if [ "${NVM_NO_COLORS-}" = '--no-colors' ] || [ ! -e "${NVM_HAS_COLORS_MARKER}" ]; then
+    return 1
+  fi
+  rm -f "${NVM_HAS_COLORS_MARKER}"
+}
 
 HELP="$(nvm --help)"
 
@@ -24,3 +40,15 @@ case "${HELP}" in
   *"${EXPECTED}"*) ;;
   *) die "nvm --help did not color the color codes legend" ;;
 esac
+
+rm -f "${NVM_HAS_COLORS_MARKER}"
+NVM_HAS_COLORS_MARKER="$(mktemp)"
+
+HELP="$(nvm --help --no-colors)"
+
+EXPECTED="$(command printf %b '\033[')"
+case "${HELP}" in
+  *"${EXPECTED}"*) die "nvm --help --no-colors colored the legend" ;;
+esac
+
+cleanup

--- a/test/fast/Set Colors/nvm --help colors the set-colors legend
+++ b/test/fast/Set Colors/nvm --help colors the set-colors legend
@@ -51,4 +51,7 @@ case "${HELP}" in
   *"${EXPECTED}"*) die "nvm --help --no-colors colored the legend" ;;
 esac
 
+nvm --help >/dev/null
+[ -z "${NVM_HAS_COLORS-}" ] || die "nvm --help leaked NVM_HAS_COLORS=${NVM_HAS_COLORS} into the shell"
+
 cleanup

--- a/test/fast/Set Colors/nvm --help colors the set-colors legend
+++ b/test/fast/Set Colors/nvm --help colors the set-colors legend
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+die () { echo "$@" ; exit 1; }
+
+export NVM_DIR="$(cd ../../.. && pwd)"
+
+: nvm.sh
+\. ../../../nvm.sh
+
+nvm_has_colors() { return 0; }
+
+HELP="$(nvm --help)"
+
+EXPECTED="$(command printf %b '\033[0;34mb\033[0m\033[0;33my\033[0m\033[0;32mg\033[0m\033[0;31mr\033[0m\033[0;37me\033[0m')"
+case "${HELP}" in
+  *"${EXPECTED}"*) ;;
+  *) die "nvm --help did not color the initial colors sample" ;;
+esac
+
+EXPECTED="$(command printf %b '\033[0;34mb\033[0m/\033[1;34mB\033[0m = \033[0;34mblue\033[0m / \033[1;34mbold blue\033[0m')"
+case "${HELP}" in
+  *"${EXPECTED}"*) ;;
+  *) die "nvm --help did not color the color codes legend" ;;
+esac

--- a/test/fast/Set Colors/nvm set-colors colors the confirmation line
+++ b/test/fast/Set Colors/nvm set-colors colors the confirmation line
@@ -29,4 +29,9 @@ EXPECTED_OUTPUT="$(command printf %b 'Setting colors to: \033[0;34mb\033[0m\033[
 
 [ "_${OUTPUT}" = "_${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
 
+rm -f "${NVM_HAS_COLORS_MARKER}"
+NVM_HAS_COLORS_MARKER="$(mktemp)"
+nvm set-colors bygre >/dev/null
+[ -z "${NVM_HAS_COLORS-}" ] || die "nvm set-colors leaked NVM_HAS_COLORS=${NVM_HAS_COLORS} into the shell"
+
 cleanup

--- a/test/fast/Set Colors/nvm set-colors colors the confirmation line
+++ b/test/fast/Set Colors/nvm set-colors colors the confirmation line
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -e
+
+cleanup() {
+  rm -f "${NVM_HAS_COLORS_MARKER}"
+  unset NVM_HAS_COLORS_MARKER
+  unset -f nvm_has_colors
+}
+
+die () { echo "$@" ; cleanup ; exit 1; }
+
+: nvm.sh
+\. ../../../nvm.sh
+
+unset NVM_HAS_COLORS
+
+NVM_HAS_COLORS_MARKER="$(mktemp)"
+# one-shot: the fix asks once up front, while the unfixed code re-asks inside every command substitution
+nvm_has_colors() {
+  if [ ! -e "${NVM_HAS_COLORS_MARKER}" ]; then
+    return 1
+  fi
+  rm -f "${NVM_HAS_COLORS_MARKER}"
+}
+
+OUTPUT="$(nvm set-colors bygre)"
+EXPECTED_OUTPUT="$(command printf %b 'Setting colors to: \033[0;34mb\033[0m\033[0;33my\033[0m\033[0;32mg\033[0m\033[0;31mr\033[0m\033[0;37me\033[0m')"
+
+[ "_${OUTPUT}" = "_${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+
+cleanup

--- a/test/fast/Unit tests/nvm_nvmrc_invalid_msg
+++ b/test/fast/Unit tests/nvm_nvmrc_invalid_msg
@@ -17,4 +17,9 @@ case "${OUTPUT}" in
   *"${ESC}"*) die "an exported NVM_HAS_COLORS should not color the invalid .nvmrc message; got >${OUTPUT}<" ;;
 esac
 
+case "${OUTPUT}" in
+  *'invalid .nvmrc!'*) ;;
+  *) die "expected the invalid-.nvmrc message; got >${OUTPUT}<" ;;
+esac
+
 cleanup

--- a/test/fast/Unit tests/nvm_nvmrc_invalid_msg
+++ b/test/fast/Unit tests/nvm_nvmrc_invalid_msg
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+cleanup() {
+  unset NVM_HAS_COLORS OUTPUT ESC
+}
+
+die () { echo "$@" ; cleanup ; exit 1; }
+
+: nvm.sh
+\. ../../../nvm.sh
+
+export NVM_HAS_COLORS=1
+
+OUTPUT="$(nvm_nvmrc_invalid_msg 'lts/*' 2>&1)"
+ESC="$(command printf %b '\033[')"
+case "${OUTPUT}" in
+  *"${ESC}"*) die "an exported NVM_HAS_COLORS should not color the invalid .nvmrc message; got >${OUTPUT}<" ;;
+esac
+
+cleanup

--- a/test/fast/Unit tests/nvm_wrap_with_color_code
+++ b/test/fast/Unit tests/nvm_wrap_with_color_code
@@ -5,6 +5,8 @@ die () { echo "$@" ; exit 1; }
 : nvm.sh
 \. ../../../nvm.sh
 
+unset NVM_HAS_COLORS
+
 # nvm_wrap_with_color_code should not color inside command substitution when colors are undetected
 OUTPUT="$(nvm_wrap_with_color_code 'b' 'b')"
 [ "_${OUTPUT}" = '_b' ] || die "expected plain text without color support; got >${OUTPUT}<"
@@ -19,4 +21,11 @@ EXPECTED_OUTPUT="$(command printf %b '\033[0;34mb\033[0m')"
 OUTPUT="$(nvm_wrap_with_color_code 'z' 'z')"
 [ "_${OUTPUT}" = '_z' ] || die "expected plain text for an unknown color code; got >${OUTPUT}<"
 
+# NVM_HAS_COLORS=0 is not an off switch; it falls through to nvm_has_colors
+NVM_HAS_COLORS=0
+nvm_has_colors() { return 0; }
+OUTPUT="$(nvm_wrap_with_color_code 'b' 'b')"
+[ "_${OUTPUT}" = "_${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+
 unset NVM_HAS_COLORS
+unset -f nvm_has_colors

--- a/test/fast/Unit tests/nvm_wrap_with_color_code
+++ b/test/fast/Unit tests/nvm_wrap_with_color_code
@@ -1,1 +1,22 @@
+#!/bin/sh
 
+die () { echo "$@" ; exit 1; }
+
+: nvm.sh
+\. ../../../nvm.sh
+
+# nvm_wrap_with_color_code should not color inside command substitution when colors are undetected
+OUTPUT="$(nvm_wrap_with_color_code 'b' 'b')"
+[ "_${OUTPUT}" = '_b' ] || die "expected plain text without color support; got >${OUTPUT}<"
+
+# nvm_wrap_with_color_code should color inside command substitution when NVM_HAS_COLORS is 1
+NVM_HAS_COLORS=1
+OUTPUT="$(nvm_wrap_with_color_code 'b' 'b')"
+EXPECTED_OUTPUT="$(command printf %b '\033[0;34mb\033[0m')"
+[ "_${OUTPUT}" = "_${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+
+# nvm_wrap_with_color_code should not color an unknown color code
+OUTPUT="$(nvm_wrap_with_color_code 'z' 'z')"
+[ "_${OUTPUT}" = '_z' ] || die "expected plain text for an unknown color code; got >${OUTPUT}<"
+
+unset NVM_HAS_COLORS


### PR DESCRIPTION
The `set-colors` legend in `nvm --help` builds its samples inside command substitution, so `nvm_wrap_with_color_code` sees a pipe on stdout, `nvm_has_colors` returns false, and every token falls back to plain text. That section can never show color, on any terminal. `nvm set-colors` prints its confirmation line the same way and loses its colors too, even though it already checked that colors are supported.

`nvm_wrap_with_color_code` now accepts a pre-computed `NVM_HAS_COLORS`, the way `nvm_print_alias_path` already does, and both call sites compute it before wrapping. Output stays plain with `--no-colors`, when stdout is not a terminal, or when the terminal has fewer than 8 colors.

Fixes #3896