### PR TITLE
Add support for OpenHarmony platform

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2253,6 +2253,18 @@ nvm_get_os() {
     AIX\ *) NVM_OS=aix ;;
     CYGWIN* | MSYS* | MINGW*) NVM_OS=win ;;
   esac
+
+  # OpenHarmony can't be identified from `uname` alone: a device may run either
+  # a Linux kernel or a HarmonyOS kernel. Ask the userland, but only when
+  # `uname` has not already identified some other OS.
+  case "${NVM_OS-}" in
+    '' | linux)
+      if [ -x /system/bin/param ] && /system/bin/param get const.ohos.fullname </dev/null 2>/dev/null | nvm_grep -q '^OpenHarmony'; then
+        NVM_OS=openharmony
+      fi
+      ;;
+  esac
+
   nvm_echo "${NVM_OS-}"
 }
 

--- a/nvm.sh
+++ b/nvm.sh
@@ -2329,6 +2329,18 @@ nvm_get_os() {
     AIX\ *) NVM_OS=aix ;;
     CYGWIN* | MSYS* | MINGW*) NVM_OS=win ;;
   esac
+
+  # OpenHarmony can't be identified from `uname` alone: a device may run either
+  # a Linux kernel or a HarmonyOS kernel. Ask the userland, but only when
+  # `uname` has not already identified some other OS.
+  case "${NVM_OS-}" in
+    '' | linux)
+      if [ -x /system/bin/param ] && /system/bin/param get const.ohos.fullname </dev/null 2>/dev/null | nvm_grep -q '^OpenHarmony'; then
+        NVM_OS=openharmony
+      fi
+      ;;
+  esac
+
   nvm_echo "${NVM_OS-}"
 }
 

