### PR TITLE
feat: allow npm flags (e.g. --install-links) in default-packages file

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,12 +517,15 @@ nvm install --offline --lts
 
 If you have a list of default packages you want installed every time you install a new version, we support that too -- just add the package names, one per line, to the file `$NVM_DIR/default-packages`. You can add anything npm would accept as a package argument on the command line.
 
+Each line may also carry npm flags (anything starting with `-`, such as `--install-links`) alongside the package name, or on a line by itself to apply to every package. Only multiple *packages* on one line are rejected.
+
 ```sh
 # $NVM_DIR/default-packages
 
 rimraf
 object-inspect@1.0.2
 stevemao/left-pad
+my-internal-tool --install-links
 ```
 
 ### io.js

--- a/nvm.sh
+++ b/nvm.sh
@@ -5066,12 +5066,14 @@ nvm_get_default_packages() {
     command awk -v filename="${NVM_DEFAULT_PACKAGE_FILE}" '
       /^[ \t]*#/ { next }                           # Skip lines that begin with #
       /^[ \t]*$/ { next }                           # Skip empty lines
-      /[ \t]/ && !/^[ \t]*#/ {
-        print "Only one package per line is allowed in `" filename "`. Please remove any lines with multiple space-separated values." > "/dev/stderr"
-        err = 1
-        exit 1
-      }
       {
+        pkgs = 0
+        for (i = 1; i <= NF; i++) if ($i !~ /^-/) pkgs++  # flags (leading -) may share a line with a package
+        if (pkgs > 1) {
+          print "Only one package per line is allowed in `" filename "`. Please remove any lines with multiple space-separated values." > "/dev/stderr"
+          err = 1
+          exit 1
+        }
         if (NR > 1 && !prev_space) printf " "
         printf "%s", $0
         prev_space = 0

--- a/test/fast/Unit tests/nvm_get_default_packages
+++ b/test/fast/Unit tests/nvm_get_default_packages
@@ -84,6 +84,36 @@ cleanup
 
 setup
 
+# a package may carry npm flags on the same line; flag-only lines are allowed too
+cat > "${FILE}" << EOF
+rimraf
+my-internal-tool --install-links
+--foreground-scripts
+EOF
+
+DEFAULT_PKGS="$(nvm_get_default_packages)"
+EXPECTED_PKGS='rimraf my-internal-tool --install-links --foreground-scripts'
+[ "${DEFAULT_PKGS}" = "${EXPECTED_PKGS}" ] || die "6: expected default packages >${EXPECTED_PKGS}<; got >${DEFAULT_PKGS}<"
+echo "6: ok: >${DEFAULT_PKGS}<"
+
+cleanup
+
+setup
+
+# two real packages on one line must still be rejected
+cat > "${FILE}" << EOF
+rimraf mkdirp
+EOF
+
+DEFAULT_PKGS="$(nvm_get_default_packages 2>&1 >/dev/null)"
+EXPECTED_PKGS="Only one package per line is allowed in \`${FILE}\`. Please remove any lines with multiple space-separated values."
+[ "${DEFAULT_PKGS}" = "${EXPECTED_PKGS}" ] || die "7: expected default packages >${EXPECTED_PKGS}<; got >${DEFAULT_PKGS}<"
+echo "7: ok: >${DEFAULT_PKGS}<"
+
+cleanup
+
+setup
+
 rm -rf "${FILE}"
 
 DEFAULT_PKGS="$(nvm_get_default_packages)"


### PR DESCRIPTION
nvm_get_default_packages now permits npm flags (tokens starting with -) alongside a package on a line, or on their own line, instead of rejecting any line containing whitespace. Lines with 2+ actual packages are still rejected. Fixes #3866.

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```
Only one package per line is allowed in `/tmp/tmp.TK9aPs5jOf/default-packages`. Please remove any lines with multiple space-separated values.
6: expected default packages >rimraf my-internal-tool --install-links --foreground-scripts<; got >rimraf<
```

With the fix applied, the test passes (GREEN):

```
GREEN attempt 1/2 (exit 0)
6: ok: >rimraf my-internal-tool --install-links --foreground-scripts<
7: ok: >Only one package per line is allowed in `/tmp/tmp.nLf2gNVUfX/default-packages`. Please remove any lines with multiple space-separated values.<
```

## Full local suite

Command: `npm run test/fast`

```
+ type setopt
+ type shopt
+ rm -fR v* src alias test/test-xz
+ cd ../..
+ type setopt
+ type shopt
+ rm -Rf v* src alias
+ mkdir src alias
+ cd ../..
+ type setopt
+ type shopt
+ rm -fR v* src alias test/test-xz
+ cd ../..
+ type setopt
+ type shopt
+ rm -Rf v* src alias
+ mkdir src alias
+ cd ../..
+ type setopt
+ type shopt
+ rm -fR v* src alias test/test-xz
+ cd ../..
+ type setopt
+ type shopt
+ rm -Rf v* src alias
+ mkdir src alias
+ cd ../..
+ type setopt
+ type shopt
+ rm -fR v* src alias test/test-xz
+ cd ../..
+ [ -d bak ]
+ mv bak/alias bak/versions .
+ rmdir bak
+ mkdir -p src alias

Done, took 205 seconds.
223 tests passed.
[31m6 tests failed.
[mmake: *** [Makefile:43: test-bash] Error 6
```

Fix #3866
