### PR TITLE
fix(mirror): allow port numbers in implicit mirror URL validation

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2387,7 +2387,7 @@ nvm_get_mirror() {
   esac
 
 
-  if ! nvm_echo "${NVM_MIRROR}" | command awk '{ if ($0 !~ /^https?:\/\/[a-zA-Z0-9.\/_-]+$/) exit 1 }'; then
+  if ! nvm_echo "${NVM_MIRROR}" | command awk '{ if ($0 !~ /^https?:\/\/[a-zA-Z0-9.\:/_-]+$/) exit 1 }'; then
       nvm_err '$NVM_NODEJS_ORG_MIRROR and $NVM_IOJS_ORG_MIRROR may only contain a URL'
       return 2
   fi


### PR DESCRIPTION

The URL regex check in `nvm_get_mirror` previously excluded colons (`:`), causing `$NVM_NODEJS_ORG_MIRROR` and `$NVM_IOJS_ORG_MIRROR` validation to fail when using non-standard ports (e.g., http://host:8200/node/).

This patch adds `:` to the allowed character set in the awk pattern, allowing custom intranet or proxy mirror URLs with explicit port numbers.