### PR TITLE
fix: nvm_err and nvm_err_with_colors should not fail when stderr is closed

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -34,11 +34,22 @@ nvm_cd() {
 }
 
 nvm_err() {
-  >&2 nvm_echo "$@"
+  # Run the stderr redirection in a subshell so that a closed stderr (eg, from
+  # `IO.popen(..., err: :close)`) does not propagate a non-zero exit status
+  # back to the caller. `nvm_compare_checksum` ends with `nvm_err 'Checksums
+  # matched!'`, so a successful checksum would otherwise be reported as a
+  # failure. `|| true` swallows the subshell's exit code; `nvm_echo` itself
+  # silences any `printf` errors via `2>/dev/null`. See issue #3906.
+  (
+    >&2 nvm_echo "$@"
+  ) || true
 }
 
 nvm_err_with_colors() {
-  >&2 nvm_echo_with_colors "$@"
+  # See `nvm_err` for rationale.
+  (
+    >&2 nvm_echo_with_colors "$@"
+  ) || true
 }
 
 nvm_grep() {


### PR DESCRIPTION
When a caller closes stderr (instead of redirecting it to /dev/null) - for example Ruby's `IO.popen(..., err: :close)` or a child process that closes fd 2 explicitly - the `>&2` redirection inside `nvm_err` returns non-zero. Because `nvm_compare_checksum` ends with `nvm_err 'Checksums matched!'` on success, a successful checksum is then reported as a failure and the install is aborted. zsh can additionally abort the whole shell when its own diagnostic about the failed redirection cannot be written.

Running the redirection in a subshell and discarding its exit code keeps that failure isolated from the caller. `nvm_echo` itself already silences `printf` errors via `2>/dev/null`, so no further change is needed there.

The fix applies the same treatment to `nvm_err_with_colors` for consistency.

Fixes #3906