### PR TITLE
[Fix] only run `hash -r` when hashing is enabled in shell

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -4228,7 +4228,11 @@ nvm() {
         fi
       else
         export PATH="${NEWPATH}"
-        \hash -r
+        # run only when hashing is enabled, else `hash` prints
+        # "hash: hashing disabled" on every new terminal
+        if [ "${-#*h}" != "$-" ]; then
+          \hash -r
+        fi
         if [ "${NVM_SILENT:-0}" -ne 1 ]; then
           nvm_echo "${NVM_DIR}/*/bin removed from \${PATH}"
         fi
@@ -4373,7 +4377,11 @@ nvm() {
         export MANPATH
       fi
       export PATH
-      \hash -r
+      # run only when hashing is enabled, else `hash` prints
+      # "hash: hashing disabled" on every new terminal
+      if [ "${-#*h}" != "$-" ]; then
+        \hash -r
+      fi
       export NVM_BIN="${NVM_VERSION_DIR}/bin"
       export NVM_INC="${NVM_VERSION_DIR}/include/node"
       if [ "${NVM_SYMLINK_CURRENT-}" = true ]; then

--- a/test/fast/Unit tests/nvm_deactivate does not error when hashing is disabled
+++ b/test/fast/Unit tests/nvm_deactivate does not error when hashing is disabled
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+: nvm.sh
+\. ../../../nvm.sh
+
+# bash errors on `hash -r` when hashing is disabled (`set +h`); the guarded
+# call in `nvm deactivate` must not print "hash: hashing disabled"
+if [ "${-#*h}" != "$-" ]; then
+  NVM_DIR="$(command pwd)"
+  PATH="$NVM_DIR/fake/bin:$PATH"
+  set +h
+  OUTPUT=`nvm deactivate 2>&1`
+  set -h
+  case "${OUTPUT}" in
+    *"hash: hashing disabled"*) die "nvm deactivate printed 'hash: hashing disabled': ${OUTPUT}" ;;
+  esac
+fi


### PR DESCRIPTION
If hash is disabled in shell (default in some shell configs), opening a terminal displays the message "bash: hash: hashing disabled".  To fix, wrap `hash -r` in an if fi.  May also remove `hash -r` entirely: According to POSIX, hash, and shells nvm supports, when we `export PATH` it clears hash history because it can nolonger rely on its previous assumption that the paths to the commands are correct. Per hash: `man 1 hash`
"The effects of hash -r can also be achieved portably by resetting the value of PATH;"