--- a/test/fast/Unit tests/nvm_get_os
+++ b/test/fast/Unit tests/nvm_get_os
@@ -1,0 +1,160 @@
+#!/bin/sh
+
+# Save the PATH as it was when the test started to restore it when it finishes
+ORIG_PATH="${PATH}"
+
+cleanup() {
+  # Restore the PATH as it was when the test started
+  export PATH="${ORIG_PATH}"
+  rm -rf "${TMP_DIR}"
+}
+
+die() {
+  cleanup
+  echo "$@"
+  exit 1
+}
+
+: nvm.sh
+\. ../../../nvm.sh
+
+# Directory where mocked binaries used by nvm_get_os for each OS/arch are located
+MOCKS_DIR="$(pwd)/../../mocks"
+
+# Sets the PATH for these tests to include the symlinks to the mocked binaries
+export PATH=".:${PATH}"
+
+TMP_DIR=$(mktemp -d)
+
+# Setups mock binaries for a given OS and arch that mimic the output of
+# the real binaries used by nvm_get_os to guess the OS of a given system.
+setup_mock_os() {
+  local OS
+  OS=$1
+  local ARCH
+  ARCH=$2
+  ln -sf "${MOCKS_DIR}/uname_${OS}_${ARCH}" ./uname
+}
+
+# Cleans up the setup done by setup_mock_os.
+cleanup_mock_os() {
+  rm -f ./uname
+}
+
+# Runs nvm_get_os for OS $OS and arch $ARCH, and compares the expected
+# output $EXPECTED_OUTPUT with the actual output. Does nothing and exits
+# cleanly if they match, dies otherwise.
+run_test() {
+  local EXPECTED
+  EXPECTED=$1
+  local OUTPUT
+  OUTPUT="$(nvm_get_os)"
+  [ "_${OUTPUT}" = "_${EXPECTED}" ] ||
+    die "nvm_get_os produced \"${OUTPUT}\", expected \"${EXPECTED}\""
+}
+
+# Pre-existing arms
+
+setup_mock_os linux aarch64
+run_test "linux"
+cleanup_mock_os
+
+setup_mock_os osx amd64
+run_test "darwin"
+cleanup_mock_os
+
+setup_mock_os smartos amd64
+run_test "sunos"
+cleanup_mock_os
+
+# HarmonyOS kernel without OpenHarmony userland
+
+setup_mock_os harmonyos aarch64
+run_test ""
+cleanup_mock_os
+
+# OpenHarmony detection via chroot
+
+setup_chroot() {
+  chroot_dir=$1
+  param_mock=$2
+  uname_mock=$3
+
+  # Directories
+  mkdir -p "${chroot_dir}/etc"
+  mkdir -p "${chroot_dir}/bin"
+  mkdir -p "${chroot_dir}/usr/bin"
+  mkdir -p "${chroot_dir}/lib64"
+  mkdir -p "${chroot_dir}/dev"
+  mkdir -p "${chroot_dir}/system/bin"
+
+  # Files and binaries
+  cp ../../../nvm.sh "${chroot_dir}/"
+  cp /bin/sh /usr/bin/dirname /usr/bin/grep "${chroot_dir}/usr/bin/"
+  cp "${uname_mock}" "${chroot_dir}/usr/bin/uname"
+  chmod +x "${chroot_dir}/usr/bin/uname"
+  ln -sf ../usr/bin/sh "${chroot_dir}/bin/sh"
+
+  # Fake OpenHarmony param binary
+  cp "${param_mock}" "${chroot_dir}/system/bin/param"
+  chmod +x "${chroot_dir}/system/bin/param"
+
+  # Libraries
+  for binary in /bin/sh /usr/bin/dirname /usr/bin/uname /usr/bin/grep; do
+    for lib in $(ldd $binary | awk '{print $3}' | grep "^/"); do
+      dir=$(dirname "${lib}")
+      mkdir -p "${chroot_dir}${dir}"
+      cp "${lib}" "${chroot_dir}${dir}/"
+    done
+  done
+
+  # Dynamic linker
+  cp /lib64/ld-linux-x86-64.so.2 "${chroot_dir}/lib64/"
+
+  # /dev/null
+  sudo mknod "${chroot_dir}/dev/null" c 1 3
+}
+
+# The chroot fixtures assume a glibc layout (fixed dynamic-linker path
+# under /lib64, coreutils binaries). On musl Alpine that setup does not
+# apply, and nvm_get_os's OpenHarmony probe cannot be exercised there;
+# skip the chroot checks on Alpine.
+if [ -f "/etc/alpine-release" ]; then
+  echo "on Alpine; skipping chroot OpenHarmony checks"
+else
+  CHROOT_UNAME_LINUX_PARAM_OPENHARMONY="${TMP_DIR}/uname_linux_param_openharmony"
+  CHROOT_UNAME_LINUX_PARAM_OTHER="${TMP_DIR}/uname_linux_param_other"
+  CHROOT_UNAME_HARMONYOS_PARAM_OPENHARMONY="${TMP_DIR}/uname_harmonyos_param_openharmony"
+  CHROOT_UNAME_HARMONYOS_PARAM_OTHER="${TMP_DIR}/uname_harmonyos_param_other"
+
+  setup_chroot "${CHROOT_UNAME_LINUX_PARAM_OPENHARMONY}" "${MOCKS_DIR}/param_openharmony" "${MOCKS_DIR}/uname_linux_aarch64"
+  setup_chroot "${CHROOT_UNAME_LINUX_PARAM_OTHER}" "${MOCKS_DIR}/param_other" "${MOCKS_DIR}/uname_linux_aarch64"
+  setup_chroot "${CHROOT_UNAME_HARMONYOS_PARAM_OPENHARMONY}" "${MOCKS_DIR}/param_openharmony" "${MOCKS_DIR}/uname_harmonyos_aarch64"
+  setup_chroot "${CHROOT_UNAME_HARMONYOS_PARAM_OTHER}" "${MOCKS_DIR}/param_other" "${MOCKS_DIR}/uname_harmonyos_aarch64"
+
+  # Linux kernel with an OpenHarmony param -> openharmony
+  OS_UNAME_LINUX_PARAM_OPENHARMONY=$(sudo chroot "${CHROOT_UNAME_LINUX_PARAM_OPENHARMONY}" /bin/sh -c ". ./nvm.sh && nvm_get_os")
+  if [ "${OS_UNAME_LINUX_PARAM_OPENHARMONY}" != "openharmony" ]; then
+    die "nvm_get_os produced \"${OS_UNAME_LINUX_PARAM_OPENHARMONY}\", expected \"openharmony\""
+  fi
+
+  # Linux kernel with an unrelated param stays linux
+  OS_UNAME_LINUX_PARAM_OTHER=$(sudo chroot "${CHROOT_UNAME_LINUX_PARAM_OTHER}" /bin/sh -c ". ./nvm.sh && nvm_get_os")
+  if [ "${OS_UNAME_LINUX_PARAM_OTHER}" != "linux" ]; then
+    die "nvm_get_os produced \"${OS_UNAME_LINUX_PARAM_OTHER}\", expected \"linux\""
+  fi
+
+  # HarmonyOS kernel with an OpenHarmony param -> openharmony
+  OS_UNAME_HARMONYOS_PARAM_OPENHARMONY=$(sudo chroot "${CHROOT_UNAME_HARMONYOS_PARAM_OPENHARMONY}" /bin/sh -c ". ./nvm.sh && nvm_get_os")
+  if [ "${OS_UNAME_HARMONYOS_PARAM_OPENHARMONY}" != "openharmony" ]; then
+    die "nvm_get_os produced \"${OS_UNAME_HARMONYOS_PARAM_OPENHARMONY}\", expected \"openharmony\""
+  fi
+
+  # HarmonyOS kernel with an unrelated param stays empty
+  OS_UNAME_HARMONYOS_PARAM_OTHER=$(sudo chroot "${CHROOT_UNAME_HARMONYOS_PARAM_OTHER}" /bin/sh -c ". ./nvm.sh && nvm_get_os")
+  if [ "_${OS_UNAME_HARMONYOS_PARAM_OTHER}" != "_" ]; then
+    die "nvm_get_os produced \"${OS_UNAME_HARMONYOS_PARAM_OTHER}\", expected \"\""
+  fi
+fi
+
+cleanup

