### PR TITLE
[Fix] `nvm_err`, `nvm_err_with_colors`: do not fail when stderr is closed

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -33,12 +33,15 @@ nvm_cd() {
   \cd "$@"
 }
 
+# a caller that closed stderr, rather than redirecting it to /dev/null, makes
+# the `>&2` fail; zsh cannot report that, so it aborts the script, which only a
+# subshell contains, and `|| return 0` keeps the status from the caller
 nvm_err() {
-  >&2 nvm_echo "$@"
+  (>&2 nvm_echo "$@") || return 0
 }
 
 nvm_err_with_colors() {
-  >&2 nvm_echo_with_colors "$@"
+  (>&2 nvm_echo_with_colors "$@") || return 0
 }
 
 nvm_grep() {

--- a/test/fast/Unit tests/nvm_compare_checksum
+++ b/test/fast/Unit tests/nvm_compare_checksum
@@ -54,4 +54,6 @@ EXPECTED_OUTPUT='Checksums matched!'
 [ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
 [ "${CAPTURED_EXIT_CODE}" = 0 ] || die "expected to exit with code 0, got ${CAPTURED_EXIT_CODE}"
 
+(set +x; nvm_compare_checksum ../../../nvm.sh checksum 2>&-) || die "with stderr closed, expected to exit with code 0, got $?"
+
 cleanup

--- a/test/fast/Unit tests/nvm_err
+++ b/test/fast/Unit tests/nvm_err
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+: nvm.sh
+\. ../../../nvm.sh
+
+\. ../../common.sh
+
+try_err nvm_err 'an error'
+EXPECTED_OUTPUT='an error'
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 0 ] || die "expected to exit with code 0, got ${CAPTURED_EXIT_CODE}"
+
+try_err nvm_err_with_colors 'an error'
+EXPECTED_OUTPUT='an error'
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 0 ] || die "expected to exit with code 0, got ${CAPTURED_EXIT_CODE}"
+
+nvm_err 'an error' 2>&- || die "nvm_err with stderr closed exited with code $?"
+nvm_err_with_colors 'an error' 2>&- || die "nvm_err_with_colors with stderr closed exited with code $?"


### PR DESCRIPTION
When a caller closes stderr instead of redirecting it to `/dev/null`, which Ruby's `IO.popen(..., err: :close)` and similar APIs do, the `>&2` redirection in `nvm_err` fails, so `nvm_err` returns non-zero. `nvm_compare_checksum` ends with `nvm_err 'Checksums matched!'`, so a successful checksum then reports failure and the install is aborted.

Running the redirection in a subshell keeps that failure out of the caller. It also matters in zsh, which aborts the whole shell when its own diagnostic about the failed redirection cannot be written either.

Fixes #3906
