### PR TITLE
fix: bypass shell functions in internal cd

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -30,7 +30,7 @@ nvm_echo_with_colors() {
 }
 
 nvm_cd() {
-  \cd "$@"
+  command cd "$@"
 }
 
 # a caller that closed stderr, rather than redirecting it to /dev/null, makes

--- a/test/fast/Unit tests/nvm_cd bypasses shell functions
+++ b/test/fast/Unit tests/nvm_cd bypasses shell functions
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+die() {
+  echo "$@"
+  exit 1
+}
+
+\. ../../../nvm.sh
+
+# A user-defined cd function must not intercept nvm's internal directory changes.
+cd() {
+  return 1
+}
+
+nvm_cd ../../../ || die 'nvm_cd failed when cd was overridden by a shell function'


### PR DESCRIPTION
Fixes #3835. nvm_cd used an escaped cd, which bypasses aliases but can still invoke a user-defined cd function in zsh. Use the POSIX command utility to resolve the builtin and add a regression test.