--- a/test/mocks/param_openharmony
+++ b/test/mocks/param_openharmony
@@ -1,0 +1,3 @@
+if [ "$#" -eq 2 ] && [ "$1" = "get" ] && [ "$2" = "const.ohos.fullname" ]; then
+  echo "OpenHarmony-6.1.0.31"
+fi

--- a/test/mocks/param_other
+++ b/test/mocks/param_other
@@ -1,0 +1,3 @@
+if [ "$#" -eq 2 ] && [ "$1" = "get" ] && [ "$2" = "const.ohos.fullname" ]; then
+  echo "SomeOtherOS-1.2.3"
+fi

--- a/test/mocks/uname_harmonyos_aarch64
+++ b/test/mocks/uname_harmonyos_aarch64
@@ -1,0 +1,5 @@
+if [ "_$1" = "_-m" ]; then
+  echo "aarch64"
+else
+  echo "HarmonyOS localhost HongMeng Kernel 1.12.0 #1 SMP Tue Jul 14 09:40:51 UTC 2026 aarch64 Toybox"
+fi


### PR DESCRIPTION
## Description

Node.js currently supports the OpenHarmony platform (see [BUILDING.md](https://github.com/nodejs/node/blob/main/BUILDING.md)), but `nvm` does not yet support it. Therefore, I am submitting this patch to add OpenHarmony platform support to `nvm`.

## Proposed Changes

OpenHarmony has various distributions featuring mutually compatible user spaces but different underlying kernels, meaning the same binary may run on different kernels. Currently, the industry primarily uses Linux and HarmonyOS kernels. Consequently, we cannot simply rely on `uname` to identify the platform. Instead, platform detection is implemented using user-space characteristic files and strings.

## Distribution Source

Since the support tier for OpenHarmony in Node.js is currently marked as "Experimental", the official distribution source [nodejs.org/dist](https://nodejs.org/dist/) does not publish OpenHarmony binaries. Users must specify a third-party source to install OpenHarmony builds via `nvm`.

For example, [ohos-node.com/dist](https://ohos-node.com/dist) is an available third-party source. This source is currently maintained by me. You can visit the project [homepage](https://ohos-node.com/) for more information.

I have verified that after running `export NVM_NODEJS_ORG_MIRROR="https://ohos-node.com/dist"`, `nvm` can successfully fetch OpenHarmony binaries from this source.

## Support

I am willing to actively participate in maintaining OpenHarmony support for `nvm`. If users submit OpenHarmony-related issues to `nvm` in the future, feel free to mention me or send me an email, and I will be happy to provide assistance.